### PR TITLE
Fill Apache 2.0 appendix copyright (Kentucky AI)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Kentucky AI and the OpenTakeoff contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fills the LICENSE appendix template placeholder `Copyright [yyyy] [name of copyright owner]` with the actual owner — **`Copyright 2026 Kentucky AI and the OpenTakeoff contributors`** — matching the `NOTICE` file.

The rest of the Apache 2.0 text is unchanged. GitHub still detects the license as `Apache-2.0` (verified on this branch).