### PR TITLE
Zone check, sheet levels, condition plays; readout height cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-07-08 (later)
+
+### Added
+- **Zone check.** A new toolbar tool: trace a region — an apartment, a wing — like you'd trace a deduct, close it (⏎ / double-click / Finish), and a panel lists every condition inside with quantities **and its materials scaled to the zone**, computed by the same rules as the Report. Shapes count by their center point and glow cobalt so inclusion is visible. Nothing is saved: redraw replaces the zone, Esc or leaving the tool clears it.
+- **Sheet levels.** Select sheets in the gallery → **Assign level…** ("L1", "Garage"). The gallery groups by level (unassigned last, title-block order within), cards wear a level chip, and tabs + the page picker carry the label. Stored with the project.
+- **Condition plays.** **⭑ Save play** stores a tuned condition — appearance, waste, full materials list — in this browser; **Plays ▾** applies it as a fresh condition on any project. No geometry or ids travel; re-saving a name replaces it.
+
+### Fixed
+- The live readout is height-capped with internal scroll so fully populated totals never cover the right-edge panel rail.
+
 ## 2026-07-07
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,7 +26,7 @@ The buildable map: what OpenTakeoff does and exactly where each piece lives, so 
 ## Tested surface
 
 `cd web && npm test` — `node:test` over the pure math: `web/test/geometry.test.ts` (One-Click pipeline incl. the hatch-robust fill and meta emission), `web/test/canvas-geometry.test.ts` (angle lock, hit-testing, metrics, snap grid), `web/test/totals.test.ts` (waste, SY, coverage → order quantities, vertical-wall SF), and `web/test/coverage.test.ts` (material-kind classification, grout coverage from tile geometry).
-`cd web && npm test` — `node:test` over the pure math: `web/test/geometry.test.ts` (One-Click pipeline incl. the hatch-robust fill and meta emission), `web/test/canvas-geometry.test.ts` (angle lock, hit-testing, metrics, snap grid, highlighter stroke geometry), `web/test/totals.test.ts` (waste, SY, coverage → order quantities, vertical-wall SF), and `web/test/units.test.ts` (metric display layer + ratio-scale math).
+`cd web && npm test` — `node:test` over the pure math: `web/test/geometry.test.ts` (One-Click pipeline incl. the hatch-robust fill and meta emission), `web/test/canvas-geometry.test.ts` (angle lock, hit-testing, metrics, snap grid, highlighter stroke geometry), `web/test/totals.test.ts` (waste, SY, coverage → order quantities, vertical-wall SF), and `web/test/units.test.ts` (metric display layer + ratio-scale math), `web/test/zone.test.ts` (zone-check classification + rollup), and `web/test/plays.test.ts` (condition plays).
 
 ## Extending it
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Every drawing, scale, condition, and markup autosaves to **your browser** (Index
 |---|---|
 | **Ingest** | PDF, image, or `.zip` plan set — unpacked in-browser, multi-page, up to 4 sheets side-by-side |
 | **Scale** | Auto-detect the drawn scale note, or calibrate from a known dimension — per sheet |
-| **Measure** | One-Click Area (flood-fill), Area, Rectangle, Linear, Surface-Area (walls), Count, Eraser (deduct) — imperial or metric (m²/m, 1:50-style scales) |
+| **Measure** | One-Click Area (flood-fill), Area, Rectangle, Linear, Surface-Area (walls), Count, Eraser (deduct), Zone check (per-region breakdown) — imperial or metric (m²/m, 1:50-style scales) |
 | **Drawing aids** | 45°/90° angle lock with ⇧ hard-lock, live angle + segment-length readout at the cursor, endpoint Snap (beta) |
 | **Conditions** | Color + CAD hatch per finish, waste %, ×N multiplier, height, thickness → border SF |
 | **Assemblies** | Per-condition supporting materials with coverage rates → rounded order quantities, per-material coverage presets + grout calculator |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -110,6 +110,18 @@ Highlighter, revision clouds, callouts, and text notes — annotations only, kep
 Per‑condition breakdown (Floor/Wall/Border SF, LF, EA, Total SF, SY, with and without waste), a combined materials buy list, and **CSV / JSON** export — plus **Marked set**: a distribution-ready PDF of every sheet that carries takeoffs or markups, with the work burned in as drawn and a legend cover (net totals, waste-adjusted order quantities, by-sheet breakdown). It exports in your current view — dark canvas → dark PDF. Share it with a PM or GC; they need nothing but a PDF reader.
 
 ### Saving
+## Zone check
+
+Arm **Zone** in the toolbar and trace a region — an apartment, a wing, a phase — the way you'd trace a deduct; **⏎, double‑click, or Finish** closes it. A panel lists every condition whose shapes sit inside (counted by their **center point**, same sheet only — counted shapes glow cobalt), with quantities and each condition's **materials scaled to the zone**, computed by the same rules as the Report. It's a reading, not a takeoff: nothing is saved — redraw replaces the zone; `Esc` or switching tools clears it.
+
+## Sheet levels (multi‑floor sets)
+
+In the gallery, select sheets and hit **Assign level…** ("L1", "Level 2", "Garage" — empty clears). The gallery groups by level with unassigned sheets last, each card wears its level chip, and open tabs plus the page picker carry the label. Levels save with the project.
+
+## Condition plays
+
+Tuned a condition just right — waste, materials, appearance? **⭑ Save play** (in the condition bar) stores it in this browser; **Plays ▾** applies any saved play as a fresh condition on any project (you pick the new finish tag). No geometry travels with a play, and re‑saving a name replaces it.
+
 All drawings, scales, conditions, and markups autosave to this browser (IndexedDB + localStorage). Storage is **per origin** — i.e. per `localhost:PORT` / per domain. A different port = a fresh, empty workspace.
 
 ---

--- a/web/src/brand/icons.jsx
+++ b/web/src/brand/icons.jsx
@@ -45,6 +45,7 @@ export const icons = {
   chevronRight: (s) => <I size={s}><path d="M9 6 L 15 12 L 9 18" /></I>,
   markup: (s) => <I size={s}><path d="M12 3 L 17 10 L 12 21 L 7 10 Z" /><line x1="12" y1="3" x2="12" y2="12.5" /><circle cx="12" cy="13" r="1" fill="currentColor" /></I>,
   takeoffs: (s) => <I size={s}><rect x="4" y="5" width="3" height="3" fill="currentColor" stroke="none" /><line x1="10" y1="6.5" x2="20" y2="6.5" /><rect x="4" y="10.5" width="3" height="3" fill="currentColor" stroke="none" /><line x1="10" y1="12" x2="20" y2="12" /><rect x="4" y="16" width="3" height="3" fill="currentColor" stroke="none" /><line x1="10" y1="17.5" x2="20" y2="17.5" /></I>,
+  zone: (s) => <I size={s}><path d="M4 4 H 8 M11 4 H 15 M18 4 H 20 V 6 M20 9 H 20 V 13 M20 16 V 20 H 17 M14 20 H 10 M7 20 H 4 V 16 M4 13 V 9 M4 6 V 4" /><circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none" /></I>,
   highlighter: (s) => <I size={s}><path d="M5 21 L8.5 17.5 M8.5 17.5 L6.8 14 L14 6.8 L17.2 10 L10 17.2 Z M14 6.8 L15.8 5 L19 8.2 L17.2 10" /></I>,
   target: (s) => <I size={s}><circle cx="12" cy="12" r="6" /><path d="M12 3 V 7 M12 17 V 21 M3 12 H 7 M17 12 H 21" /><circle cx="12" cy="12" r="1" fill="currentColor" /></I>,
   height: (s) => <I size={s}><line x1="6" y1="4" x2="18" y2="4" /><line x1="6" y1="20" x2="18" y2="20" /><path d="M12 6.5 V 17.5 M12 6.5 L 9.8 8.7 M12 6.5 L 14.2 8.7 M12 17.5 L 9.8 15.3 M12 17.5 L 14.2 15.3" /></I>,

--- a/web/src/components/SheetGallery.jsx
+++ b/web/src/components/SheetGallery.jsx
@@ -12,6 +12,7 @@ const THUMB_W = 380;
 export default function SheetGallery({
   sheets, getDoc, scales, detectedScales, shapes, labels, onLabel, onDetect,
   thumbCacheRef, busyRef, openTabs, onOpen, onClose, canClose, onAddFiles,
+  levels = {}, onAssignLevel,
 }) {
   const fileRef = useRef(null);
   const [pages, setPages] = useState({});   // file -> numPages (as discovered)
@@ -132,6 +133,21 @@ export default function SheetGallery({
     const base = t.file.replace(/\.pdf$/i, "");
     return t.page > 1 ? `${base} · ${t.page}` : base;
   };
+  // multi-floor: group by assigned level (natural sort), unassigned last; within a
+  // group, order by the title-block label so A-sheets read in drawing order
+  const cmp = (a, b) => String(a).localeCompare(String(b), undefined, { numeric: true });
+  const levelNames = [...new Set(allKeys.map((k) => levels[k]).filter(Boolean))].sort(cmp);
+  const groups = levelNames.length
+    ? [...levelNames.map((lv) => ({ level: lv, keys: allKeys.filter((k) => levels[k] === lv) })),
+       { level: "", keys: allKeys.filter((k) => !levels[k]) }].filter((g) => g.keys.length)
+    : [{ level: null, keys: allKeys }];
+  for (const g of groups) g.keys = [...g.keys].sort((a, b) => cmp(labelOf(a), labelOf(b)));
+  const assignLevel = () => {
+    const label = window.prompt('Level for the selected sheets (e.g. "L1", "Level 2", "Garage") — empty clears:', "");
+    if (label === null) return;
+    onAssignLevel?.(sel, label.trim());
+    setSel([]);
+  };
 
   return (
     <div
@@ -163,8 +179,15 @@ export default function SheetGallery({
       </div>
 
       <div style={{ flex: 1, overflow: "auto", padding: 18 }}>
+        {groups.map((grp) => (
+        <div key={grp.level ?? "__all"} style={{ marginBottom: grp.level !== null ? 22 : 0 }}>
+        {grp.level !== null && (
+          <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--ink-muted)", margin: "0 0 8px 2px" }}>
+            {grp.level || "Unassigned"} · {grp.keys.length}
+          </div>
+        )}
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(270px, 1fr))", gap: 14 }}>
-          {allKeys.map((key) => {
+          {grp.keys.map((key) => {
             const idx = sel.indexOf(key);
             const isSel = idx >= 0;
             const thumb = thumbCacheRef.current.get(key);
@@ -184,6 +207,7 @@ export default function SheetGallery({
                 </div>
                 <div style={{ padding: "8px 10px", display: "flex", alignItems: "baseline", gap: 8 }}>
                   <strong style={{ fontFamily: "var(--f-mono)", fontSize: 12.5, color: "var(--ink)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1 }} title={key}>{labelOf(key)}</strong>
+                  {levels[key] && <span title="Level" style={{ fontSize: 9.5, fontFamily: "var(--f-mono)", color: "var(--ink-muted)", border: "1px solid var(--ink-faint)", padding: "1px 5px" }}>{levels[key]}</span>}
                   {isOpenTab && <span title="Already open as a tab" style={{ fontSize: 9.5, fontFamily: "var(--f-mono)", color: "var(--cobalt)", textTransform: "uppercase", letterSpacing: "0.08em" }}>open</span>}
                   {cnt > 0 && <span style={{ fontFamily: "var(--f-mono)", fontSize: 10.5, color: "var(--ink-muted)" }}>{cnt}▦</span>}
                   <span style={{ fontSize: 10, fontWeight: 600, whiteSpace: "nowrap", color: scales[key] ? "var(--c-positive)" : detectedScales[key] ? "var(--c-warning)" : "var(--c-danger)" }}>
@@ -194,6 +218,8 @@ export default function SheetGallery({
             );
           })}
         </div>
+        </div>
+        ))}
         {!allKeys.length && (
           <div style={{ padding: 48, textAlign: "center", color: "var(--ink-muted)", fontSize: 13.5, lineHeight: 1.7 }}>
             {!sheets.length ? (
@@ -230,7 +256,11 @@ export default function SheetGallery({
         <span style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--ink-muted)" }}>{sel.length ? `${sel.length} selected` : "select sheets, or hover a card and hit View"}</span>
         <div style={{ flex: 1 }} />
         {sel.length > 0 && (
-          <button onClick={() => setSel([])} style={{ padding: "7px 12px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink-muted)", cursor: "pointer", fontSize: 12 }}>Clear</button>
+          <>
+            <button onClick={assignLevel} title="Group the selected sheets under a floor/level — the gallery sorts by it and tabs carry the label"
+              style={{ padding: "7px 12px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", cursor: "pointer", fontSize: 12 }}>Assign level…</button>
+            <button onClick={() => setSel([])} style={{ padding: "7px 12px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink-muted)", cursor: "pointer", fontSize: 12 }}>Clear</button>
+          </>
         )}
         <button disabled={!sel.length} onClick={() => onOpen(sel, false)}
           style={{ padding: "8px 14px", border: "1px solid var(--ink)", background: "transparent", color: "var(--ink)", cursor: sel.length ? "pointer" : "default", opacity: sel.length ? 1 : 0.4, fontWeight: 700, fontSize: 12.5 }}>

--- a/web/src/lib/plays.js
+++ b/web/src/lib/plays.js
@@ -1,0 +1,48 @@
+// Condition plays — save a tuned condition (appearance, params, waste, and its
+// full materials list) as a reusable recipe in THIS browser (localStorage,
+// same per-origin scope as the rest of the workspace). No geometry and no ids
+// are saved; applying a play mints a fresh condition. Pure list/shape helpers
+// are separated from the storage wrappers so they stay node-testable.
+const KEY = "opentakeoff_plays";
+const COND_KEEP = ["finish_tag", "color", "fill", "hatch", "height_ft", "thickness_in", "waste_pct"];
+const MAT_KEEP = ["name", "kind", "per", "basis", "unit", "round", "note", "grout"];
+
+const pick = (obj, keys) => {
+  const out = {};
+  for (const k of keys) if (obj?.[k] !== undefined && obj?.[k] !== null && obj?.[k] !== "") out[k] = obj[k];
+  return out;
+};
+
+export function playFromCondition(name, cond, mintId) {
+  return {
+    id: mintId(),
+    name: String(name || cond?.finish_tag || "Play").trim(),
+    ...pick(cond, COND_KEEP),
+    materials: (cond?.materials || []).filter((m) => m && m.name).map((m) => pick(m, MAT_KEEP)),
+  };
+}
+
+export function conditionFromPlay(play, finishTag, mintCondId, mintMatId) {
+  return {
+    id: mintCondId(),
+    finish_tag: finishTag || play.finish_tag || "",
+    color: play.color, fill: play.fill ?? play.color, hatch: play.hatch || "solid",
+    multiplier: 1,
+    ...(play.height_ft != null ? { height_ft: play.height_ft } : {}),
+    ...(play.thickness_in != null ? { thickness_in: play.thickness_in } : {}),
+    ...(play.waste_pct != null ? { waste_pct: play.waste_pct } : {}),
+    materials: (play.materials || []).map((m) => ({ id: mintMatId(), ...m })),
+  };
+}
+
+/** re-saving under the same name replaces (keeps the playbook tidy) */
+export function upsertPlay(plays, play) {
+  return [...(plays || []).filter((p) => p.name !== play.name), play];
+}
+
+export function loadPlays() {
+  try { return JSON.parse(localStorage.getItem(KEY) || "[]") || []; } catch { return []; }
+}
+export function savePlays(plays) {
+  try { localStorage.setItem(KEY, JSON.stringify(plays || [])); } catch { /* private mode */ }
+}

--- a/web/src/lib/zone.js
+++ b/web/src/lib/zone.js
@@ -1,0 +1,25 @@
+// Zone check — the ephemeral trace-a-region breakdown. A zone is {key, pts}:
+// the sheet it was drawn on plus a polygon normalized to that sheet's image.
+// Shapes count by their center point (predictable, and the canvas traces every
+// counted shape so inclusion is visible). Quantities come from feeding the
+// filtered shapes through the same conditionTotals rules the Report uses —
+// one source of role math, three scopes (Report / panel / zone).
+import { pointInPoly } from "./geometry.js";
+
+export function shapeCenter(shape) {
+  const vs = shape?.verts_norm || [];
+  if (!vs.length) return null;
+  return [
+    vs.reduce((n, v) => n + v[0], 0) / vs.length,
+    vs.reduce((n, v) => n + v[1], 0) / vs.length,
+  ];
+}
+
+export function shapesInZone(shapes, zone) {
+  if (!zone || !(zone.pts || []).length) return [];
+  return (shapes || []).filter((s) => {
+    if (s.sheet_id !== zone.key) return false;
+    const c = shapeCenter(s);
+    return !!c && pointInPoly(c[0], c[1], zone.pts);
+  });
+}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -20,6 +20,8 @@ import ReportPanel from "../components/ReportPanel.jsx";
 import { Icon } from "../brand/icons.jsx";
 import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, extractSheetNumber, detectScale } from "../lib/sheets";
 import { areaVal, areaUnit, lenVal, lenUnit, calInputToFeet } from "../lib/units";
+import { shapesInZone } from "../lib/zone.js";
+import { playFromCondition, conditionFromPlay, upsertPlay, loadPlays, savePlays } from "../lib/plays.js";
 import { extractVectorGeometry, buildMask, floodRegion, traceRegion, snapVertices, ringArea, MASK_MAX_DIM } from "../lib/oneclick";
 import { conditionTotals, verticalWallSf } from "../lib/totals.js";
 import { buildMarkedSetPdf, downloadBytes } from "../lib/markedset.js";
@@ -328,9 +330,14 @@ export default function TakeoffCanvas() {
   const [galleryLabels, setGalleryLabels] = useState({}); // sheetKey → title-block number, all files
   const [pageLabels, setPageLabels] = useState({}); // { pageNum: "A003" } from the title block
   const [sheetGroup, setSheetGroup] = useState([]);   // sheetKeys shown side-by-side; [] = single-sheet mode
+  const [sheetLevels, setSheetLevels] = useState({}); // sheetKey → level label ("L1") — persisted; groups the gallery for multi-floor sets
   const [lastGroup, setLastGroup] = useState([]);     // most recent side-by-side composition — "Regroup" restores it
   const [focusKey, setFocusKey] = useState("");         // panel of the last click — scale/calibrate target in group mode
   const [hatchOpen, setHatchOpen] = useState(false);         // hatch picker popover (declutters the row)
+  const [zoneCheck, setZoneCheck] = useState(null);          // ephemeral zone-check region {key, pts (norm)} — never persisted
+  const [zoneExpand, setZoneExpand] = useState(null);        // zone panel: condition id with materials expanded
+  const [plays, setPlays] = useState(loadPlays);             // saved condition plays (this browser)
+  const [playsOpen, setPlaysOpen] = useState(false);         // plays picker popover
   const [hatchHover, setHatchHover] = useState("");          // picker caption — hovered pattern name
   const [matOpen, setMatOpen] = useState(false);             // supporting-materials editor panel
   const [markups, setMarkups] = useState([]);                // cloud/callout/text annotations (separate from measurement shapes)
@@ -491,7 +498,8 @@ export default function TakeoffCanvas() {
     if (!sheetGroup.length && key === sheetKey) { const nb = next[Math.min(Math.max(i, 0), next.length - 1)]; if (nb) goToSheet(nb); }
   }
   const tabLabel = (k) => {
-    if (galleryLabels[k]) return galleryLabels[k];
+    const lvl = sheetLevels[k] ? `${sheetLevels[k]} · ` : "";
+    if (galleryLabels[k]) return lvl + galleryLabels[k];
     const t = parseSheetKey(k);
     if (t.file === active && pageLabels[t.page]) return pageLabels[t.page];
     const base = t.file.replace(/\.pdf$/i, "");
@@ -646,6 +654,7 @@ export default function TakeoffCanvas() {
       for (const s of a.sheets || []) if (s.sheet_id && s.units_per_px) sc[s.sheet_id] = s.units_per_px;
       if (a.units === "metric" || a.units === "imperial") setUnits(a.units);
       setScales(sc);
+      if (a.sheet_levels && typeof a.sheet_levels === "object") setSheetLevels(a.sheet_levels);
       hydrated.current = true;
     }).catch(() => { hydrated.current = true; });
     return () => { off = true; };
@@ -683,7 +692,7 @@ export default function TakeoffCanvas() {
     tabInitRef.current = true;
     goToSheet(openTabs[0]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [openTabs, sheets]);
+  }, [openTabs, sheetLevels, sheets]);
 
   useEffect(() => { statusRef.current = status; }, [status]);
   useEffect(() => { viewRef.current = view; }, [view]);
@@ -931,7 +940,7 @@ export default function TakeoffCanvas() {
   // omitting it dropped markup saves and could persist a stale markups array.
   useEffect(() => {
     if (!hydrated.current) return;
-    const payload = { project_name: projectName, units, sheets: Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px })), conditions, shapes, markups, sheet_group: sheetGroup, last_group: lastGroup, sheet_tabs: openTabs };
+    const payload = { project_name: projectName, units, sheets: Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px })), conditions, shapes, markups, sheet_group: sheetGroup, last_group: lastGroup, sheet_tabs: openTabs, sheet_levels: sheetLevels };
     saveDataRef.current = payload;          // keep the freshest payload for an unmount flush
     setSaveState("saving");
     const t = setTimeout(() => {
@@ -1039,7 +1048,7 @@ export default function TakeoffCanvas() {
       if (menuDepthRef.current > 0) return;
       if (e.key === "Enter") {
         if (tool === "oneclick" && proposal?.regions.length) { e.preventDefault(); createProposal(); return; }
-        const ok = ((tool === "area" || tool === "deduct") && poly.length >= 3) || ((tool === "linear" || tool === "surface") && poly.length >= 2);
+        const ok = ((tool === "area" || tool === "deduct" || tool === "zone") && poly.length >= 3) || ((tool === "linear" || tool === "surface") && poly.length >= 2);
         if (ok) { e.preventDefault(); finishShape(); }
         return;
       }
@@ -1084,7 +1093,7 @@ export default function TakeoffCanvas() {
         else if (proposal?.regions.length) { setProposal((pr) => { const rg = pr.regions.slice(0, -1); return rg.length ? { ...pr, regions: rg } : null; }); }
         else if (selectedId) { setShapes((ss) => ss.filter((s) => s.id !== selectedId)); setSelectedId(null); }
         else setCalib((c) => c.slice(0, -1));
-      } else if (e.key === "Escape") { setPoly([]); setCalib([]); setSelectedId(null); setSelectedMarkupId(null); setMarkupDraft(null); setProposal(null); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; }
+      } else if (e.key === "Escape") { setPoly([]); setCalib([]); setSelectedId(null); setSelectedMarkupId(null); setMarkupDraft(null); setProposal(null); setZoneCheck(null); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; }
       else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "z") { e.preventDefault(); setPoly((q) => (q.length ? q.slice(0, -1) : q)); }
       else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "c") { if (selectedId) { e.preventDefault(); copySelected(); } }
       else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "v") { if (clipRef.current.length) { e.preventDefault(); pasteClipboard(); } }
@@ -1136,7 +1145,7 @@ export default function TakeoffCanvas() {
   function performClick(p, ev) {
     if (tool === "calibrate") setCalib((c) => (c.length >= 2 ? [p] : [...c, p]));
     else if (tool === "oneclick") oneClickAt(p, !!(ev && ev.altKey));
-    else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "surface") setPoly((q) => [...q, p]);
+    else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "surface" || tool === "zone") setPoly((q) => [...q, p]);
     else if (tool === "count") commitCount(p);
     else if (tool === "rect" || tool === "deduct-rect") {
       if (poly.length === 0) setPoly([p]);
@@ -1721,7 +1730,19 @@ export default function TakeoffCanvas() {
   function updateMarkup(mid, patch) { setMarkups((ms) => ms.map((m) => (m.id === mid ? { ...m, ...patch } : m))); }
   function deleteMarkup(mid) { setMarkups((ms) => ms.filter((m) => m.id !== mid)); }
 
-  function finishShape() { if (tool === "surface") commitSurface(poly); else if (tool === "linear") commitLinear(poly); else commitPoly(poly, tool === "deduct"); setPoly([]); }
+  function finishShape() {
+    if (tool === "zone") {
+      // ephemeral: classify, show, never save. Belongs to the panel of its first point.
+      if (poly.length >= 3) {
+        const tp = panelAt(poly[0][0]);
+        setZoneCheck({ key: tp.key, pts: poly.map(([x, y]) => [(x - tp.xOffset) / tp.img.w, y / tp.img.h]) });
+        setZoneExpand(null);
+      }
+      setPoly([]);
+      return;
+    }
+    if (tool === "surface") commitSurface(poly); else if (tool === "linear") commitLinear(poly); else commitPoly(poly, tool === "deduct"); setPoly([]);
+  }
   function deleteSelected() { if (selectedId) { setShapes((ss) => ss.filter((s) => s.id !== selectedId)); setSelectedId(null); } }
   function reassignSelected(condId) { if (selectedId) setShapes((ss) => ss.map((s) => (s.id === selectedId ? { ...s, condition_id: condId } : s))); }
 
@@ -1744,6 +1765,28 @@ export default function TakeoffCanvas() {
   const updateCond = (patch) => setConditions((cs) => cs.map((c) => (c.id === activeCond ? { ...c, ...patch } : c)));
 
   // delete a condition entirely (and its takeoffs); pick a new active one
+  function saveActiveAsPlay() {
+    if (!aCond) return;
+    const name = window.prompt("Save this condition (appearance + waste + materials) as a reusable play.\nName:", aCond.finish_tag || "");
+    if (!name || !name.trim()) return;
+    const next = upsertPlay(plays, playFromCondition(name.trim(), aCond, () => uid("play")));
+    setPlays(next); savePlays(next);
+    setCommitMsg(`Play “${name.trim()}” saved — apply it from Plays ▾ on any project in this browser.`);
+  }
+  function applyPlay(play) {
+    const tag = (window.prompt("Finish tag for this condition:", play.finish_tag || play.name || "") || "").trim();
+    if (!tag) return;
+    const c = conditionFromPlay(play, tag, () => uid("cnd"), () => uid("mat"));
+    if (!c.color) c.color = PALETTE[conditions.length % PALETTE.length];
+    if (!c.fill) c.fill = c.color;
+    setConditions((cs) => [...cs, c]); setActiveCond(c.id); setPlaysOpen(false);
+    setCommitMsg(`Applied play “${play.name}” as ${tag} — measure it.`);
+  }
+  function deletePlayByName(name) {
+    if (!window.confirm(`Delete the play “${name}”?`)) return;
+    const next = plays.filter((pl) => pl.name !== name);
+    setPlays(next); savePlays(next);
+  }
   function deleteCondition(id) {
     const c = condById[id];
     if (!c) return;
@@ -1809,6 +1852,11 @@ export default function TakeoffCanvas() {
   // VISIBLE shapes through the same conditionTotals rules the Report uses —
   // one source of role math, two scopes.
   const visRows = conditionTotals(conditions, visibleShapes);
+  const zoneRows = zoneCheck
+    ? conditionTotals(conditions, shapesInZone(shapes, zoneCheck)).filter((r) => r.shape_count > 0)
+    : null;
+  const zoneIds = zoneCheck ? new Set(shapesInZone(shapes, zoneCheck).map((sh) => sh.id)) : null;
+  useEffect(() => { if (tool !== "zone") { setZoneCheck(null); setZoneExpand(null); } }, [tool]);
   const visRowById = new Map(visRows.map((r) => [r.id, r]));
   const condRow = visRowById.get(activeCond);
   const condTotal = condRow?.floor_sf || 0;
@@ -1844,7 +1892,7 @@ export default function TakeoffCanvas() {
   };
   const measureActive = MEASURE_TOOLS.some((t) => t.id === tool);
   const faceTool = MEASURE_TOOLS.find((t) => t.id === (measureActive ? tool : lastMeasureRef.current)) || MEASURE_TOOLS[0];
-  const finishOk = ((tool === "area" || tool === "deduct") && poly.length >= 3) || ((tool === "linear" || tool === "surface") && poly.length >= 2);
+  const finishOk = ((tool === "area" || tool === "deduct" || tool === "zone") && poly.length >= 3) || ((tool === "linear" || tool === "surface") && poly.length >= 2);
 
   // compact icon button — chrome on the brand tokens; active = cobalt
   const iconBtn = (key, iconName, label, hint, showLabel = true) => (
@@ -1926,7 +1974,7 @@ export default function TakeoffCanvas() {
           <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
             <button type="button" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page <= 1} style={{ padding: "5px 8px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", cursor: "pointer" }}><Icon name="chevronLeft" size={12} /></button>
             <select value={page} onChange={(e) => setPage(parseInt(e.target.value, 10))} style={{ padding: "5px 6px", border: "1px solid var(--ink-faint)", background: "transparent", fontFamily: "var(--f-mono,monospace)", fontSize: 12 }}>
-              {Array.from({ length: pageCount }, (_, i) => i + 1).map((n) => <option key={n} value={n}>{pageLabels[n] ? `${pageLabels[n]}  ·  ${n}/${pageCount}` : `Sheet ${n} / ${pageCount}`}</option>)}
+              {Array.from({ length: pageCount }, (_, i) => i + 1).map((n) => { const k = n > 1 ? `${active}#${n}` : active; const lvl = sheetLevels[k] ? `${sheetLevels[k]} · ` : ""; return <option key={n} value={n}>{pageLabels[n] ? `${lvl}${pageLabels[n]}  ·  ${n}/${pageCount}` : `${lvl}Sheet ${n} / ${pageCount}`}</option>; })}
             </select>
             <button type="button" onClick={() => setPage((p) => Math.min(pageCount, p + 1))} disabled={page >= pageCount} style={{ padding: "5px 8px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", cursor: "pointer" }}><Icon name="chevronRight" size={12} /></button>
           </span>
@@ -1999,6 +2047,7 @@ export default function TakeoffCanvas() {
             { id: "del", icon: "close", label: "Delete selected", shortcut: "⌫", disabled: !selectedId, tint: "var(--c-danger)", onSelect: deleteSelected },
           ]}
         />
+        {iconBtn("zone", "zone", "Zone", "Zone check — trace a region (an apartment, a wing) to read every condition's quantities inside it, materials included. Nothing is saved; the outline clears when you leave the tool.")}
         <button onClick={() => setSnapOn((v) => !v)} title="Snap to plan lines/corners (beta)"
           style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "6px 10px", border: `1px solid ${snapOn ? "var(--c-positive)" : "var(--ink-faint)"}`, background: snapOn ? "var(--c-positive)" : "transparent", color: snapOn ? "var(--paper-bright)" : "var(--ink)", cursor: "pointer", fontWeight: 600, fontSize: 12.5, lineHeight: 1 }}>
           <Icon name="snap" size={15} />{snapOn ? "Snap ✓" : "Snap"}
@@ -2167,6 +2216,27 @@ export default function TakeoffCanvas() {
             style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 9px", borderRadius: 0, border: "1px solid var(--ink-faint)", background: matOpen ? "var(--ink)" : "transparent", color: matOpen ? "var(--paper-bright)" : "var(--ink)", cursor: "pointer", fontSize: 11.5, fontWeight: 600 }}>
             <Icon name="product" size={12} />Materials{aCond.materials?.length ? ` (${aCond.materials.length})` : ""}
           </button>
+          <span style={{ position: "relative", display: "inline-flex", gap: 6 }}>
+            <button onClick={saveActiveAsPlay} title="Save this condition + its materials & waste as a reusable play (stored in this browser)"
+              style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 9px", borderRadius: 0, border: "1px solid var(--ink-faint)", background: "transparent", cursor: "pointer", fontSize: 11.5, fontWeight: 600, color: "var(--ink)" }}>⭑ Save play</button>
+            <button onClick={() => setPlaysOpen((v) => !v)} title="Apply a saved play (condition + materials + waste) as a new condition"
+              style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 9px", borderRadius: 0, border: playsOpen ? "1px solid var(--cobalt)" : "1px solid var(--ink-faint)", background: playsOpen ? "var(--paper-bright)" : "transparent", cursor: "pointer", fontSize: 11.5, fontWeight: 600, color: "var(--ink)" }}>Plays{plays.length ? ` · ${plays.length}` : ""} ▾</button>
+            {playsOpen && (
+              <div style={{ position: "absolute", top: 26, right: 0, zIndex: 30, minWidth: 250, maxHeight: 320, overflow: "auto", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", borderRadius: 0, boxShadow: "0 6px 22px rgba(0,0,0,.16)" }}>
+                {plays.length === 0 ? (
+                  <div style={{ padding: "9px 11px", color: "var(--ink-muted)", fontSize: 11.5 }}>No plays yet — tune a condition's materials + waste, then <b>⭑ Save play</b>.</div>
+                ) : plays.map((pl) => (
+                  <div key={pl.name} style={{ display: "flex", alignItems: "center", gap: 6, padding: "6px 10px", borderTop: "1px solid var(--ink-faint)" }}>
+                    <button onClick={() => applyPlay(pl)} title="Apply this play as a new condition"
+                      style={{ flex: 1, minWidth: 0, textAlign: "left", border: "none", background: "none", cursor: "pointer", fontSize: 12, color: "var(--ink)" }}>
+                      <b>{pl.name}</b> <span style={{ color: "var(--ink-muted)" }}>· {(pl.materials?.length || 0)} mat{pl.waste_pct ? ` · ${pl.waste_pct}%` : ""}</span>
+                    </button>
+                    <button onClick={() => deletePlayByName(pl.name)} title="Delete this play" style={{ border: "none", background: "none", cursor: "pointer", color: "#b03a26", fontSize: 13, lineHeight: 1 }}>×</button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </span>
           <button onClick={() => deleteCondition(aCond.id)} title="Delete this condition (and its takeoffs)"
             style={{ display: "inline-flex", alignItems: "center", gap: 5, padding: "3px 9px", borderRadius: 0, border: "1px solid var(--ink-faint)", background: "transparent", color: "#b03a26", cursor: "pointer", fontSize: 11.5, fontWeight: 600 }}>
             <Icon name="close" size={11} />Delete
@@ -2201,7 +2271,7 @@ export default function TakeoffCanvas() {
        <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
         <div ref={containerRef} onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp}
           onPointerLeave={hideCrosshair} onContextMenu={(e) => e.preventDefault()}
-          onDoubleClick={() => { if (tool === "oneclick") { if (proposal?.regions.length) createProposal(); } else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "surface") finishShape(); }}
+          onDoubleClick={() => { if (tool === "oneclick") { if (proposal?.regions.length) createProposal(); } else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "surface" || tool === "zone") finishShape(); }}
           style={{ position: "absolute", inset: 0, background: darkMode ? "#0b0e14" : "var(--paper-cream)", cursor: tool === "pan" ? "grab" : tool === "select" ? "default" : "none", touchAction: "none" }}>
           {/* aim crosshair (draw modes): the OS cursor is hidden on the canvas — the
               crosshair IS the cursor. Two crisp full-page hairlines riding the
@@ -2330,6 +2400,21 @@ export default function TakeoffCanvas() {
                         </g>
                       );
                     })}
+                    {/* zone check — transparent dashed region + a cobalt trace on every counted shape */}
+                    {zoneCheck && zoneCheck.key === p.key && (
+                      <g style={{ pointerEvents: "none" }}>
+                        <polygon points={zoneCheck.pts.map(([nx, ny]) => `${nx * p.img.w},${ny * p.img.h}`).join(" ")}
+                          fill="rgba(31,63,199,.06)" stroke="#1f3fc7" strokeWidth={2 / tf.scale}
+                          strokeDasharray={`${7 / tf.scale} ${5 / tf.scale}`} />
+                        {zoneIds && shapes.filter((sh) => zoneIds.has(sh.id) && sh.sheet_id === p.key).map((sh) => (
+                          (sh.verts_norm || []).length >= 2
+                            ? <polyline key={"zc" + sh.id} points={sh.verts_norm.map(([nx, ny]) => `${nx * p.img.w},${ny * p.img.h}`).join(" ")}
+                                fill="none" stroke="#1f3fc7" strokeOpacity={0.45} strokeWidth={3.5 / tf.scale} strokeLinejoin="round" />
+                            : <circle key={"zc" + sh.id} cx={(sh.verts_norm?.[0]?.[0] || 0) * p.img.w} cy={(sh.verts_norm?.[0]?.[1] || 0) * p.img.h}
+                                r={7 / tf.scale} fill="none" stroke="#1f3fc7" strokeOpacity={0.45} strokeWidth={2.5 / tf.scale} />
+                        ))}
+                      </g>
+                    )}
                     {/* One-Click proposal preview — dashed cobalt selection, red dashed carve */}
                     {proposal && proposal.key === p.key && proposal.regions.map((r, i) => (
                       <g key={"oc" + i}>
@@ -2351,7 +2436,7 @@ export default function TakeoffCanvas() {
               <path ref={hlPathRef} style={{ display: "none" }} />
               {poly.length >= 2 && (tool === "linear" || tool === "surface"
                 ? <polyline points={poly.map((p) => p.join(",")).join(" ")} fill="none" stroke={tool === "surface" ? activeColor : "#1f3fc7"} strokeWidth={(tool === "surface" ? 3.5 : 2.5) / tf.scale} strokeDasharray={tool === "surface" ? `${10 / tf.scale} ${3 / tf.scale} ${2 / tf.scale} ${3 / tf.scale}` : undefined} strokeLinecap="round" strokeLinejoin="round" />
-                : <polygon points={poly.map((p) => p.join(",")).join(" ")} fill={poly.length >= 3 ? (tool === "deduct" ? "rgba(176,58,38,.22)" : shapeFill(aCond)) : "none"} stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={2 / tf.scale} />)}
+                : <polygon points={poly.map((p) => p.join(",")).join(" ")} fill={poly.length >= 3 ? (tool === "deduct" ? "rgba(176,58,38,.22)" : tool === "zone" ? "rgba(31,63,199,.06)" : shapeFill(aCond)) : "none"} stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={2 / tf.scale} strokeDasharray={tool === "zone" ? `${7 / tf.scale} ${5 / tf.scale}` : undefined} />)}
               {/* bold the most recent segment so you see where you just clicked */}
               {poly.length >= 2 && (
                 <line x1={poly[poly.length - 2][0]} y1={poly[poly.length - 2][1]} x2={poly[poly.length - 1][0]} y2={poly[poly.length - 1][1]}
@@ -2393,9 +2478,10 @@ export default function TakeoffCanvas() {
           </div>
         </div>
 
-        {/* live readout — top-right */}
-        <div style={{ position: "absolute", right: 14, top: 14, background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", borderRadius: 0, padding: "12px 16px", minWidth: 200, boxShadow: "0 4px 18px rgba(0,0,0,.12)", fontVariantNumeric: "tabular-nums", zIndex: 6 }}>
-          <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.5, opacity: 0.55, marginBottom: 6 }}>{aCond?.finish_tag || "No condition"}</div>
+        {/* live readout — top-right. Height is capped short of the panel rail's centered
+            band (same right:14 column) so populated totals never cover the rail buttons. */}
+        <div style={{ position: "absolute", right: 14, top: 14, background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", borderRadius: 0, padding: "12px 16px", minWidth: 200, maxWidth: 260, maxHeight: "calc(50% - 110px)", overflowY: "auto", boxShadow: "0 4px 18px rgba(0,0,0,.12)", fontVariantNumeric: "tabular-nums", zIndex: 6 }}>
+          <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.5, opacity: 0.55, marginBottom: 6, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{tool === "zone" ? "Zone check" : (aCond?.finish_tag || "No condition")}</div>
           {tool === "oneclick" && proposal?.regions.length ? (() => {
             const pos = proposal.regions.filter((r) => r.kind === "pos");
             const neg = proposal.regions.filter((r) => r.kind === "neg");
@@ -2417,6 +2503,11 @@ export default function TakeoffCanvas() {
                 </>
               ) : <div style={{ fontSize: 12.5, color: "#b03a26" }}>Set a height for {aCond?.finish_tag || "this condition"} — H in the condition bar</div>;
             })()
+          ) : tool === "zone" && poly.length >= 1 ? (
+            <>
+              {liveArea != null && poly.length >= 3 && <div style={{ fontSize: 22, fontWeight: 700, color: "#1f3fc7" }}>{num(areaVal(liveArea, units))} <span style={{ fontSize: 13, fontWeight: 600 }}>{areaUnit(units)} in zone</span></div>}
+              <div style={{ fontSize: 11.5, color: "var(--ink-muted)", marginTop: 4 }}>⏎, double-click, or the Finish button closes the zone and lists everything inside · Esc cancels</div>
+            </>
           ) : liveArea != null && poly.length >= 3 ? (
             <>
               <div style={{ fontSize: 22, fontWeight: 700, color: tool === "deduct" ? "#b03a26" : "#0e1a2e" }}>{tool === "deduct" ? "−" : ""}{num(areaVal(liveArea, units))} <span style={{ fontSize: 13, fontWeight: 600 }}>{areaUnit(units)}</span></div>
@@ -2424,7 +2515,7 @@ export default function TakeoffCanvas() {
               {condH > 0 && <div style={{ fontSize: 11.5, color: "var(--ink-muted)", marginTop: 2 }}>@H {num(condH, 2)}′: {fa(livePerim * condH)} vert{units === "metric" ? "" : ` · ${num((liveArea * condH) / 27)} CY`}</div>}
             </>
           ) : (
-            <div style={{ fontSize: 12.5, opacity: 0.6 }}>{!unitsPerPx ? "Set scale first" : !activeCond ? "Pick a condition" : tool === "oneclick" ? "Click inside a room — it selects itself" : tool === "surface" ? "Trace the wall run" : "Click to trace an area"}</div>
+            <div style={{ fontSize: 12.5, opacity: 0.6 }}>{!unitsPerPx ? "Set scale first" : tool === "zone" ? "Trace a region (an apartment, a wing) — ⏎ closes it and lists every condition inside" : !activeCond ? "Pick a condition" : tool === "oneclick" ? "Click inside a room — it selects itself" : tool === "surface" ? "Trace the wall run" : "Click to trace an area"}</div>
           )}
           {selShape?.measure_role === "surface_area" && (
             <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 8 }} title="Height for THIS wall only — full-height tile here, 4-ft wainscot there, same condition. ↺ returns to the condition height.">
@@ -2450,6 +2541,51 @@ export default function TakeoffCanvas() {
           {condTotal === 0 && lfTotal === 0 && countTotal === 0 && wallTotal === 0 && borderTotal === 0 && <div style={{ fontSize: 12.5, color: "var(--ink-muted)", marginTop: 2 }}>—</div>}
           <div style={{ fontSize: 10.5, opacity: 0.45, marginTop: 6 }}>{visibleShapes.length} shapes on {groupKeys.length > 1 ? `${groupKeys.length} sheets` : "sheet"} · zoom {(tf.scale * 100).toFixed(0)}%</div>
         </div>
+
+        {/* zone check results — ephemeral, clears with the tool/outline */}
+        {zoneRows && (
+          <div style={{ position: "absolute", right: 56, top: 14, width: 300, maxHeight: "calc(100% - 28px)", overflowY: "auto", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", borderRadius: 0, boxShadow: "0 6px 22px rgba(0,0,0,.16)", zIndex: 7, fontSize: 12.5, fontVariantNumeric: "tabular-nums" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "9px 12px", borderBottom: "1px solid var(--ink-faint)" }}>
+              <b style={{ fontSize: 12.5 }}>Zone check</b>
+              <span style={{ fontFamily: "var(--f-mono)", fontSize: 9.5, color: "var(--ink-muted)" }}>nothing saved</span>
+              <button onClick={() => setZoneCheck(null)} style={{ marginLeft: "auto", border: "none", background: "none", cursor: "pointer", fontSize: 15, lineHeight: 1, color: "var(--ink)" }}>×</button>
+            </div>
+            {zoneRows.length === 0 && (
+              <div style={{ padding: "10px 12px", color: "var(--ink-muted)", fontSize: 11.5 }}>No takeoffs inside this zone on this sheet.</div>
+            )}
+            {zoneRows.map((zr) => {
+              const parts = [];
+              if (zr.floor_sf) parts.push(fa(zr.floor_sf));
+              if (zr.wall_sf) parts.push(`${fa(zr.wall_sf)} wall`);
+              if (zr.border_sf) parts.push(`${fa(zr.border_sf)} border`);
+              if (zr.lf) parts.push(fl(zr.lf));
+              if (zr.ea) parts.push(`${num(zr.ea, 0)} EA`);
+              const open = zoneExpand === zr.id;
+              return (
+                <div key={zr.id} style={{ padding: "8px 12px", borderBottom: "1px solid var(--ink-faint)" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+                    <HatchSwatch type={zr.hatch || "solid"} line={zr.color} fill={zr.fill} />
+                    <b style={{ fontFamily: "var(--f-mono)", fontSize: 11.5 }}>{zr.finish_tag || "—"}</b>
+                    <span style={{ marginLeft: "auto", fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--ink)" }}>{parts.join(" · ") || "—"}</span>
+                  </div>
+                  {zr.materials.length > 0 && (
+                    <button onClick={() => setZoneExpand(open ? null : zr.id)}
+                      style={{ marginTop: 4, padding: 0, border: "none", background: "none", cursor: "pointer", fontSize: 10.5, color: "var(--ink-muted)" }}>
+                      {open ? "▾" : "▸"} materials · {zr.materials.length}
+                    </button>
+                  )}
+                  {open && zr.materials.map((m, i) => (
+                    <div key={i} style={{ display: "flex", gap: 8, marginTop: 3, marginLeft: 12, fontSize: 11, color: "var(--ink-soft)" }}>
+                      <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{m.name}</span>
+                      <span style={{ fontFamily: "var(--f-mono)" }}>{num(m.qty)} {m.unit}</span>
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+            <div style={{ padding: "7px 12px", fontSize: 10, color: "var(--ink-muted)" }}>Shapes counted by their center point · same sheet only · counted shapes glow cobalt.</div>
+          </div>
+        )}
 
         {/* panel rail — markup/takeoffs toggles on the right edge (zoom-cluster
             style). Moved out of the toolbar so it never wraps a third row; z above the
@@ -2548,6 +2684,12 @@ export default function TakeoffCanvas() {
           thumbCacheRef={thumbCacheRef} busyRef={statusRef}
           openTabs={openTabs} onOpen={openSheets} onClose={() => setView("canvas")} canClose={openTabs.length > 0}
           onAddFiles={handleFiles}
+          levels={sheetLevels}
+          onAssignLevel={(keys, label) => setSheetLevels((m) => {
+            const next = { ...m };
+            for (const k of keys) { if (label) next[k] = label; else delete next[k]; }
+            return next;
+          })}
         />
       )}
 

--- a/web/test/plays.test.ts
+++ b/web/test/plays.test.ts
@@ -1,0 +1,40 @@
+// Condition plays: shape round-trip, id hygiene, name-replace semantics.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { playFromCondition, conditionFromPlay, upsertPlay } from "../src/lib/plays.js";
+
+const mint = (p: string) => { let n = 0; return () => `${p}-${++n}`; };
+
+test("playFromCondition keeps recipe fields, drops ids/geometry", () => {
+  const play: any = playFromCondition("LVT std", {
+    id: "cnd-real", finish_tag: "LVT-1", color: "#123456", hatch: "plank",
+    waste_pct: 8, multiplier: 4, shapes_do_not_exist_here: true,
+    materials: [{ id: "m-real", name: "Adhesive", per: 200, basis: "area", unit: "gal", note: "PSA" }, { name: "" }],
+  }, mint("play"));
+  assert.equal(play.name, "LVT std");
+  assert.equal(play.waste_pct, 8);
+  assert.equal((play as any).multiplier, undefined);   // project-specific — never saved
+  assert.equal((play as any).id, "play-1");
+  assert.equal(play.materials.length, 1);
+  assert.equal((play.materials[0] as any).id, undefined);
+});
+
+test("conditionFromPlay mints fresh ids and defaults", () => {
+  const play = { id: "p1", name: "CT", finish_tag: "CT-1", color: "#111", hatch: "grid",
+    waste_pct: 10, materials: [{ name: "Thinset", per: 50, basis: "area", unit: "bag" }] };
+  const c: any = conditionFromPlay(play as any, "CT-9", mint("cnd"), mint("mat"));
+  assert.equal(c.id, "cnd-1");
+  assert.equal(c.finish_tag, "CT-9");
+  assert.equal(c.multiplier, 1);
+  assert.equal(c.waste_pct, 10);
+  assert.equal(c.materials[0].id, "mat-1");
+  assert.equal(c.materials[0].name, "Thinset");
+});
+
+test("upsertPlay replaces by name", () => {
+  const a = { id: "1", name: "X", color: "#1" };
+  const b = { id: "2", name: "X", color: "#2" };
+  const out = upsertPlay([a, { id: "3", name: "Y" }] as any, b as any);
+  assert.equal(out.length, 2);
+  assert.equal((out.find((p) => p.name === "X") as any).color, "#2");
+});

--- a/web/test/zone.test.ts
+++ b/web/test/zone.test.ts
@@ -1,0 +1,40 @@
+// Zone check: center-point classification + Report-rule rollup on the filtered set.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shapesInZone, shapeCenter } from "../src/lib/zone.js";
+import { conditionTotals } from "../src/lib/totals.js";
+
+const zone = { key: "plan.pdf", pts: [[0.1, 0.1], [0.5, 0.1], [0.5, 0.5], [0.1, 0.5]] };
+const sq = (id: string, cond: string, cx: number, cy: number, sf: number, sheet = "plan.pdf") => ({
+  id, sheet_id: sheet, condition_id: cond, measure_role: "floor_area",
+  verts_norm: [[cx - 0.01, cy - 0.01], [cx + 0.01, cy - 0.01], [cx + 0.01, cy + 0.01], [cx - 0.01, cy + 0.01]],
+  computed: { area_sf: sf },
+});
+
+test("shapesInZone counts by center, same sheet only", () => {
+  const shapes = [
+    sq("in1", "c1", 0.2, 0.2, 100),
+    sq("in2", "c2", 0.4, 0.4, 50),
+    sq("out", "c1", 0.8, 0.8, 999),
+    sq("other-sheet", "c1", 0.2, 0.2, 999, "other.pdf"),
+  ];
+  const hit = shapesInZone(shapes, zone);
+  assert.deepEqual(hit.map((s: any) => s.id).sort(), ["in1", "in2"]);
+  assert.equal(shapesInZone(shapes, null).length, 0);
+  assert.equal(shapeCenter({ verts_norm: [] }), null);
+});
+
+test("zone rollup uses the Report's own rules incl. materials", () => {
+  const conditions = [
+    { id: "c1", finish_tag: "CT-1", multiplier: 1, waste_pct: 0,
+      materials: [{ name: "Thinset", per: 50, basis: "area", unit: "bag" }] },
+    { id: "c2", finish_tag: "LVT-1", multiplier: 1, waste_pct: 0, materials: [] },
+  ];
+  const rows = conditionTotals(conditions, shapesInZone([
+    sq("in1", "c1", 0.2, 0.2, 100), sq("in2", "c2", 0.4, 0.4, 50), sq("out", "c1", 0.8, 0.8, 999),
+  ], zone)).filter((r: any) => r.shape_count > 0);
+  const ct = rows.find((r: any) => r.finish_tag === "CT-1");
+  assert.equal(ct.total_sf, 100);            // the out-of-zone 999 SF never leaks in
+  assert.equal(ct.materials[0].qty, 2);      // ceil(100 / 50)
+  assert.equal(rows.find((r: any) => r.finish_tag === "LVT-1").total_sf, 50);
+});


### PR DESCRIPTION
Four ports from the sibling canvas — all vendor-neutral:

- **Zone check** (new toolbar tool): trace a region like a deduct, close with ⏎ / double-click / Finish, and a panel lists every condition inside — quantities **and materials scaled to the zone**, computed by the same `conditionTotals` rules as the Report (new pure `lib/zone.js`). Center-point classification, counted shapes glow cobalt, metric-aware display. Ephemeral by design: nothing persists, Esc or leaving the tool clears it.
- **Sheet levels**: gallery multi-select → Assign level… — groups the gallery by floor (natural sort, title-block order within), level chips on cards, labels carried on tabs + the page picker. Stored as `sheet_levels` with the project.
- **Condition plays**: ⭑ Save play stores a tuned condition (appearance, waste, materials — no ids/geometry) in this browser via new pure `lib/plays.js`; Plays ▾ applies it as a fresh condition on any project. Same-name saves replace.
- **Readout height cap**: populated totals scroll internally instead of covering the right-edge rail.

**Tests:** 55/55 (`zone.test.ts`: center-point classification + Report-rule rollup incl. materials; `plays.test.ts`: shape round-trip, id hygiene, name-replace). Typecheck clean; docs synced (README / USER_GUIDE / FEATURES / CHANGELOG).