### PR TITLE
feat(report): Excel (.xlsx) export — Summary, By-sheet, Materials, Shapes-audit tabs

### DIFF
--- a/web/src/components/ReportPanel.jsx
+++ b/web/src/components/ReportPanel.jsx
@@ -24,6 +24,11 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
   const exportJson = () => downloadText(`${baseName}.json`,
     JSON.stringify({ project_name: projectName || null, generated_with: "OpenTakeoff", units: "imperial (SF/LF — raw internal values)", display_units: units, conditions: rows, totals: g, materials: matSummary }, null, 2),
     "application/json");
+  // lazy: the SpreadsheetML writer + fflate load only when someone actually exports
+  const exportXlsx = async () => {
+    const { downloadXlsx, takeoffWorkbook } = await import("../lib/xlsx.js");
+    await downloadXlsx(`${baseName}.xlsx`, takeoffWorkbook({ projectName, units, conditions, shapes }));
+  };
 
   const th = { textAlign: "right", padding: "7px 10px", fontFamily: "var(--f-mono)", fontSize: 9.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--ink-muted)", borderBottom: "1px solid var(--ink)", whiteSpace: "nowrap" };
   const td = { textAlign: "right", padding: "8px 10px", fontVariantNumeric: "tabular-nums", borderBottom: "1px solid var(--ink-faint)", whiteSpace: "nowrap" };
@@ -37,6 +42,8 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
           className="field-input" style={{ width: 260, padding: "5px 9px", fontSize: 13 }} />
         <div style={{ flex: 1 }} />
         <button className="btn-ghost" onClick={exportCsv} disabled={!rows.length}><Icon name="document" size={13} />CSV</button>
+        <button className="btn-ghost" onClick={exportXlsx} disabled={!rows.length}
+          title="Excel workbook — Summary, By sheet, Materials, and a per-shape audit tab"><Icon name="document" size={13} />Excel</button>
         <button className="btn-ghost" onClick={exportJson} disabled={!rows.length}><Icon name="document" size={13} />JSON</button>
         <button className="btn-ghost" onClick={() => window.print()} disabled={!rows.length}>Print</button>
         {onMarkedSet && (

--- a/web/src/lib/totals.js
+++ b/web/src/lib/totals.js
@@ -73,6 +73,35 @@ export function verticalWallSf(shapes, conditionId, heightFt, multiplier = 1) {
   return round2(perim * h * (multiplier || 1));
 }
 
+// Per-sheet base quantities: where the takeoff lives in the drawing set, one
+// row per (sheet, condition) that actually has shapes. BASE measured numbers
+// only — no multiplier, no waste: those are ordering concerns and apply at
+// condition level (conditionTotals). This is for reconciling sheet by sheet.
+export function sheetTotals(conditions, shapes) {
+  const condById = new Map(conditions.map((c) => [c.id, c]));
+  const acc = new Map();   // sheet_id \x00 condition_id -> row
+  for (const s of shapes) {
+    const c = condById.get(s.condition_id);
+    if (!c || !s.sheet_id) continue;
+    const key = `${s.sheet_id}\x00${c.id}`;
+    let row = acc.get(key);
+    if (!row) { row = { sheet_id: s.sheet_id, id: c.id, finish_tag: c.finish_tag, floor_sf: 0, wall_sf: 0, border_sf: 0, lf: 0, ea: 0 }; acc.set(key, row); }
+    const cp = s.computed || {};
+    switch (s.measure_role) {
+      case "deduct": row.floor_sf -= cp.area_sf || 0; break;
+      case "floor_area": row.floor_sf += cp.area_sf || 0; break;
+      case "surface_area": row.wall_sf += cp.area_sf || 0; break;
+      case "linear": row.lf += cp.perimeter_lf || 0; row.border_sf += cp.area_sf || 0; break;
+      case "count": row.ea += cp.count || 1; break;
+      default: break;
+    }
+  }
+  const condOrder = new Map(conditions.map((c, i) => [c.id, i]));
+  return [...acc.values()]
+    .map((r) => ({ ...r, floor_sf: round2(r.floor_sf), wall_sf: round2(r.wall_sf), border_sf: round2(r.border_sf), lf: round2(r.lf) }))
+    .sort((a, b) => a.sheet_id.localeCompare(b.sheet_id) || condOrder.get(a.id) - condOrder.get(b.id));
+}
+
 // Combined buy list: same-named materials summed across all conditions (each
 // condition is rounded first, then summed — you order per condition).
 export function materialsSummary(rows) {

--- a/web/src/lib/xlsx.js
+++ b/web/src/lib/xlsx.js
@@ -1,0 +1,296 @@
+// Native Excel (.xlsx) export — a hand-rolled SpreadsheetML writer zipped with
+// fflate (already a dependency; lazy-loaded like the ingest zip path, so Excel
+// export costs nothing until the button is clicked). No SheetJS, no exceljs:
+// the report needs exactly one thing — worksheets of plain cells — and a
+// megabyte of spreadsheet library is the wrong price for it.
+//
+// Two layers:
+//   buildXlsxParts(sheets)  -> Map<path, xmlString>   pure, fully testable
+//   xlsxBytes(sheets)       -> Promise<Uint8Array>    parts zipped by fflate
+//   downloadXlsx(name, sheets)                        browser download
+//   takeoffWorkbook(...)    -> sheets[]               the report as a workbook
+//
+// A sheet is { name, rows, autoFilter?, freezeTop? } where rows is an array of
+// cell arrays. A cell is:
+//   number            -> numeric cell (NaN/Infinity written as blank)
+//   string            -> inline string, XML-escaped
+//   null/undefined/"" -> skipped
+//   { v, s }          -> value with a named style (see STYLE below)
+//
+// Every string goes out as an INLINE string (<is><t>…), never a shared string
+// and never a formula — so a condition named "=HYPERLINK(…)" or "+SUM(A1)" is
+// inert text in Excel, the same reasoning as CSV formula-injection hygiene.
+// Numbers keep full precision in <v>; display rounding is the style's job
+// (#,##0.0 for quantities, #,##0 for counts), so the workbook shows what the
+// report shows while the cells stay exact for downstream arithmetic.
+
+import { conditionTotals, grandTotals, materialsSummary, sheetTotals } from "./totals.js";
+import { parseSheetKey } from "./sheets";
+import { areaVal, areaUnit, lenVal, lenUnit } from "./units";
+
+// Named styles -> cellXfs index in stylesXml(). th = bold header with a rule
+// under it; qty = 1-decimal grouped number; int = whole number; b* = bold
+// (grand-total row). Keep the two tables in lockstep.
+const STYLE = { th: 1, qty: 2, int: 3, b: 4, bqty: 5, bint: 6 };
+
+// XML-escape text, dropping the control characters XML 1.0 forbids (a pasted
+// NUL or vertical tab in a condition name must not produce a file Excel
+// refuses to open). Tab/newline/CR survive. Escape sequences, never literal
+// control bytes — a raw byte in source makes git treat the file as binary.
+export function xmlEsc(v) {
+  return String(v)
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "") // eslint-disable-line no-control-regex
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// 0-based column index -> spreadsheet letters (0=A, 25=Z, 26=AA …)
+export function colRef(i) {
+  let s = "";
+  for (let n = i; n >= 0; n = Math.floor(n / 26) - 1) s = String.fromCharCode(65 + (n % 26)) + s;
+  return s;
+}
+
+// Excel worksheet-name rules: non-empty, ≤31 chars, none of [ ] : * ? / \,
+// no leading/trailing apostrophe, unique case-insensitively, and "History" is
+// reserved by Excel. `used` carries the taken names across calls.
+export function safeSheetName(name, used = new Set()) {
+  let s = String(name ?? "").replace(/[[\]:*?/\\]/g, " ").replace(/^'+|'+$/g, "").trim().slice(0, 31).trim();
+  if (!s || s.toLowerCase() === "history") s = s ? `${s}_` : "Sheet";
+  let out = s;
+  for (let n = 2; used.has(out.toLowerCase()); n++) {
+    const tail = ` (${n})`;
+    out = s.slice(0, 31 - tail.length) + tail;
+  }
+  used.add(out.toLowerCase());
+  return out;
+}
+
+const cellVal = (c) => (c !== null && typeof c === "object" ? c.v : c);
+const cellStyle = (c) => (c !== null && typeof c === "object" && c.s ? STYLE[c.s] || 0 : 0);
+const isBlank = (v) => v === null || v === undefined || v === "";
+
+// Column widths from content: Excel's width unit is roughly one character.
+// Grouped 1-decimal display adds ~2 chars over the raw digits; +2 breathing
+// room; clamp so a long note can't produce a 300-char column.
+function colWidths(rows) {
+  const w = [];
+  for (const row of rows) row.forEach((c, i) => {
+    const v = cellVal(c);
+    if (isBlank(v)) return;
+    const len = typeof v === "number" ? String(Math.round(v)).length + 3 : String(v).length;
+    if (!w[i] || len > w[i]) w[i] = len;
+  });
+  return w.map((len) => Math.min(44, Math.max(8, (len || 0) + 2)));
+}
+
+// One worksheet part. Row/cell refs (r=) are explicit so skipped blanks never
+// shift their neighbours.
+/** @param {{ rows: any[][], autoFilter?: { cols: number, rows: number } | null, freezeTop?: boolean }} sheet */
+export function worksheetXml({ rows, autoFilter = null, freezeTop = false }) {
+  const parts = ['<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+    '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'];
+  parts.push('<sheetViews><sheetView workbookViewId="0">'
+    + (freezeTop ? '<pane ySplit="1" topLeftCell="A2" activePane="bottomLeft" state="frozen"/>' : "")
+    + "</sheetView></sheetViews>");
+  const widths = colWidths(rows);
+  if (widths.length) {
+    parts.push("<cols>" + widths.map((wd, i) => `<col min="${i + 1}" max="${i + 1}" width="${wd}" customWidth="1"/>`).join("") + "</cols>");
+  }
+  parts.push("<sheetData>");
+  rows.forEach((row, ri) => {
+    parts.push(`<row r="${ri + 1}">`);
+    row.forEach((c, ci) => {
+      const v = cellVal(c);
+      if (isBlank(v)) return;
+      const ref = `${colRef(ci)}${ri + 1}`;
+      const s = cellStyle(c);
+      const sAttr = s ? ` s="${s}"` : "";
+      if (typeof v === "number") {
+        if (Number.isFinite(v)) parts.push(`<c r="${ref}"${sAttr}><v>${v}</v></c>`);
+        return;
+      }
+      const t = xmlEsc(v);
+      const sp = /^\s|\s$/.test(String(v)) ? ' xml:space="preserve"' : "";
+      parts.push(`<c r="${ref}"${sAttr} t="inlineStr"><is><t${sp}>${t}</t></is></c>`);
+    });
+    parts.push("</row>");
+  });
+  parts.push("</sheetData>");
+  // autoFilter: header + data rows only — a grand-total row below the range
+  // stays out of the filter. Emitted AFTER sheetData (schema order).
+  if (autoFilter && autoFilter.cols > 0 && autoFilter.rows > 0) {
+    parts.push(`<autoFilter ref="A1:${colRef(autoFilter.cols - 1)}${autoFilter.rows}"/>`);
+  }
+  parts.push("</worksheet>");
+  return parts.join("");
+}
+
+// Minimal stylesheet: two custom number formats, normal + bold fonts, and the
+// two fills/one border Excel insists exist. cellXfs order must match STYLE.
+function stylesXml() {
+  return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    + '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+    + '<numFmts count="2"><numFmt numFmtId="164" formatCode="#,##0.0"/><numFmt numFmtId="165" formatCode="#,##0"/></numFmts>'
+    + '<fonts count="2"><font><sz val="11"/><name val="Calibri"/></font><font><b/><sz val="11"/><name val="Calibri"/></font></fonts>'
+    + '<fills count="2"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill></fills>'
+    + '<borders count="2"><border><left/><right/><top/><bottom/><diagonal/></border>'
+    + '<border><left/><right/><top/><bottom style="thin"><color auto="1"/></bottom><diagonal/></border></borders>'
+    + '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>'
+    + '<cellXfs count="7">'
+    + '<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>'
+    + '<xf numFmtId="0" fontId="1" fillId="0" borderId="1" xfId="0" applyFont="1" applyBorder="1"/>'
+    + '<xf numFmtId="164" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>'
+    + '<xf numFmtId="165" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>'
+    + '<xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>'
+    + '<xf numFmtId="164" fontId="1" fillId="0" borderId="0" xfId="0" applyNumberFormat="1" applyFont="1"/>'
+    + '<xf numFmtId="165" fontId="1" fillId="0" borderId="0" xfId="0" applyNumberFormat="1" applyFont="1"/>'
+    + "</cellXfs>"
+    + '<cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>'
+    + "</styleSheet>";
+}
+
+// The full package as path -> XML string. Pure: tests unzip nothing, they
+// read the parts straight off this map.
+export function buildXlsxParts(sheets) {
+  const used = new Set();
+  const named = sheets.map((sh) => ({ ...sh, name: safeSheetName(sh.name, used) }));
+  const parts = new Map();
+  parts.set("[Content_Types].xml",
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    + '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    + '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+    + '<Default Extension="xml" ContentType="application/xml"/>'
+    + '<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>'
+    + '<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>'
+    + named.map((_, i) => `<Override PartName="/xl/worksheets/sheet${i + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`).join("")
+    + "</Types>");
+  parts.set("_rels/.rels",
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    + '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    + '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>'
+    + "</Relationships>");
+  parts.set("xl/workbook.xml",
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    + '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+    + "<sheets>"
+    + named.map((sh, i) => `<sheet name="${xmlEsc(sh.name)}" sheetId="${i + 1}" r:id="rId${i + 1}"/>`).join("")
+    + "</sheets></workbook>");
+  parts.set("xl/_rels/workbook.xml.rels",
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    + '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    + named.map((_, i) => `<Relationship Id="rId${i + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet${i + 1}.xml"/>`).join("")
+    + `<Relationship Id="rId${named.length + 1}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>`
+    + "</Relationships>");
+  parts.set("xl/styles.xml", stylesXml());
+  named.forEach((sh, i) => parts.set(`xl/worksheets/sheet${i + 1}.xml`, worksheetXml(sh)));
+  return parts;
+}
+
+export async function xlsxBytes(sheets) {
+  const { zipSync, strToU8 } = await import("fflate");
+  const files = {};
+  for (const [path, xml] of buildXlsxParts(sheets)) files[path] = strToU8(xml);
+  return zipSync(files, { level: 6 });
+}
+
+export async function downloadXlsx(filename, sheets) {
+  const bytes = await xlsxBytes(sheets);
+  const blob = new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url; a.download = filename;
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+// ---------------------------------------------------------------------------
+// The takeoff report as a workbook — same sources and same numbers as the
+// on-screen table and the CSV/JSON exports (conditionTotals / grandTotals /
+// materialsSummary / sheetTotals), so the four tabs can never disagree with
+// the report. Waste applies to order quantities only, never measured ones.
+
+const ROLE_LABEL = {
+  floor_area: "Floor area", deduct: "Deduct", surface_area: "Wall (surface)",
+  linear: "Linear", count: "Count",
+};
+
+// "plan.pdf#3" -> "plan — p.3" (page 1 keys are the bare file name)
+function sheetLabel(sheetId) {
+  const { file, page } = parseSheetKey(sheetId);
+  const stem = file.replace(/\.pdf$/i, "");
+  return page > 1 ? `${stem} — p.${page}` : stem;
+}
+
+export function takeoffWorkbook({ projectName = "", units = "imperial", conditions, shapes }) {
+  const M = units === "metric";
+  const AU = areaUnit(units), LU = lenUnit(units);
+  const av = (sf) => areaVal(sf, units), lv = (lf) => lenVal(lf, units);
+  const rows = conditionTotals(conditions, shapes).filter((r) => r.shape_count > 0);
+  const g = grandTotals(rows);
+  const th = (v) => ({ v, s: "th" });
+  const qty = (v) => ({ v, s: "qty" });
+  const int = (v) => ({ v, s: "int" });
+
+  // — Summary: the STACK-style per-condition breakdown + grand total —
+  const sumHeader = ["Finish", "Shapes", "Multiplier", "Waste %", `Floor ${AU}`, `Wall ${AU}`, `Border ${AU}`,
+    `Total ${AU}`, LU, "EA", `Total ${AU} (w/ waste)`, `${LU} (w/ waste)`, ...(M ? [] : ["SY (w/ waste)"])];
+  const summary = [sumHeader.map(th)];
+  for (const r of rows) {
+    summary.push([r.finish_tag, int(r.shape_count), int(r.multiplier), int(r.waste_pct),
+      qty(av(r.floor_sf)), qty(av(r.wall_sf)), qty(av(r.border_sf)), qty(av(r.total_sf)), qty(lv(r.lf)), int(r.ea),
+      qty(av(r.total_sf_net)), qty(lv(r.lf_net)), ...(M ? [] : [qty(r.sy_net)])]);
+  }
+  summary.push([{ v: "TOTAL", s: "b" }, "", "", "", "", "", "", { v: av(g.total_sf), s: "bqty" }, { v: lv(g.lf), s: "bqty" },
+    { v: g.ea, s: "bint" }, { v: av(g.total_sf_net), s: "bqty" }, { v: lv(g.lf_net), s: "bqty" }, ...(M ? [] : [{ v: g.sy_net, s: "bqty" }])]);
+  summary.push([]);
+  summary.push([`Total ${AU} (w/ waste) = measured quantity × waste %. Wall ${AU} comes from Surface-Area traces (run × height); Border ${AU} from Linear runs with a thickness.`]);
+  if (projectName) summary.push([`Project: ${projectName} — generated with OpenTakeoff`]);
+
+  // — By sheet: where the quantities live in the drawing set —
+  const bySheetRows = sheetTotals(conditions, shapes);
+  const bySheet = [["Sheet", "Finish", `Floor ${AU}`, `Wall ${AU}`, `Border ${AU}`, LU, "EA"].map(th)];
+  for (const r of bySheetRows) {
+    bySheet.push([sheetLabel(r.sheet_id), r.finish_tag,
+      qty(av(r.floor_sf)), qty(av(r.wall_sf)), qty(av(r.border_sf)), qty(lv(r.lf)), int(r.ea)]);
+  }
+  bySheet.push([]);
+  bySheet.push(["Base measured quantities per sheet — the condition multiplier and waste apply at condition level (see Summary)."]);
+
+  // — Materials: per-condition needs, then the combined buy list —
+  const basisLabel = (b) => (b === "linear" ? LU : b === "count" ? "EA" : AU);
+  const matRows = [];
+  for (const r of rows) for (const m of (r.materials || [])) {
+    matRows.push([r.finish_tag, m.name, qty(m.qty), m.unit, `1 ${m.unit || "unit"} / ${m.per} ${basisLabel(m.basis)}`, m.note || ""]);
+  }
+  const materials = [["Finish", "Material", "Qty", "Unit", "Coverage", "Note"].map(th), ...matRows];
+  const combined = materialsSummary(rows);
+  if (combined.length) {
+    materials.push([]);
+    materials.push(["Material (combined)", "Qty", "Unit"].map(th));
+    for (const m of combined) materials.push([m.name, qty(m.qty), m.unit]);
+  }
+
+  // — Shapes: the per-shape audit trail (deducts carry their sign) —
+  const shapesRows = [["#", "Sheet", "Finish", "Role", `Area ${AU}`, LU, "EA", `Height ${M ? "m" : "ft"}`].map(th)];
+  const condById = new Map(conditions.map((c) => [c.id, c]));
+  shapes.forEach((s, i) => {
+    const c = condById.get(s.condition_id);
+    if (!c) return;
+    const cp = s.computed || {};
+    const sign = s.measure_role === "deduct" ? -1 : 1;
+    shapesRows.push([int(i + 1), sheetLabel(s.sheet_id), c.finish_tag, ROLE_LABEL[s.measure_role] || s.measure_role,
+      cp.area_sf ? qty(av(sign * cp.area_sf)) : "",
+      s.measure_role === "linear" && cp.perimeter_lf ? qty(lv(cp.perimeter_lf)) : "",
+      s.measure_role === "count" ? int(cp.count || 1) : "",
+      s.measure_role === "surface_area" && s.height_ft ? qty(M ? lv(s.height_ft) : s.height_ft) : ""]);
+  });
+
+  const out = [
+    { name: "Summary", rows: summary, freezeTop: true, autoFilter: { cols: sumHeader.length, rows: 1 + rows.length } },
+    { name: "By sheet", rows: bySheet, freezeTop: true, autoFilter: { cols: 7, rows: 1 + bySheetRows.length } },
+  ];
+  if (matRows.length) out.push({ name: "Materials", rows: materials, freezeTop: true });
+  out.push({ name: "Shapes", rows: shapesRows, freezeTop: true, autoFilter: { cols: 8, rows: shapesRows.length } });
+  return out;
+}

--- a/web/test/xlsx.test.ts
+++ b/web/test/xlsx.test.ts
@@ -1,0 +1,158 @@
+// Excel export — the pure part builder (buildXlsxParts) is asserted directly,
+// and one test round-trips through fflate's unzip to prove the zip layer
+// produces a readable package with the same parts.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { xmlEsc, colRef, safeSheetName, worksheetXml, buildXlsxParts, xlsxBytes, takeoffWorkbook } from "../src/lib/xlsx.js";
+import { sheetTotals } from "../src/lib/totals.js";
+
+const cond = (over: Record<string, unknown> = {}) => ({
+  id: "c1", finish_tag: "CPT-1", color: "#123456", multiplier: 1, waste_pct: 10, materials: [], ...over,
+});
+const shape = (over: Record<string, unknown> = {}) => ({
+  id: "s1", sheet_id: "plan.pdf", condition_id: "c1", measure_role: "floor_area", computed: { area_sf: 100 }, ...over,
+});
+
+// ── XML plumbing ────────────────────────────────────────────────────────────
+
+test("xmlEsc escapes markup and strips XML-illegal control chars", () => {
+  assert.equal(xmlEsc('<a href="x">&\'</a>'), "&lt;a href=&quot;x&quot;&gt;&amp;'&lt;/a&gt;");
+  assert.equal(xmlEsc("a\x00b\x0Bc\x7Fd"), "abcd");
+  assert.equal(xmlEsc("keep\ttab\nand newline"), "keep\ttab\nand newline");
+});
+
+test("colRef produces spreadsheet letters past Z", () => {
+  assert.equal(colRef(0), "A");
+  assert.equal(colRef(25), "Z");
+  assert.equal(colRef(26), "AA");
+  assert.equal(colRef(26 + 26 * 26 - 1), "ZZ");
+});
+
+test("safeSheetName enforces Excel's rules and dedupes", () => {
+  const used = new Set<string>();
+  assert.equal(safeSheetName("Summary", used), "Summary");
+  assert.equal(safeSheetName("summary", used), "summary (2)");           // case-insensitive collision
+  assert.equal(safeSheetName("a/b:c*d?e[f]g\\h", used), "a b c d e f g h");
+  assert.equal(safeSheetName("x".repeat(40), used).length, 31);
+  assert.equal(safeSheetName("", used), "Sheet");
+  assert.equal(safeSheetName("History", used), "History_");              // reserved by Excel
+});
+
+test("worksheetXml: numbers as <v>, strings inline, blanks skipped, refs explicit", () => {
+  const xml = worksheetXml({ rows: [["Finish", "SF"], ["CPT-1", 270.5], ["", 3]] });
+  assert.match(xml, /<c r="A1" t="inlineStr"><is><t>Finish<\/t><\/is><\/c>/);
+  assert.match(xml, /<c r="B2"><v>270.5<\/v><\/c>/);
+  assert.ok(!xml.includes('r="A3" t')) ;                                  // blank skipped entirely
+  assert.match(xml, /<c r="B3"><v>3<\/v><\/c>/);                          // neighbour keeps its ref
+  assert.ok(!xml.includes("<f>"), "no formulas, ever");
+});
+
+test("worksheetXml: formula-shaped text stays inert inline text", () => {
+  const xml = worksheetXml({ rows: [["=HYPERLINK(\"http://x\")", "+SUM(A1)", "-2+3", "@cmd"]] });
+  assert.match(xml, /t="inlineStr"><is><t>=HYPERLINK\(&quot;http:\/\/x&quot;\)<\/t>/);
+  assert.match(xml, /<t>\+SUM\(A1\)<\/t>/);
+  assert.ok(!xml.includes("<f>"));
+});
+
+test("worksheetXml: freeze pane, column widths, autoFilter over data rows only", () => {
+  const xml = worksheetXml({
+    rows: [["Finish", "SF"], ["CPT-1", 1], ["TOTAL", 1]],
+    freezeTop: true, autoFilter: { cols: 2, rows: 2 },
+  });
+  assert.match(xml, /<pane ySplit="1" topLeftCell="A2" activePane="bottomLeft" state="frozen"\/>/);
+  assert.match(xml, /<cols><col min="1" max="1" width="\d+(\.\d+)?" customWidth="1"\/>/);
+  assert.match(xml, /<autoFilter ref="A1:B2"\/>/);                        // TOTAL row excluded
+  assert.ok(xml.indexOf("<autoFilter") > xml.indexOf("</sheetData>"), "autoFilter after sheetData");
+});
+
+test("worksheetXml: styled cells carry s= indices; NaN written as blank", () => {
+  const xml = worksheetXml({ rows: [[{ v: "Finish", s: "th" }, { v: 12.5, s: "qty" }, { v: NaN, s: "qty" }]] });
+  assert.match(xml, /<c r="A1" s="1" t="inlineStr">/);
+  assert.match(xml, /<c r="B1" s="2"><v>12.5<\/v><\/c>/);
+  assert.ok(!xml.includes('r="C1"'), "NaN cell skipped");
+});
+
+// ── package assembly ────────────────────────────────────────────────────────
+
+test("buildXlsxParts: complete package with one part per sheet, names deduped", () => {
+  const parts = buildXlsxParts([{ name: "Summary", rows: [["a"]] }, { name: "Summary", rows: [["b"]] }]);
+  for (const p of ["[Content_Types].xml", "_rels/.rels", "xl/workbook.xml", "xl/_rels/workbook.xml.rels", "xl/styles.xml", "xl/worksheets/sheet1.xml", "xl/worksheets/sheet2.xml"]) {
+    assert.ok(parts.has(p), `missing ${p}`);
+  }
+  const wb = parts.get("xl/workbook.xml")!;
+  assert.match(wb, /<sheet name="Summary" sheetId="1" r:id="rId1"\/>/);
+  assert.match(wb, /<sheet name="Summary \(2\)" sheetId="2" r:id="rId2"\/>/);
+  assert.match(parts.get("xl/styles.xml")!, /formatCode="#,##0\.0"/);
+});
+
+test("xlsxBytes round-trips through fflate unzip", async () => {
+  const bytes = await xlsxBytes([{ name: "Summary", rows: [["Finish", "SF"], ["CPT-1", 270.5]] }]);
+  assert.equal(bytes[0], 0x50); assert.equal(bytes[1], 0x4b);            // PK zip magic
+  const { unzipSync, strFromU8 } = await import("fflate");
+  const files = unzipSync(bytes);
+  const ws = strFromU8(files["xl/worksheets/sheet1.xml"]);
+  assert.match(ws, /<t>CPT-1<\/t>/);
+  assert.match(strFromU8(files["xl/workbook.xml"]), /name="Summary"/);
+});
+
+// ── the report as a workbook ────────────────────────────────────────────────
+
+test("takeoffWorkbook: four tabs, report numbers, waste only on order quantities", () => {
+  const conditions = [cond({ materials: [{ name: "Adhesive", unit: "pail", per: 40, basis: "area" }] })];
+  const shapes = [shape(), shape({ id: "s2", measure_role: "deduct", computed: { area_sf: 20 } })];
+  const sheets = takeoffWorkbook({ projectName: "Job", units: "imperial", conditions, shapes });
+  assert.deepEqual(sheets.map((s) => s.name), ["Summary", "By sheet", "Materials", "Shapes"]);
+
+  const summary = sheets[0].rows;
+  const data = summary[1].map((c: any) => (c && typeof c === "object" ? c.v : c));
+  assert.equal(data[0], "CPT-1");
+  assert.equal(data[4], 80);          // floor: 100 − 20 deduct
+  assert.equal(data[7], 80);          // total measured — waste NOT applied
+  assert.equal(data[10], 88);         // ordered: 80 × 1.10
+  const totalRow = summary[2].map((c: any) => (c && typeof c === "object" ? c.v : c));
+  assert.equal(totalRow[0], "TOTAL");
+
+  const shapesTab = sheets[3].rows;
+  const deductRow = shapesTab.find((r: any[]) => r.some((c: any) => c && c.v === -20));
+  assert.ok(deductRow, "deduct row carries its sign in the audit tab");
+});
+
+test("takeoffWorkbook: metric converts areas/lengths and drops the SY column", () => {
+  const sheets = takeoffWorkbook({ units: "metric", conditions: [cond()], shapes: [shape()] });
+  const header = sheets[0].rows[0].map((c: any) => c.v);
+  assert.ok(header.includes("Floor m²"));
+  assert.ok(!header.some((h: string) => /SY/.test(h)));
+  const data = sheets[0].rows[1].map((c: any) => (c && typeof c === "object" ? c.v : c));
+  assert.equal(data[4], 9.290304);    // 100 SF → m², full precision (the #,##0.0 style rounds the DISPLAY)
+});
+
+test("takeoffWorkbook: no materials -> no Materials tab; empty takeoff still builds", () => {
+  const sheets = takeoffWorkbook({ conditions: [cond()], shapes: [shape()] });
+  assert.deepEqual(sheets.map((s) => s.name), ["Summary", "By sheet", "Shapes"]);
+  const empty = takeoffWorkbook({ conditions: [], shapes: [] });
+  assert.ok(empty.length >= 2);
+});
+
+// ── sheetTotals (lives in totals.js, feeds the By-sheet tab) ────────────────
+
+test("sheetTotals: base quantities per sheet×condition — no multiplier, no waste", () => {
+  const conditions = [cond({ multiplier: 3, waste_pct: 25 })];
+  const shapes = [
+    shape(),                                                                      // plan.pdf: +100
+    shape({ id: "s2", sheet_id: "plan.pdf", measure_role: "deduct", computed: { area_sf: 10 } }),
+    shape({ id: "s3", sheet_id: "plan.pdf#2", computed: { area_sf: 50 } }),
+    shape({ id: "s4", sheet_id: "plan.pdf#2", measure_role: "linear", computed: { perimeter_lf: 12, area_sf: 4 } }),
+  ];
+  const rows = sheetTotals(conditions, shapes);
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows.map((r) => r.sheet_id), ["plan.pdf", "plan.pdf#2"]);
+  assert.equal(rows[0].floor_sf, 90);                                             // 100 − 10, multiplier NOT applied
+  assert.equal(rows[1].floor_sf, 50);
+  assert.equal(rows[1].lf, 12);
+  assert.equal(rows[1].border_sf, 4);
+});
+
+test("sheetTotals: orphan shapes (deleted condition) are skipped", () => {
+  const rows = sheetTotals([cond()], [shape({ condition_id: "ghost" })]);
+  assert.equal(rows.length, 0);
+});


### PR DESCRIPTION
## What

A real Excel export next to CSV/JSON on the report: a four-tab workbook — **Summary** (the per-condition breakdown + grand total), **By sheet** (base measured quantities per sheet × condition, for reconciling against the drawing set), **Materials** (per-condition needs + the combined buy list), and **Shapes** (the per-shape audit trail; deducts carry their sign).

## How

Hand-rolled SpreadsheetML zipped with fflate — already a dependency, lazy-loaded at click time, so no new deps and zero initial-load cost. No SheetJS/exceljs.

- Strings always go out as **inline strings** — a condition named `=HYPERLINK(…)` is inert text in Excel (same reasoning as CSV formula-injection hygiene).
- Numbers keep full precision in cells; display rounding is done by number-format styles (`#,##0.0` quantities, `#,##0` counts) so the workbook shows what the report shows while cells stay exact for downstream math.
- Bold frozen header row, content-derived column widths, autofilter over data rows only (grand-total row stays out of the filter).
- New `sheetTotals()` in totals.js feeds the By-sheet tab — base quantities only; multiplier and waste stay condition-level ordering concerns.

## Verification

14 new tests (94 total green): XML plumbing, sheet-name rules (31-char, reserved names, dedupe), injection inertness, freeze/filter/width emission, workbook math incl. metric, sheetTotals incl. deducts and orphan shapes. Also validated end-to-end with an independent parser (openpyxl): styles, freeze pane, filter ranges, and totals read back correctly. Typecheck + build clean.