### PR TITLE
feat(revisions): save takeoff revisions and compare quantity deltas

### DIFF
--- a/web/src/brand/icons.jsx
+++ b/web/src/brand/icons.jsx
@@ -45,6 +45,7 @@ export const icons = {
   chevronRight: (s) => <I size={s}><path d="M9 6 L 15 12 L 9 18" /></I>,
   markup: (s) => <I size={s}><path d="M12 3 L 17 10 L 12 21 L 7 10 Z" /><line x1="12" y1="3" x2="12" y2="12.5" /><circle cx="12" cy="13" r="1" fill="currentColor" /></I>,
   takeoffs: (s) => <I size={s}><rect x="4" y="5" width="3" height="3" fill="currentColor" stroke="none" /><line x1="10" y1="6.5" x2="20" y2="6.5" /><rect x="4" y="10.5" width="3" height="3" fill="currentColor" stroke="none" /><line x1="10" y1="12" x2="20" y2="12" /><rect x="4" y="16" width="3" height="3" fill="currentColor" stroke="none" /><line x1="10" y1="17.5" x2="20" y2="17.5" /></I>,
+  revisions: (s) => <I size={s}><circle cx="12" cy="12" r="8" /><path d="M12 7.5 V 12 L 15.4 14" /><circle cx="12" cy="12" r="0.9" fill="currentColor" /></I>,
   zone: (s) => <I size={s}><path d="M4 4 H 8 M11 4 H 15 M18 4 H 20 V 6 M20 9 H 20 V 13 M20 16 V 20 H 17 M14 20 H 10 M7 20 H 4 V 16 M4 13 V 9 M4 6 V 4" /><circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none" /></I>,
   highlighter: (s) => <I size={s}><path d="M5 21 L8.5 17.5 M8.5 17.5 L6.8 14 L14 6.8 L17.2 10 L10 17.2 Z M14 6.8 L15.8 5 L19 8.2 L17.2 10" /></I>,
   target: (s) => <I size={s}><circle cx="12" cy="12" r="6" /><path d="M12 3 V 7 M12 17 V 21 M3 12 H 7 M17 12 H 21" /><circle cx="12" cy="12" r="1" fill="currentColor" /></I>,

--- a/web/src/components/RevisionsPanel.jsx
+++ b/web/src/components/RevisionsPanel.jsx
@@ -1,0 +1,312 @@
+// RevisionsPanel — save the takeoff as a named revision, then compare any two
+// (or a revision against the live takeoff) as quantity deltas: per condition,
+// per sheet, and on the supporting-materials buy list. Addendum lands → save
+// "Addendum 2", retrace what moved, and the compare reads out exactly which
+// finishes and sheets changed and by how much. Restore is guarded: restoring
+// auto-banks the live takeoff first, so it is never destructive.
+import React, { useEffect, useMemo, useState } from "react";
+import { Icon } from "../brand/icons.jsx";
+import { store } from "../lib/store.js";
+import { diffTakeoffs, diffToCsv, revSheetLabel } from "../lib/revisions.js";
+import { downloadText } from "../lib/totals.js";
+import { areaVal, areaUnit, lenVal, lenUnit } from "../lib/units";
+
+const num = (v, d = 1) => (Number(v) || 0).toLocaleString(undefined, { maximumFractionDigits: d });
+const STATUS_COLOR = { added: "var(--c-positive)", removed: "var(--c-danger)", changed: "var(--c-warning)", unchanged: "var(--ink-muted)" };
+
+export default function RevisionsPanel({ current, units = "imperial", onRestore, onClose }) {
+  const [revs, setRevs] = useState(null);          // null = loading
+  const [saveName, setSaveName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+  const [baseId, setBaseId] = useState("");        // revision id
+  const [compareId, setCompareId] = useState("current");
+  const [payloads, setPayloads] = useState({});    // id -> revision payload
+  const [confirmId, setConfirmId] = useState("");  // two-step delete/restore: "del:<id>" | "restore:<id>"
+  const [showUnchanged, setShowUnchanged] = useState(false);
+
+  const refresh = () => store.listRevisions().then(setRevs).catch((e) => setErr(String(e.message || e)));
+  useEffect(() => { refresh(); }, []);
+  // default the baseline to the newest revision once the list is in
+  useEffect(() => { if (revs?.length && !baseId) setBaseId(revs[0].id); }, [revs]);   // eslint-disable-line react-hooks/exhaustive-deps
+  // the two-step confirm decays back to the safe state on its own
+  useEffect(() => {
+    if (!confirmId) return;
+    const t = setTimeout(() => setConfirmId(""), 4000);
+    return () => clearTimeout(t);
+  }, [confirmId]);
+
+  // load the selected revisions' payloads (cached by id for the panel's life)
+  useEffect(() => {
+    for (const id of [baseId, compareId]) {
+      if (!id || id === "current" || payloads[id]) continue;
+      store.loadRevision(id).then((rec) => setPayloads((p) => ({ ...p, [id]: rec.payload || {} }))).catch((e) => setErr(String(e.message || e)));
+    }
+  }, [baseId, compareId]);   // eslint-disable-line react-hooks/exhaustive-deps
+
+  const sideA = baseId && baseId !== "current" ? payloads[baseId] : baseId === "current" ? current : null;
+  const sideB = compareId === "current" ? current : payloads[compareId];
+  const diff = useMemo(() => (sideA && sideB ? diffTakeoffs(sideA, sideB) : null), [sideA, sideB]);
+
+  const nameOf = (id) => (id === "current" ? "Current takeoff" : revs?.find((r) => r.id === id)?.name || "Revision");
+  const defaultName = () => `Rev ${(revs?.length || 0) + 1} — ${new Date().toLocaleDateString()}`;
+
+  const save = async (name) => {
+    setBusy(true); setErr("");
+    try { await store.saveRevision({ name: (name || "").trim() || defaultName(), payload: current }); setSaveName(""); await refresh(); }
+    catch (e) { setErr(String(e.message || e)); }
+    setBusy(false);
+  };
+  const del = async (id) => {
+    setBusy(true); setErr("");
+    try {
+      await store.deleteRevision(id);
+      if (baseId === id) setBaseId("");
+      if (compareId === id) setCompareId("current");
+      await refresh();
+    } catch (e) { setErr(String(e.message || e)); }
+    setBusy(false); setConfirmId("");
+  };
+  const restore = async (id) => {
+    setBusy(true); setErr("");
+    try {
+      // bank the live takeoff first — restore must never be a one-way door
+      await store.saveRevision({ name: `Auto-backup before restore — ${new Date().toLocaleString()}`, payload: current });
+      const rec = await store.loadRevision(id);
+      onRestore(rec.payload || {});
+      await refresh();
+    } catch (e) { setErr(String(e.message || e)); }
+    setBusy(false); setConfirmId("");
+  };
+
+  const exportCsv = () => {
+    if (!diff) return;
+    const base = (current.project_name || "takeoff").replace(/[^\w.-]+/g, "_");
+    downloadText(`${base}_compare.csv`, diffToCsv(diff, { aName: nameOf(baseId), bName: nameOf(compareId), units, projectName: current.project_name || "" }), "text/csv");
+  };
+
+  const AU = areaUnit(units), LU = lenUnit(units);
+  const av = (sf) => areaVal(sf, units), lv = (lf) => lenVal(lf, units);
+  const th = { textAlign: "right", padding: "7px 10px", fontFamily: "var(--f-mono)", fontSize: 9.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--ink-muted)", borderBottom: "1px solid var(--ink)", whiteSpace: "nowrap" };
+  const td = { textAlign: "right", padding: "8px 10px", fontVariantNumeric: "tabular-nums", borderBottom: "1px solid var(--ink-faint)", whiteSpace: "nowrap" };
+  // deltas render signed and zero-gate at display precision — the same 0.05/0.5
+  // thresholds the diff's own "changed" judgment uses, so a "changed" row always
+  // shows at least one visible number
+  const delta = (v, isEa = false, convert = (x) => x) => {
+    if (Math.abs(v) < (isEa ? 0.5 : 0.05)) return <span style={{ color: "var(--ink-muted)" }}>—</span>;
+    const shown = convert(v);
+    return <span style={{ fontWeight: 700, color: v > 0 ? "var(--cobalt)" : "var(--c-danger)" }}>{v > 0 ? "+" : "−"}{num(Math.abs(shown), isEa ? 0 : 1)}</span>;
+  };
+  const chip = (status) => (
+    <span style={{ fontFamily: "var(--f-mono)", fontSize: 9.5, letterSpacing: "0.08em", textTransform: "uppercase", color: STATUS_COLOR[status] || "var(--ink)", fontWeight: 700 }}>{status}</span>
+  );
+
+  const condRows = diff ? diff.conditions.filter((c) => showUnchanged || c.status !== "unchanged") : [];
+  const sheetRows = diff ? diff.sheets.filter((s) => showUnchanged || s.status !== "unchanged") : [];
+  const matRows = diff ? diff.materials.filter((m) => showUnchanged || m.status !== "unchanged") : [];
+  const identical = diff && diff.changed === 0 && diff.sheets.every((s) => s.status === "unchanged");
+
+  const sel = { padding: "5px 8px", fontSize: 12.5, border: "1px solid var(--ink-faint)", background: "var(--paper-bright)", color: "var(--ink)", maxWidth: 240 };
+
+  return (
+    <div style={{ position: "absolute", inset: 0, zIndex: 50, display: "flex", flexDirection: "column", background: "var(--paper-cream)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 18px", borderBottom: "1px solid var(--ink)", background: "var(--paper-bright)" }}>
+        <Icon name="revisions" size={18} />
+        <strong style={{ fontFamily: "var(--f-display)", fontSize: 16, color: "var(--ink)" }}>Revisions</strong>
+        <span style={{ fontSize: 12, color: "var(--ink-muted)" }}>save the takeoff at each bid revision, then compare what moved</span>
+        <div style={{ flex: 1 }} />
+        <input value={saveName} onChange={(e) => setSaveName(e.target.value)} placeholder={defaultName()}
+          className="field-input" style={{ width: 220, padding: "5px 9px", fontSize: 13 }}
+          onKeyDown={(e) => { if (e.key === "Enter") save(saveName); }} name="revision-name" />
+        <button className="btn-primary" onClick={() => save(saveName)} disabled={busy}
+          title="Snapshot the current takeoff (conditions, shapes, markups) as a named revision">
+          <Icon name="revisions" size={13} />Save revision
+        </button>
+        <button onClick={onClose} title="Back to the canvas"
+          style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "6px 10px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", cursor: "pointer", fontSize: 12.5 }}>
+          <Icon name="close" size={12} />Close
+        </button>
+      </div>
+
+      <div style={{ flex: 1, overflow: "auto", padding: "20px 24px" }}>
+        {err && <p style={{ maxWidth: 980, margin: "0 auto 12px", color: "var(--c-danger)", fontSize: 12.5 }}>{err}</p>}
+
+        {/* saved revisions */}
+        <div style={{ maxWidth: 980, margin: "0 auto" }}>
+          {revs === null ? (
+            <div style={{ padding: 24, textAlign: "center", color: "var(--ink-muted)" }}>Loading revisions…</div>
+          ) : revs.length === 0 ? (
+            <div style={{ padding: "28px 24px", textAlign: "center", color: "var(--ink-muted)", border: "1px dashed var(--ink-faint)", background: "var(--paper-bright)" }}>
+              No revisions yet. Save one now, and after the next addendum lands you can compare exactly which quantities moved.
+            </div>
+          ) : (
+            <table style={{ width: "100%", borderCollapse: "collapse", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)" }}>
+              <thead><tr>
+                <th style={{ ...th, textAlign: "left" }}>Revision</th>
+                <th style={th}>Saved</th>
+                <th style={th}>Conditions</th>
+                <th style={th}>Shapes</th>
+                <th style={{ ...th, textAlign: "left", paddingLeft: 18 }}>Actions</th>
+              </tr></thead>
+              <tbody>
+                {revs.map((r) => (
+                  <tr key={r.id}>
+                    <td style={{ ...td, textAlign: "left", fontWeight: 600 }}>{r.name}</td>
+                    <td style={{ ...td, color: "var(--ink-muted)" }}>{r.created_at ? new Date(r.created_at).toLocaleString() : "—"}</td>
+                    <td style={td}>{r.conditions}</td>
+                    <td style={td}>{r.shapes}</td>
+                    <td style={{ ...td, textAlign: "left", paddingLeft: 18 }}>
+                      <button className="btn-ghost" style={{ fontSize: 11.5, padding: "3px 8px" }}
+                        onClick={() => { setBaseId(r.id); setCompareId("current"); }}
+                        title="Diff this revision against the live takeoff">Compare with current</button>{" "}
+                      <button className="btn-ghost" style={{ fontSize: 11.5, padding: "3px 8px", color: confirmId === `restore:${r.id}` ? "var(--c-warning)" : undefined }}
+                        onClick={() => (confirmId === `restore:${r.id}` ? restore(r.id) : setConfirmId(`restore:${r.id}`))} disabled={busy}
+                        title="Replace the live takeoff with this revision — the live takeoff is auto-backed-up first">
+                        {confirmId === `restore:${r.id}` ? "Really restore? (auto-backup saved)" : "Restore"}</button>{" "}
+                      <button className="btn-ghost" style={{ fontSize: 11.5, padding: "3px 8px", color: confirmId === `del:${r.id}` ? "var(--c-danger)" : undefined }}
+                        onClick={() => (confirmId === `del:${r.id}` ? del(r.id) : setConfirmId(`del:${r.id}`))} disabled={busy}>
+                        {confirmId === `del:${r.id}` ? "Really delete?" : "Delete"}</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* compare picker + results */}
+        {revs?.length > 0 && (
+          <div style={{ maxWidth: 980, margin: "26px auto 0" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+              <h3 style={{ fontFamily: "var(--f-display)", fontSize: 14, color: "var(--ink)", margin: 0 }}>Compare</h3>
+              <select value={baseId} onChange={(e) => setBaseId(e.target.value)} style={sel} name="compare-baseline">
+                <option value="" disabled>baseline…</option>
+                {revs.map((r) => <option key={r.id} value={r.id}>{r.name}</option>)}
+              </select>
+              <span style={{ color: "var(--ink-muted)" }}>→</span>
+              <select value={compareId} onChange={(e) => setCompareId(e.target.value)} style={sel} name="compare-to">
+                <option value="current">Current takeoff</option>
+                {revs.filter((r) => r.id !== baseId).map((r) => <option key={r.id} value={r.id}>{r.name}</option>)}
+              </select>
+              <div style={{ flex: 1 }} />
+              <label style={{ fontSize: 12, color: "var(--ink-muted)", display: "inline-flex", gap: 6, alignItems: "center", cursor: "pointer" }}>
+                <input type="checkbox" checked={showUnchanged} onChange={(e) => setShowUnchanged(e.target.checked)} name="show-unchanged" />show unchanged
+              </label>
+              <button className="btn-ghost" onClick={exportCsv} disabled={!diff}><Icon name="document" size={13} />Export compare CSV</button>
+            </div>
+
+            {!diff ? (
+              <p style={{ marginTop: 14, color: "var(--ink-muted)", fontSize: 12.5 }}>Pick a baseline revision to diff.</p>
+            ) : identical ? (
+              <p style={{ marginTop: 14, color: "var(--c-positive)", fontSize: 13, fontWeight: 600 }}>
+                Identical takeoffs — no visible quantity change between “{nameOf(baseId)}” and “{nameOf(compareId)}”.
+              </p>
+            ) : (
+              <>
+                {/* headline: the ordered-quantity move */}
+                <p style={{ margin: "14px 0 10px", fontSize: 13, color: "var(--ink)" }}>
+                  <strong>{nameOf(baseId)}</strong> → <strong>{nameOf(compareId)}</strong>:{" "}
+                  ordered {AU} {num(av(diff.totals.a.total_sf_net))} → <strong>{num(av(diff.totals.b.total_sf_net))}</strong>{" "}
+                  ({delta(diff.totals.deltas.total_sf_net, false, av)}) · {diff.changed} condition{diff.changed === 1 ? "" : "s"} moved
+                </p>
+                <table style={{ width: "100%", borderCollapse: "collapse", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)" }}>
+                  <thead><tr>
+                    <th style={{ ...th, textAlign: "left" }}>Finish</th>
+                    <th style={{ ...th, textAlign: "left" }}>Status</th>
+                    <th style={th}>Δ Floor {AU}</th>
+                    <th style={th}>Δ Wall {AU}</th>
+                    <th style={th}>Δ Border {AU}</th>
+                    <th style={th}>Δ {LU}</th>
+                    <th style={th}>Δ EA</th>
+                    <th style={{ ...th, color: "var(--cobalt)" }}>{AU} ordered</th>
+                  </tr></thead>
+                  <tbody>
+                    {condRows.map((c) => (
+                      <tr key={c.key}>
+                        <td style={{ ...td, textAlign: "left" }}>
+                          <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                            <span style={{ width: 12, height: 12, background: c.color, display: "inline-block", border: "1px solid var(--ink-faint)" }} />
+                            <strong style={{ fontFamily: "var(--f-mono)", fontWeight: 600 }}>{c.finish_tag}</strong>
+                          </span>
+                        </td>
+                        <td style={{ ...td, textAlign: "left" }}>{chip(c.status)}</td>
+                        <td style={td}>{delta(c.deltas.floor_sf, false, av)}</td>
+                        <td style={td}>{delta(c.deltas.wall_sf, false, av)}</td>
+                        <td style={td}>{delta(c.deltas.border_sf, false, av)}</td>
+                        <td style={td}>{delta(c.deltas.lf, false, lv)}</td>
+                        <td style={td}>{delta(c.deltas.ea, true)}</td>
+                        <td style={{ ...td, color: "var(--cobalt)" }}>
+                          {c.a ? num(av(c.a.total_sf_net)) : "·"} → <strong>{c.b ? num(av(c.b.total_sf_net)) : "·"}</strong>
+                        </td>
+                      </tr>
+                    ))}
+                    {!condRows.length && <tr><td colSpan={8} style={{ ...td, textAlign: "center", color: "var(--ink-muted)" }}>Only unchanged conditions — tick “show unchanged” to list them.</td></tr>}
+                  </tbody>
+                </table>
+
+                {sheetRows.length > 0 && (
+                  <>
+                    <h3 style={{ fontFamily: "var(--f-display)", fontSize: 14, color: "var(--ink)", margin: "22px 0 8px" }}>By sheet</h3>
+                    <table style={{ width: "100%", borderCollapse: "collapse", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)" }}>
+                      <thead><tr>
+                        <th style={{ ...th, textAlign: "left" }}>Sheet</th>
+                        <th style={{ ...th, textAlign: "left" }}>Status</th>
+                        <th style={th}>Δ Floor {AU}</th>
+                        <th style={th}>Δ Wall {AU}</th>
+                        <th style={th}>Δ Border {AU}</th>
+                        <th style={th}>Δ {LU}</th>
+                        <th style={th}>Δ EA</th>
+                      </tr></thead>
+                      <tbody>
+                        {sheetRows.map((s) => (
+                          <tr key={s.sheet_id}>
+                            <td style={{ ...td, textAlign: "left", fontFamily: "var(--f-mono)" }}>{revSheetLabel(s.sheet_id)}</td>
+                            <td style={{ ...td, textAlign: "left" }}>{chip(s.status)}</td>
+                            <td style={td}>{delta(s.deltas.floor_sf, false, av)}</td>
+                            <td style={td}>{delta(s.deltas.wall_sf, false, av)}</td>
+                            <td style={td}>{delta(s.deltas.border_sf, false, av)}</td>
+                            <td style={td}>{delta(s.deltas.lf, false, lv)}</td>
+                            <td style={td}>{delta(s.deltas.ea, true)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    <p style={{ margin: "8px 0 0", fontSize: 11.5, color: "var(--ink-muted)" }}>Base measured quantities per sheet — multiplier and waste apply at condition level.</p>
+                  </>
+                )}
+
+                {matRows.length > 0 && (
+                  <>
+                    <h3 style={{ fontFamily: "var(--f-display)", fontSize: 14, color: "var(--ink)", margin: "22px 0 8px" }}>Buy list</h3>
+                    <table style={{ width: "100%", borderCollapse: "collapse", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)" }}>
+                      <thead><tr>
+                        <th style={{ ...th, textAlign: "left" }}>Material</th>
+                        <th style={{ ...th, textAlign: "left" }}>Status</th>
+                        <th style={th}>Qty ({nameOf(baseId)})</th>
+                        <th style={th}>Qty ({nameOf(compareId)})</th>
+                        <th style={th}>Δ</th>
+                        <th style={{ ...th, textAlign: "left", paddingLeft: 16 }}>Unit</th>
+                      </tr></thead>
+                      <tbody>
+                        {matRows.map((m, i) => (
+                          <tr key={i}>
+                            <td style={{ ...td, textAlign: "left" }}>{m.name}</td>
+                            <td style={{ ...td, textAlign: "left" }}>{chip(m.status)}</td>
+                            <td style={td}>{num(m.a_qty, 2)}</td>
+                            <td style={{ ...td, fontWeight: 700 }}>{num(m.b_qty, 2)}</td>
+                            <td style={td}>{delta(m.delta)}</td>
+                            <td style={{ ...td, textAlign: "left", paddingLeft: 16, color: "var(--ink-muted)" }}>{m.unit || "—"}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/revisions.js
+++ b/web/src/lib/revisions.js
@@ -1,0 +1,205 @@
+// Revision compare — bid revisions and addenda as QUANTITY deltas.
+//
+// The diff is deliberately quantity-level, not geometric: shape uids don't
+// survive a re-imported sheet or a deleted-and-redrawn room, so pairing shapes
+// across revisions would read as noise. What an estimator actually reviews
+// after Addendum 2 lands is "which finish moved, by how much, and on which
+// sheet" — so both payloads are totaled with the SAME role math the report
+// uses (conditionTotals) and the totals are diffed.
+//
+// Condition pairing: id first. Conditions that were deleted and recreated get
+// fresh uids, so unmatched rows then pair by finish_tag, in order — two
+// leftover "CT-1" rows on each side pair first-with-first, and the pair key
+// carries an ordinal so duplicate tags can't collide in maps or React keys.
+//
+// "Changed" is judged at DISPLAY precision (quantities render 1 decimal, EA
+// whole): sub-display drift — a 0.02 SF wobble from re-tracing the same room —
+// is not a change the reviewer can even see, so it reports unchanged.
+
+import { conditionTotals, grandTotals, materialsSummary } from "./totals.js";
+import { parseSheetKey } from "./sheets";
+
+const round2 = (n) => Math.round((n + Number.EPSILON) * 100) / 100;
+
+// The condition-level fields compared. total_sf_net is the ordered quantity,
+// so a waste_pct-only edit shows there and only there — the takeoff didn't
+// change, the order did, and the diff says exactly that.
+export const COND_FIELDS = ["floor_sf", "wall_sf", "border_sf", "lf", "ea", "total_sf", "total_sf_net"];
+// Sheet-level rows carry base measured quantities (no multiplier, no waste —
+// those are condition-level ordering concerns, not sheet locations).
+export const SHEET_FIELDS = ["floor_sf", "wall_sf", "border_sf", "lf", "ea"];
+
+const visible = (f, d) => Math.abs(d) >= (f === "ea" ? 0.5 : 0.05);
+
+function deltasOf(fields, a, b) {
+  /** @type {Record<string, number>} */
+  const out = {};
+  for (const f of fields) out[f] = round2((b ? b[f] || 0 : 0) - (a ? a[f] || 0 : 0));
+  return out;
+}
+const anyVisible = (fields, deltas) => fields.some((f) => visible(f, deltas[f]));
+
+// A lone-side row only counts as added/removed if there is anything on it —
+// a shapeless seeded condition that exists in one revision and not the other
+// diffs as unchanged, never as a fabricated add/remove.
+const hasSubstance = (fields, r) => r.shape_count > 0 || fields.some((f) => visible(f, r[f] || 0));
+
+// Pair rows across revisions: id match first, finish_tag fallback for the
+// leftovers (first-come within a tag, empty tags never pair). Entries come
+// back in B order with removed-A rows appended — review reads top to bottom
+// as "the takeoff as it stands now, then what disappeared".
+function pairRows(rowsA, rowsB) {
+  const aById = new Map(rowsA.map((r) => [r.id, r]));
+  const matched = new Set(rowsB.filter((b) => aById.has(b.id)).map((b) => b.id));
+
+  const tagQueues = new Map();                    // finish_tag -> unmatched A rows, A order
+  for (const a of rowsA) {
+    if (matched.has(a.id) || !a.finish_tag) continue;
+    let q = tagQueues.get(a.finish_tag);
+    if (!q) { q = []; tagQueues.set(a.finish_tag, q); }
+    q.push(a);
+  }
+
+  const consumedA = new Set(matched);
+  const ordinals = new Map();
+  const entries = [];
+  for (const b of rowsB) {
+    if (matched.has(b.id)) { entries.push({ key: b.id, a: aById.get(b.id), b }); continue; }
+    const q = b.finish_tag ? tagQueues.get(b.finish_tag) : null;
+    const a = q && q.length ? q.shift() : null;
+    if (a) {
+      const n = ordinals.get(b.finish_tag) || 0;
+      ordinals.set(b.finish_tag, n + 1);
+      consumedA.add(a.id);
+      entries.push({ key: `tag:${b.finish_tag}#${n}`, a, b });
+    } else entries.push({ key: b.id, a: null, b });
+  }
+  for (const a of rowsA) if (!consumedA.has(a.id)) entries.push({ key: a.id, a, b: null });
+  return entries;
+}
+
+// Base quantities per sheet, all conditions pooled — "which sheet moved".
+// Orphan shapes (deleted condition) are skipped, matching the report's math.
+function perSheet(conditions, shapes) {
+  const live = new Set((conditions || []).map((c) => c.id));
+  const acc = new Map();
+  for (const s of shapes || []) {
+    if (!live.has(s.condition_id) || !s.sheet_id) continue;
+    let row = acc.get(s.sheet_id);
+    if (!row) { row = { sheet_id: s.sheet_id, floor_sf: 0, wall_sf: 0, border_sf: 0, lf: 0, ea: 0, shape_count: 0 }; acc.set(s.sheet_id, row); }
+    row.shape_count++;
+    const cp = s.computed || {};
+    switch (s.measure_role) {
+      case "deduct": row.floor_sf -= cp.area_sf || 0; break;
+      case "floor_area": row.floor_sf += cp.area_sf || 0; break;
+      case "surface_area": row.wall_sf += cp.area_sf || 0; break;
+      case "linear": row.lf += cp.perimeter_lf || 0; row.border_sf += cp.area_sf || 0; break;
+      case "count": row.ea += cp.count || 1; break;
+      default: break;
+    }
+  }
+  for (const row of acc.values()) for (const f of SHEET_FIELDS) row[f] = round2(row[f]);
+  return acc;
+}
+
+// "plan.pdf#3" -> "plan — p.3"
+export function revSheetLabel(sheetId) {
+  const { file, page } = parseSheetKey(sheetId);
+  const stem = file.replace(/\.pdf$/i, "");
+  return page > 1 ? `${stem} — p.${page}` : stem;
+}
+
+// Diff two takeoff payloads ({ conditions, shapes } — the autosave shape;
+// missing arrays tolerated, so {} means "everything on the other side is new").
+//
+// Returns {
+//   conditions: [{ key, finish_tag, color, status, a, b, deltas }],
+//   sheets:     [{ sheet_id, status, a, b, deltas }],
+//   materials:  [{ name, unit, a_qty, b_qty, delta, status }],
+//   totals:     { a, b, deltas },   // grandTotals both sides
+//   changed:    n,                  // condition rows that aren't unchanged
+// }
+export function diffTakeoffs(a, b) {
+  const rowsA = conditionTotals(a?.conditions || [], a?.shapes || []);
+  const rowsB = conditionTotals(b?.conditions || [], b?.shapes || []);
+
+  const conditions = pairRows(rowsA, rowsB).map(({ key, a: ra, b: rb }) => {
+    const deltas = deltasOf(COND_FIELDS, ra, rb);
+    let status;
+    if (ra && rb) status = anyVisible(COND_FIELDS, deltas) ? "changed" : "unchanged";
+    else if (rb) status = hasSubstance(COND_FIELDS, rb) ? "added" : "unchanged";
+    else status = hasSubstance(COND_FIELDS, ra) ? "removed" : "unchanged";
+    return { key, finish_tag: (rb || ra).finish_tag, color: (rb || ra).color, status, a: ra, b: rb, deltas };
+  });
+
+  const shA = perSheet(a?.conditions, a?.shapes), shB = perSheet(b?.conditions, b?.shapes);
+  const sheetIds = [...new Set([...shB.keys(), ...shA.keys()])].sort((x, y) => x.localeCompare(y));
+  const sheets = sheetIds.map((id) => {
+    const ra = shA.get(id) || null, rb = shB.get(id) || null;
+    const deltas = deltasOf(SHEET_FIELDS, ra, rb);
+    let status;
+    if (ra && rb) status = anyVisible(SHEET_FIELDS, deltas) ? "changed" : "unchanged";
+    else if (rb) status = "added";
+    else status = "removed";
+    return { sheet_id: id, status, a: ra, b: rb, deltas };
+  });
+
+  // buy-list deltas: same-named materials compared across the whole takeoff —
+  // "the adhesive order went from 12 pails to 14" is the sentence this feeds.
+  const matKey = (m) => `${m.name}\x00${m.unit}`;
+  const matA = new Map(materialsSummary(rowsA).map((m) => [matKey(m), m]));
+  const matB = new Map(materialsSummary(rowsB).map((m) => [matKey(m), m]));
+  const matKeys = [...new Set([...matB.keys(), ...matA.keys()])];
+  const materials = matKeys.map((k) => {
+    const ma = matA.get(k), mb = matB.get(k);
+    const aq = ma ? ma.qty : 0, bq = mb ? mb.qty : 0;
+    const delta = round2(bq - aq);
+    return {
+      name: (mb || ma).name, unit: (mb || ma).unit, a_qty: aq, b_qty: bq, delta,
+      status: !ma ? "added" : !mb ? "removed" : Math.abs(delta) >= 0.005 ? "changed" : "unchanged",
+    };
+  }).filter((m) => m.a_qty || m.b_qty);
+
+  const totals = { a: grandTotals(rowsA), b: grandTotals(rowsB), deltas: deltasOf(["total_sf", "total_sf_net", "lf", "lf_net", "ea", "sy_net"], grandTotals(rowsA), grandTotals(rowsB)) };
+  const changed = conditions.filter((c) => c.status !== "unchanged").length;
+  return { conditions, sheets, materials, totals, changed };
+}
+
+// The compare as a CSV record — every row with its status, deltas signed,
+// grand-total delta line, then per-sheet and buy-list sections.
+export function diffToCsv(diff, { aName = "baseline", bName = "current", units = "imperial", projectName = "" } = {}) {
+  const M = units === "metric";
+  const A = (sf) => (M ? +(sf * 0.09290304).toFixed(2) : sf);
+  const L = (lf) => (M ? +(lf * 0.3048).toFixed(2) : lf);
+  const AU = M ? "m2" : "SF", LU = M ? "m" : "LF";
+  const esc = (v) => {
+    const s = String(v ?? "");
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const row = (cells) => cells.map(esc).join(",");
+  const lines = [];
+  if (projectName) lines.push(`# ${projectName} — OpenTakeoff revision compare`);
+  lines.push(`# ${aName} -> ${bName}`);
+  lines.push(row(["Finish", "Status", `d Floor ${AU}`, `d Wall ${AU}`, `d Border ${AU}`, `d ${LU}`, "d EA", `d Total ${AU}`,
+    `${AU} ordered (${aName})`, `${AU} ordered (${bName})`, `d ${AU} ordered`]));
+  for (const c of diff.conditions) {
+    lines.push(row([c.finish_tag, c.status, A(c.deltas.floor_sf), A(c.deltas.wall_sf), A(c.deltas.border_sf),
+      L(c.deltas.lf), c.deltas.ea, A(c.deltas.total_sf),
+      c.a ? A(c.a.total_sf_net) : "", c.b ? A(c.b.total_sf_net) : "", A(c.deltas.total_sf_net)]));
+  }
+  const t = diff.totals;
+  lines.push(row(["TOTAL", "", "", "", "", L(t.deltas.lf), t.deltas.ea, A(t.deltas.total_sf), A(t.a.total_sf_net), A(t.b.total_sf_net), A(t.deltas.total_sf_net)]));
+  if (diff.sheets.length) {
+    lines.push("");
+    lines.push(row(["Sheet", "Status", `d Floor ${AU}`, `d Wall ${AU}`, `d Border ${AU}`, `d ${LU}`, "d EA"]));
+    for (const s of diff.sheets) {
+      lines.push(row([revSheetLabel(s.sheet_id), s.status, A(s.deltas.floor_sf), A(s.deltas.wall_sf), A(s.deltas.border_sf), L(s.deltas.lf), s.deltas.ea]));
+    }
+  }
+  if (diff.materials.length) {
+    lines.push("");
+    lines.push(row(["Material", "Unit", `Qty (${aName})`, `Qty (${bName})`, "d Qty"]));
+    for (const m of diff.materials) lines.push(row([m.name, m.unit, m.a_qty, m.b_qty, m.delta]));
+  }
+  return lines.join("\n") + "\n";
+}

--- a/web/src/lib/store.js
+++ b/web/src/lib/store.js
@@ -14,9 +14,10 @@
 // Plus local-only helpers the drag-drop entry needs: addPdf(file), removePdf(name).
 
 const DB_NAME = "opentakeoff";
-const DB_VERSION = 1;
+const DB_VERSION = 2;              // v2: adds the revisions store
 const PDF_STORE = "pdfs";          // key: file name -> { name, bytes: ArrayBuffer }
 const META_STORE = "meta";         // key: "annotations" -> payload object
+const REV_STORE = "revisions";     // key: id -> { id, name, created_at, payload }
 const ANN_KEY = "annotations";
 const ANN_SCHEMA = "opentakeoff.takeoff_canvas.v1";
 
@@ -27,6 +28,7 @@ function openDB() {
       const db = req.result;
       if (!db.objectStoreNames.contains(PDF_STORE)) db.createObjectStore(PDF_STORE, { keyPath: "name" });
       if (!db.objectStoreNames.contains(META_STORE)) db.createObjectStore(META_STORE);
+      if (!db.objectStoreNames.contains(REV_STORE)) db.createObjectStore(REV_STORE, { keyPath: "id" });
     };
     req.onsuccess = () => resolve(req.result);
     req.onerror = () => reject(req.error);
@@ -89,6 +91,47 @@ export const localStore = {
   async saveAnnotations(payload) {
     const db = await openDB();
     await tx(db, META_STORE, "readwrite", (os) => os.put({ ...payload, schema: ANN_SCHEMA }, ANN_KEY));
+    db.close();
+  },
+
+  // ── revisions: named takeoff snapshots for bid-revision compare ───────────
+  // The payload is the annotations subset the compare needs (conditions,
+  // shapes, markups, project_name, units) — never the PDFs, so a revision is
+  // a few hundred KB at the very worst, not a plan set.
+
+  async listRevisions() {
+    const db = await openDB();
+    const all = await tx(db, REV_STORE, "readonly", (os) => os.getAll());
+    db.close();
+    return (all || [])
+      .map((r) => ({ id: r.id, name: r.name, created_at: r.created_at, conditions: (r.payload?.conditions || []).length, shapes: (r.payload?.shapes || []).length }))
+      .sort((x, y) => (y.created_at || "").localeCompare(x.created_at || ""));   // newest first
+  },
+
+  async saveRevision({ name, payload }) {
+    const rec = {
+      id: `rev_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+      name: name || "Revision",
+      created_at: new Date().toISOString(),
+      payload,
+    };
+    const db = await openDB();
+    await tx(db, REV_STORE, "readwrite", (os) => os.put(rec));
+    db.close();
+    return { id: rec.id, name: rec.name, created_at: rec.created_at };
+  },
+
+  async loadRevision(id) {
+    const db = await openDB();
+    const rec = await tx(db, REV_STORE, "readonly", (os) => os.get(id));
+    db.close();
+    if (!rec) throw new Error(`Revision not found: ${id}`);
+    return rec;
+  },
+
+  async deleteRevision(id) {
+    const db = await openDB();
+    await tx(db, REV_STORE, "readwrite", (os) => os.delete(id));
     db.close();
   },
 };

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -17,6 +17,7 @@ import { ingestFiles } from "../lib/ingest.js";
 import ToolMenu from "../components/ToolMenu.jsx";
 import SheetGallery from "../components/SheetGallery.jsx";
 import ReportPanel from "../components/ReportPanel.jsx";
+import RevisionsPanel from "../components/RevisionsPanel.jsx";
 import { Icon } from "../brand/icons.jsx";
 import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, extractSheetNumber, detectScale, scaleFromLabel } from "../lib/sheets";
 import { isAiConfigured, visionQuery, scaleReadPrompt } from "../lib/ai.js";
@@ -395,6 +396,7 @@ export default function TakeoffCanvas() {
   const [saveState, setSaveState] = useState("idle");
   const [commitMsg, setCommitMsg] = useState("");   // transient status line (misnamed for history; just the message bar)
   const [showReport, setShowReport] = useState(false);  // Reports overlay (STACK-style breakdown + export)
+  const [showRevisions, setShowRevisions] = useState(false);  // Revisions overlay (save snapshots + compare quantity deltas)
   const [showAiSettings, setShowAiSettings] = useState(false); // bring-your-own-key AI settings modal
   const [aiScaleBusy, setAiScaleBusy] = useState("");    // sheetKey with an AI scale-read in flight
   const [projectName, setProjectName] = useState("");   // optional label for the report header
@@ -2886,6 +2888,7 @@ export default function TakeoffCanvas() {
         <div style={{ position: "absolute", right: 14, top: "50%", transform: "translateY(-50%)", display: "flex", flexDirection: "column", gap: 6, zIndex: 8 }}>
           {panelBtn(() => setShowMarkupPanel((v) => !v), "markup", "Markups on these sheets (clouds, callouts, notes)", showMarkupPanel, markupCount)}
           {panelBtn(() => setShowTakeoffs((v) => !v), "takeoffs", "Takeoffs — conditions + running totals", showTakeoffs, visibleShapes.length)}
+          {panelBtn(() => setShowRevisions(true), "revisions", "Revisions — save the takeoff at each bid revision, compare what moved", showRevisions)}
         </div>
 
         {/* markup panel — manage clouds/callouts/text + link or create RFIs (top-left, clear of HUD/FABs) */}
@@ -2993,6 +2996,25 @@ export default function TakeoffCanvas() {
           sheetLabel={(k) => tabLabel(k)}
           onMarkedSet={exportMarkedSet} markedSetDark={darkMode}
           onClose={() => setShowReport(false)}
+        />
+      )}
+
+      {showRevisions && (
+        <RevisionsPanel
+          current={{ project_name: projectName, units, conditions, shapes, markups }}
+          units={units}
+          onRestore={(p) => {
+            // swap in the revision's takeoff state; sheets/tabs/scales stay as
+            // they are (shapes on since-removed sheets are harmless — they only
+            // render on their own sheet). Autosave persists the swap.
+            const conds = p.conditions || [];
+            setConditions(conds);
+            setActiveCond(conds[0]?.id || null);
+            setShapes(p.shapes || []);
+            setMarkups(Array.isArray(p.markups) ? p.markups : []);
+            setSelectedId(null); setSelectedMarkupId(null); setProposal(null); setPoly([]);
+          }}
+          onClose={() => setShowRevisions(false)}
         />
       )}
 

--- a/web/test/revisions.test.ts
+++ b/web/test/revisions.test.ts
@@ -1,0 +1,145 @@
+// Revision compare — the quantity-level diff. Payloads use the autosave shape
+// ({ conditions, shapes }); every case runs through the same conditionTotals
+// math the report uses, so these tests pin the compare to report semantics.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { diffTakeoffs, diffToCsv, revSheetLabel } from "../src/lib/revisions.js";
+
+const cond = (over: Record<string, unknown> = {}) => ({
+  id: "c1", finish_tag: "CPT-1", color: "#123456", multiplier: 1, waste_pct: 0, materials: [], ...over,
+});
+const shape = (over: Record<string, unknown> = {}) => ({
+  id: "s1", sheet_id: "plan.pdf", condition_id: "c1", measure_role: "floor_area", computed: { area_sf: 100 }, ...over,
+});
+const takeoff = (conditions: unknown[], shapes: unknown[]) => ({ conditions, shapes });
+
+test("identical takeoffs diff as unchanged with zero deltas", () => {
+  const a = takeoff([cond()], [shape()]);
+  const d = diffTakeoffs(a, takeoff([cond()], [shape()]));
+  assert.equal(d.changed, 0);
+  assert.equal(d.conditions[0].status, "unchanged");
+  assert.equal(d.conditions[0].deltas.total_sf, 0);
+  assert.ok(d.sheets.every((s) => s.status === "unchanged"));
+});
+
+test("a waste-only edit moves the ordered quantity and nothing else", () => {
+  const d = diffTakeoffs(
+    takeoff([cond({ waste_pct: 0 })], [shape()]),
+    takeoff([cond({ waste_pct: 10 })], [shape()]),
+  );
+  const c = d.conditions[0];
+  assert.equal(c.status, "changed");
+  assert.equal(c.deltas.total_sf, 0);          // measured did not move
+  assert.equal(c.deltas.total_sf_net, 10);     // the order did
+});
+
+test("added and removed conditions report with the full quantity as the delta", () => {
+  const d = diffTakeoffs(
+    takeoff([cond()], [shape()]),
+    takeoff([cond(), cond({ id: "c2", finish_tag: "LVT-2" })], [shape(), shape({ id: "s2", condition_id: "c2", computed: { area_sf: 55 } })]),
+  );
+  const added = d.conditions.find((c) => c.finish_tag === "LVT-2");
+  assert.equal(added?.status, "added");
+  assert.equal(added?.deltas.total_sf, 55);    // b's value, not zero-filled
+
+  const d2 = diffTakeoffs(takeoff([cond()], [shape()]), takeoff([], []));
+  assert.equal(d2.conditions[0].status, "removed");
+  assert.equal(d2.conditions[0].deltas.total_sf, -100);
+});
+
+test("deleted-and-recreated condition pairs by finish_tag instead of diffing as remove+add", () => {
+  const d = diffTakeoffs(
+    takeoff([cond({ id: "old-uid" })], [shape({ condition_id: "old-uid" })]),
+    takeoff([cond({ id: "new-uid" })], [shape({ condition_id: "new-uid", computed: { area_sf: 120 } })]),
+  );
+  assert.equal(d.conditions.length, 1);
+  assert.equal(d.conditions[0].status, "changed");
+  assert.equal(d.conditions[0].deltas.total_sf, 20);
+});
+
+test("duplicate finish_tags pair in order with distinct keys", () => {
+  const two = (p: string) => [cond({ id: `${p}1`, finish_tag: "CT-1" }), cond({ id: `${p}2`, finish_tag: "CT-1" })];
+  const d = diffTakeoffs(
+    takeoff(two("a"), [shape({ condition_id: "a1" }), shape({ id: "s2", condition_id: "a2", computed: { area_sf: 30 } })]),
+    takeoff(two("b"), [shape({ condition_id: "b1" }), shape({ id: "s2", condition_id: "b2", computed: { area_sf: 30 } })]),
+  );
+  assert.equal(d.conditions.length, 2);
+  assert.notEqual(d.conditions[0].key, d.conditions[1].key);   // ordinal keeps keys unique
+  assert.ok(d.conditions.every((c) => c.status === "unchanged"));
+});
+
+test("shapeless seeded conditions never fabricate an add/remove", () => {
+  const d = diffTakeoffs(
+    takeoff([], []),
+    takeoff([cond({ id: "seed1", finish_tag: "VCT-1" })], []),     // present, zero shapes
+  );
+  assert.equal(d.conditions[0].status, "unchanged");
+  assert.equal(d.changed, 0);
+});
+
+test("sub-display drift reports unchanged; a visible move reports changed", () => {
+  const base = takeoff([cond()], [shape()]);
+  const drift = diffTakeoffs(base, takeoff([cond()], [shape({ computed: { area_sf: 100.02 } })]));
+  assert.equal(drift.conditions[0].status, "unchanged");
+  const real = diffTakeoffs(base, takeoff([cond()], [shape({ computed: { area_sf: 100.4 } })]));
+  assert.equal(real.conditions[0].status, "changed");
+});
+
+test("a shape moving between sheets shows as paired sheet deltas", () => {
+  const d = diffTakeoffs(
+    takeoff([cond()], [shape({ sheet_id: "plan.pdf" })]),
+    takeoff([cond()], [shape({ sheet_id: "plan.pdf#2" })]),
+  );
+  const s1 = d.sheets.find((s) => s.sheet_id === "plan.pdf");
+  const s2 = d.sheets.find((s) => s.sheet_id === "plan.pdf#2");
+  assert.equal(s1?.status, "removed");
+  assert.equal(s1?.deltas.floor_sf, -100);
+  assert.equal(s2?.status, "added");
+  assert.equal(s2?.deltas.floor_sf, 100);
+  assert.equal(d.conditions[0].status, "unchanged");   // condition totals didn't move
+});
+
+test("buy-list deltas track the combined materials order", () => {
+  const withMat = (per: number) => [cond({ materials: [{ name: "Adhesive", unit: "pail", per, basis: "area" }] })];
+  const d = diffTakeoffs(
+    takeoff(withMat(40), [shape()]),      // 100/40 -> 3 pails
+    takeoff(withMat(25), [shape()]),      // 100/25 -> 4 pails
+  );
+  assert.equal(d.materials.length, 1);
+  assert.equal(d.materials[0].a_qty, 3);
+  assert.equal(d.materials[0].b_qty, 4);
+  assert.equal(d.materials[0].delta, 1);
+  assert.equal(d.materials[0].status, "changed");
+});
+
+test("orphan shapes (deleted condition) stay out of sheet deltas", () => {
+  const d = diffTakeoffs(
+    takeoff([cond()], [shape(), shape({ id: "s2", condition_id: "ghost", computed: { area_sf: 999 } })]),
+    takeoff([cond()], [shape()]),
+  );
+  assert.ok(d.sheets.every((s) => s.status === "unchanged"));
+});
+
+test("revSheetLabel formats page keys", () => {
+  assert.equal(revSheetLabel("plan.pdf"), "plan");
+  assert.equal(revSheetLabel("plan.pdf#3"), "plan — p.3");
+});
+
+test("diffToCsv carries statuses, deltas, sections, and escapes commas", () => {
+  const d = diffTakeoffs(
+    takeoff([cond({ finish_tag: 'CPT,1 "x"' })], [shape()]),
+    takeoff([cond({ finish_tag: 'CPT,1 "x"' })], [shape({ computed: { area_sf: 150 } })]),
+  );
+  const csv = diffToCsv(d, { aName: "Rev 1", bName: "current", projectName: "Job" });
+  assert.match(csv, /revision compare/);
+  assert.match(csv, /"CPT,1 ""x""",changed/);
+  assert.match(csv, /TOTAL/);
+  assert.match(csv, /Sheet,Status/);
+});
+
+test("metric CSV converts areas and lengths", () => {
+  const d = diffTakeoffs(takeoff([cond()], []), takeoff([cond()], [shape()]));
+  const csv = diffToCsv(d, { units: "metric" });
+  assert.match(csv, /d Floor m2/);
+  assert.match(csv, /9\.29/);
+});


### PR DESCRIPTION
## What

Bid revisions and addenda as data. A new **Revisions** rail toggle opens an overlay where you can:

- **Save** the takeoff (conditions, shapes, markups) as a named revision — IndexedDB schema v2, new `revisions` store; payloads are the annotations subset, never the PDFs.
- **Compare** any two revisions, or a revision against the live takeoff: per-condition deltas, per-sheet deltas (which sheet moved), and buy-list deltas ("the adhesive order went from 3 pails to 4"), plus a compare CSV export.
- **Restore** a revision — never a one-way door: the live takeoff is auto-banked as a revision first.

## Design

The diff is deliberately **quantity-level, not geometric**: shape uids don't survive a re-imported sheet or a redrawn room, so pairing shapes would read as noise. Both payloads run through the same `conditionTotals` math as the report. Conditions pair by id with a finish_tag fallback (ordinal-keyed so duplicate tags can't collide); "changed" is judged at display precision so sub-display re-trace wobble reads unchanged; a waste-only edit moves exactly one column — the ordered quantity.

## Verification

13 new tests: identical/waste-only/added/removed, tag-fallback pairing, duplicate-tag ordinals, shapeless seeded conditions never fabricating adds, display-precision thresholds, sheet-move deltas, buy-list deltas, CSV escaping, metric. Full flow also exercised live in the browser: save → list → compare (identical and changed paths, headline math verified) → delete, on a fresh v1→v2 IndexedDB upgrade. Typecheck + build clean.