### PR TITLE
security: CSP + security headers on deploy; zip-ingest bounds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,22 @@
   from   = "/*"
   to     = "/index.html"
   status = 200
+
+# Security headers. The CSP is shaped by what the app actually is — a
+# client-only canvas with two user-pointed network seams:
+#   - script-src stays 'self' (+ wasm for pdf.js image codecs); no unsafe-eval —
+#     pdf.js falls back to its non-eval PostScript/font paths under CSP.
+#   - style-src needs 'unsafe-inline': the app styles via React style attributes.
+#   - worker-src blob: for the bundled pdf.js worker; img-src data:/blob: for
+#     rendered canvases and export previews.
+#   - connect-src stays open ON PURPOSE: the BYO-AI base URL and the
+#     capture/contribute endpoint are user-configured (your own server,
+#     localhost, any provider). Self-hosters who pin those can tighten it.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; worker-src 'self' blob:; connect-src * data: blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+    X-Content-Type-Options = "nosniff"
+    X-Frame-Options = "DENY"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"

--- a/web/src/lib/ingest.js
+++ b/web/src/lib/ingest.js
@@ -16,6 +16,17 @@ const PDF_EXT = /\.pdf$/i;
 const IMAGE_EXT = /\.(png|jpe?g|webp|gif|bmp)$/i;
 const ZIP_EXT = /\.zip$/i;
 
+// Zip-bomb bounds. Real plan sets are dozens of sheets, maybe a couple hundred
+// on a hospital job — the caps sit far above anything legitimate while keeping
+// a hostile archive from exhausting the tab: an entry count cap, a nesting
+// depth cap (zip-in-zip recursion), and per-entry/total decompressed-size caps
+// (fflate reports uncompressed sizes before inflating, so oversized entries
+// are refused without ever being decompressed).
+const MAX_ZIP_ENTRIES = 500;
+const MAX_ZIP_DEPTH = 2;
+const MAX_ENTRY_BYTES = 512 * 1024 * 1024;        // 512 MB per entry
+const MAX_TOTAL_BYTES = 1536 * 1024 * 1024;       // 1.5 GB decompressed per drop
+
 const isPdf = (name, type = "") => PDF_EXT.test(name) || type === "application/pdf";
 const isImage = (name, type = "") => IMAGE_EXT.test(name) || (type || "").startsWith("image/");
 const isZip = (name, type = "") => ZIP_EXT.test(name) || /zip/i.test(type);
@@ -39,17 +50,22 @@ async function looksLikeZip(file) {
 }
 
 // Decompress only the entries we can use (saves memory on big plan sets); report
-// anything else as skipped via onSkip rather than silently dropping it.
-async function unzipBytes(bytes, onSkip) {
+// anything else as skipped via onSkip rather than silently dropping it. `budget`
+// is shared across nested zips in one drop, so the caps hold for the whole batch.
+async function unzipBytes(bytes, onSkip, budget) {
   const { unzip } = await import("fflate");
   return new Promise((resolve, reject) => {
     unzip(bytes, {
       filter: (f) => {
         if (isJunk(f.name)) return false;
         const bn = baseName(f.name);
-        const ok = isPdf(bn) || isImage(bn) || isZip(bn);
-        if (!ok) onSkip?.(bn);
-        return ok;
+        if (!(isPdf(bn) || isImage(bn) || isZip(bn))) { onSkip?.(bn, "unsupported type"); return false; }
+        if (budget.entries >= MAX_ZIP_ENTRIES) { onSkip?.(bn, `zip entry cap (${MAX_ZIP_ENTRIES}) reached`); return false; }
+        if (f.originalSize > MAX_ENTRY_BYTES) { onSkip?.(bn, "entry too large"); return false; }
+        if (budget.bytes + f.originalSize > MAX_TOTAL_BYTES) { onSkip?.(bn, "zip decompressed-size cap reached"); return false; }
+        budget.entries += 1;
+        budget.bytes += f.originalSize;
+        return true;
       },
     }, (err, data) => (err ? reject(err) : resolve(data)));
   });
@@ -102,22 +118,26 @@ export async function ingestFiles(fileList, { onProgress } = {}) {
     pdfs.push(name === file.name ? file : new File([file], name, { type: "application/pdf" }));
   };
 
-  async function process(file) {
+  // one budget per drop: nested zips draw from the same entry/byte caps
+  const budget = { entries: 0, bytes: 0 };
+
+  async function process(file, depth = 0) {
     const name = file.name || "file";
     try {
       if (isPdf(name, file.type)) { pushPdf(file); return; }
       if (isImage(name, file.type)) { onProgress?.(`Converting ${baseName(name)}…`); pushPdf(await imageToPdf(file)); return; }
       if (isZip(name, file.type) || (await looksLikeZip(file))) {
+        if (depth >= MAX_ZIP_DEPTH) { skipped.push({ name: baseName(name), reason: `zip nested deeper than ${MAX_ZIP_DEPTH} levels` }); return; }
         onProgress?.(`Unzipping ${baseName(name)}…`);
         const entries = await unzipBytes(new Uint8Array(await file.arrayBuffer()),
-          (bn) => skipped.push({ name: bn, reason: "unsupported type" }));
+          (bn, reason) => skipped.push({ name: bn, reason }), budget);
         const paths = Object.keys(entries);
         if (!paths.length) { skipped.push({ name: baseName(name), reason: "no plans found in zip" }); return; }
         for (const path of paths) {
           const bn = baseName(path);
           if (isPdf(bn)) pushPdf(new File([entries[path]], bn, { type: "application/pdf" }));
           else if (isImage(bn)) { onProgress?.(`Converting ${bn}…`); pushPdf(await imageToPdf(new File([entries[path]], bn))); }
-          else if (isZip(bn)) await process(new File([entries[path]], bn, { type: "application/zip" }));
+          else if (isZip(bn)) await process(new File([entries[path]], bn, { type: "application/zip" }), depth + 1);
         }
         return;
       }

--- a/web/test/ingest.test.ts
+++ b/web/test/ingest.test.ts
@@ -1,0 +1,48 @@
+// Ingest zip bounds — the entry-count and nesting-depth caps, exercised
+// through the public ingestFiles() path with zips built in memory.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { zipSync, strToU8 } from "fflate";
+import { ingestFiles } from "../src/lib/ingest.js";
+
+const zipFile = (entries: Record<string, Uint8Array>, name = "set.zip") =>
+  new File([zipSync(entries)], name, { type: "application/zip" });
+
+test("a normal plan-set zip ingests every sheet", async () => {
+  const { pdfs, skipped } = await ingestFiles([zipFile({
+    "A1.pdf": strToU8("%PDF-1.4 a"),
+    "sub/A2.pdf": strToU8("%PDF-1.4 b"),
+    "__MACOSX/._A1.pdf": strToU8("junk"),
+    "notes.txt": strToU8("skip me"),
+  })]);
+  assert.equal(pdfs.length, 2);
+  assert.deepEqual(skipped.map((s) => s.name), ["notes.txt"]);
+});
+
+test("zip entry cap: entries beyond the cap are skipped with a reason, not exploded", async () => {
+  const entries: Record<string, Uint8Array> = {};
+  for (let i = 0; i < 510; i++) entries[`p${String(i).padStart(3, "0")}.pdf`] = strToU8("x");
+  const { pdfs, skipped } = await ingestFiles([zipFile(entries)]);
+  assert.equal(pdfs.length, 500);
+  assert.equal(skipped.length, 10);
+  assert.match(skipped[0].reason, /entry cap/);
+});
+
+test("zip-in-zip works once; deeper nesting is refused", async () => {
+  const inner = zipSync({ "deep.pdf": strToU8("%PDF-1.4") });
+  const middle = zipSync({ "inner.zip": inner, "mid.pdf": strToU8("%PDF-1.4") });
+  const outer = zipFile({ "middle.zip": middle, "top.pdf": strToU8("%PDF-1.4") });
+  const { pdfs, skipped } = await ingestFiles([outer]);
+  // top.pdf (depth 0) + mid.pdf (depth 1) land; inner.zip sits at depth 2 -> refused
+  assert.deepEqual(pdfs.map((p) => p.name).sort(), ["mid.pdf", "top.pdf"]);
+  assert.equal(skipped.length, 1);
+  assert.match(skipped[0].reason, /nested deeper/);
+});
+
+test("the shared budget spans sibling zips in one drop", async () => {
+  const half: Record<string, Uint8Array> = {};
+  for (let i = 0; i < 300; i++) half[`a${i}.pdf`] = strToU8("x");
+  const { pdfs, skipped } = await ingestFiles([zipFile(half, "one.zip"), zipFile(half, "two.zip")]);
+  assert.equal(pdfs.length, 500);                          // 300 + 200, not 600
+  assert.equal(skipped.length, 100);
+});


### PR DESCRIPTION
## What

**Headers** (netlify.toml): a Content-Security-Policy shaped by what the app is — a client-only canvas. `script-src 'self' 'wasm-unsafe-eval'` (no `unsafe-eval`; pdf.js falls back to its non-eval paths), worker/img allowances for the bundled pdf.js worker and rendered canvases, and `connect-src` deliberately open because the BYO-AI base URL and the capture endpoint are user-configured seams (self-hosters who pin those can tighten it). Plus nosniff, frame denial, referrer and permissions policies.

**Zip-ingest bounds** (ingest.js): caps that sit far above any legitimate plan set while stopping a hostile archive from exhausting the tab — 500-entry cap and 1.5 GB decompressed cap shared across one drop (nested zips draw from the same budget), 512 MB per entry refused **before** decompression off fflate's header sizes, zip-in-zip allowed once but not deeper. Every refusal lands in the skipped list with its reason.

## Verification

Headers exercised against a real build served with these exact values: app boots and renders clean, sample plan ingests and rasters through the pdf.js worker with **zero CSP violations**, and enforcement positively confirmed (an injected inline script is blocked with a `script-src-elem` violation event). Ingest bounds covered by 4 new tests (entry cap, nesting depth, shared budget across sibling zips, junk filtering). Typecheck + build clean.