### PR TITLE
fix(capture): a wedged synced share can't stall contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-07-13
+
+### Fixed
+- **Capture server: a wedged synced share can't stall contributions.** A stalled sync client can leave a mirror-folder syscall hanging at the kernel — which no `try/except` catches. The `--mirror` copy now runs on an expendable thread with a wall-clock cap (`OPENTAKEOFF_MIRROR_TIMEOUT_S`, default 15s) and a 3-slot strand budget: a hung share strands at most 3 threads, then further mirror attempts skip outright until it recovers; the corpus write and the `/contribute` response are never held hostage. Selftest gains wedged-share checks.
+
 ## 2026-07-12 — v0.3.0
 
 ### Added

--- a/capture/capture_server.py
+++ b/capture/capture_server.py
@@ -38,12 +38,29 @@ import hashlib
 import json
 import os
 import sys
+import threading
 import urllib.request
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 MAX_BODY = 32 * 1024 * 1024  # a contribution is text; anything near this is not one
 CAPTURE_SCHEMA = "opentakeoff.capture.v1"
+
+# A synced share can wedge at the KERNEL level — a stalled sync client can leave
+# open()/stat() on a placeholder file hanging indefinitely, which no try/except
+# catches. So the mirror never runs on the request thread: it runs on an
+# expendable daemon thread with a wall-clock cap, and the semaphore is the
+# strand budget — once this many threads sit wedged, further mirror attempts
+# skip outright (the corpus write itself already succeeded). A stranded thread
+# frees its slot on its own if the share recovers.
+_MIRROR_STRANDS = threading.Semaphore(3)
+
+
+def _mirror_timeout() -> float:
+    try:
+        return float(os.environ.get("OPENTAKEOFF_MIRROR_TIMEOUT_S", "") or 15.0)
+    except ValueError:
+        return 15.0
 
 
 # --- corpus ------------------------------------------------------------------
@@ -150,11 +167,7 @@ class Corpus:
             self._mirror()
         return len(fresh), dup
 
-    def _mirror(self) -> None:
-        """Whole-file atomic copy into the synced share — never live appends
-        into a sync folder. Best-effort: the mirror must never fail a capture."""
-        if not self.mirror:
-            return
+    def _mirror_now(self) -> None:
         try:
             os.makedirs(self.mirror, exist_ok=True)
             dst = os.path.join(self.mirror, "takeoff_labels.jsonl")
@@ -169,6 +182,29 @@ class Corpus:
             os.replace(mtmp, meta)
         except OSError as e:
             print(f"  mirror skipped: {e}", flush=True)
+
+    def _mirror(self) -> None:
+        """Whole-file atomic copy into the synced share — never live appends
+        into a sync folder. Best-effort: the mirror must never fail a capture,
+        nor stall it — a share that hangs at the kernel strands an expendable
+        thread (capped at OPENTAKEOFF_MIRROR_TIMEOUT_S), never the request."""
+        if not self.mirror:
+            return
+        if not _MIRROR_STRANDS.acquire(blocking=False):
+            print("  mirror skipped: share unresponsive (strand budget exhausted)", flush=True)
+            return
+
+        def work():
+            try:
+                self._mirror_now()
+            finally:
+                _MIRROR_STRANDS.release()
+
+        t = threading.Thread(target=work, daemon=True, name="capture-mirror")
+        t.start()
+        t.join(_mirror_timeout())
+        if t.is_alive():
+            print(f"  mirror abandoned: share unresponsive after {_mirror_timeout():.1f}s", flush=True)
 
     def summary(self) -> dict:
         rows = contributions = 0
@@ -323,6 +359,22 @@ def selftest() -> int:
     mirrored = os.path.join(corpus.mirror, "takeoff_labels.jsonl")
     with open(mirrored) as fh:
         check("mirror is a whole consistent copy", sum(1 for l in fh if l.strip()), 3)
+
+    # a wedged share (sync client stalled mid-syscall) may cost a contribution
+    # at most the mirror timeout — the corpus row still banks, the POST returns
+    import time
+    gate = threading.Event()
+    corpus._mirror_now = gate.wait  # stands in for a share that never answers
+    os.environ["OPENTAKEOFF_MIRROR_TIMEOUT_S"] = "0.2"
+    try:
+        wedged = json.loads(json.dumps(sample))
+        wedged["shapes"][1]["finish"] = wedged["conditions"][1]["finish"] = "VCT-1"
+        t0 = time.monotonic()
+        check("wedged share still banks the row", post(wedged)["rows_added"], 1)
+        check("wedged share can't hang the POST", time.monotonic() - t0 < 5, True)
+    finally:
+        del os.environ["OPENTAKEOFF_MIRROR_TIMEOUT_S"]
+        gate.set()  # unwedge; the stranded thread frees its strand slot
 
     httpd.shutdown()
     shutil.rmtree(tmp, ignore_errors=True)


### PR DESCRIPTION
## Problem

The capture server's `--mirror` folder is meant to live in a synced share. A stalled sync client can leave a filesystem syscall there hanging **at the kernel** — an `open()` on a placeholder file that never returns — which no `try/except` catches (the existing `OSError` handler never fires because nothing raises). Every `/contribute` POST then hangs its request thread on the mirror copy, and `ThreadingHTTPServer` happily strands one thread per contribution, unbounded, while the requester waits forever.

(Found while fixing the same failure mode in a downstream deployment, where the equivalent call sat on an async event loop and froze the whole app for hours.)

## Fix

- The mirror copy runs on an **expendable daemon thread** with a wall-clock cap: `OPENTAKEOFF_MIRROR_TIMEOUT_S`, default 15s. A wedge strands that thread, never the request — the corpus row has already banked and the POST responds normally.
- A **3-slot strand budget** (semaphore): once 3 threads sit wedged, further mirror attempts skip outright with a log line instead of piling up threads. Slots free themselves if the share recovers.
- Healthy-share behavior is unchanged and synchronous — the mirror copy is complete before `ingest()` returns.

## Tests

Selftest gains two wedged-share checks (row still banks; POST returns within the cap): `python3 capture/capture_server.py selftest` → PASS.