### PR TITLE
Add opt-in MCP tool call tracing

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -57,6 +57,16 @@ see `src/hush.ts`.)
 `tsx` is a runtime dependency, not a build tool: the engine is imported
 straight from `web/src/lib` as TypeScript, so plain `node` can't run it.
 
+For tool-call debugging, opt into structured stderr tracing:
+
+```bash
+OPENTAKEOFF_MCP_TRACE=1 node --import tsx server.ts
+```
+
+Each tool call writes one JSON line to stderr with the tool name, duration,
+sheet, result size, and error flag. The trace never writes to stdout and never
+includes document text, shape vertices, or result payload content.
+
 ## Tools
 
 | Tool | What it does |

--- a/mcp/bin.js
+++ b/mcp/bin.js
@@ -5,14 +5,6 @@
 // module that defers the server (and its hoisted externals) behind a dynamic
 // import. Same belt as src/hush.ts, one module earlier.
 console.log = console.error.bind(console);
-const tracingEnabled = process.env.OPENTAKEOFF_MCP_TRACE === '1';
-if (tracingEnabled) {
-  const originalConsoleError = console.error;
-  console.error = (...args) => {
-    const toolCallLog = args.map(arg => JSON.stringify(arg)).join(' ');
-    originalConsoleError(`TOOL_CALL ${toolCallLog}`);
-  };
-}
 // pdf.js 4.x needs Promise.withResolvers (Node 22+); polyfill here so the
 // engines floor stays Node 20 — must exist before pdfjs-dist evaluates.
 if (typeof Promise.withResolvers !== "function") {

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ok, fail, UserError, type ToolReply } from "./format.ts";
 import type { Session } from "./session.ts";
+import { traceToolCall } from "./trace.ts";
 
 // The coordinate contract, stated on every tool so any agent reading any one
 // description knows the space it is working in.
@@ -13,25 +14,29 @@ const COORDS = "Coordinates are image px at render scale 2.0: PDF pt × 2, origi
 const pointSchema = z.tuple([z.number(), z.number()]);
 const roleSchema = z.enum(["floor_area", "deduct"]).default("floor_area");
 
-const run = (fn: (args: any) => unknown | Promise<unknown>) =>
+const run = (tool: string, fn: (args: any) => unknown | Promise<unknown>) =>
   async (args: any): Promise<ToolReply> => {
+    const startedAt = process.hrtime.bigint();
+    let reply: ToolReply;
     try {
-      return ok(await fn(args));
+      reply = ok(await fn(args));
     } catch (e) {
-      return fail(e);
+      reply = fail(e);
     }
+    traceToolCall(tool, args, startedAt, reply);
+    return reply;
   };
 
 export function registerTools(server: McpServer, session: Session): void {
   server.registerTool("load_plan", {
     description: `Open a plan PDF from disk and replace the whole session (previous document, scales, conditions, and shapes are cleared). Returns file, page_count, and one entry per sheet: dims, title-block sheet_number, and the detected drawn scale where present. ${COORDS}`,
     inputSchema: { path: z.string().describe("Path to a plan PDF on disk") },
-  }, run(({ path }) => session.loadPlan(path)));
+  }, run("load_plan", ({ path }) => session.loadPlan(path)));
 
   server.registerTool("sheet_info", {
     description: `Sheet detail: dims (px and pt), vector segment count, whether the sheet has vector linework (one_click needs it), scale status, the detected scale suggestion, and this sheet's committed shape count. ${COORDS}`,
     inputSchema: { sheet: z.string().describe('Sheet key ("plan.pdf", "plan.pdf#2") or title-block number ("A-101")') },
-  }, run(({ sheet }) => session.sheetInfo(sheet)));
+  }, run("sheet_info", ({ sheet }) => session.sheetInfo(sheet)));
 
   server.registerTool("set_scale", {
     description: `Set a sheet's scale — exactly ONE of: label (a standard scale, e.g. '1/4" = 1'-0"'), upp (real feet per image px), calibrate (two points along a known dimension plus its real feet), or use_detected (adopt the drawn scale note read off the sheet). The detected scale is never applied automatically — setting it is always this explicit call. ${COORDS}`,
@@ -43,7 +48,7 @@ export function registerTools(server: McpServer, session: Session): void {
         .describe("Two points (image px) a known real distance apart, and that distance in feet"),
       use_detected: z.boolean().optional().describe("true = adopt the sheet's detected scale"),
     },
-  }, run((a) => {
+  }, run("set_scale", (a) => {
     const given = [a.label !== undefined, a.upp !== undefined, a.calibrate !== undefined, a.use_detected !== undefined].filter(Boolean).length;
     if (given !== 1) throw new UserError("Provide exactly one of: label, upp, calibrate, use_detected.");
     return session.setScale(a.sheet, a);
@@ -59,7 +64,7 @@ export function registerTools(server: McpServer, session: Session): void {
       role: roleSchema,
       return_verts: z.boolean().default(false).describe("Include the traced polygon's vertices (image px)"),
     },
-  }, run((a) => session.oneClick(a.sheet, a.x, a.y, { condition: a.condition, role: a.role, returnVerts: a.return_verts })));
+  }, run("one_click", (a) => session.oneClick(a.sheet, a.x, a.y, { condition: a.condition, role: a.role, returnVerts: a.return_verts })));
 
   server.registerTool("measure_polygon", {
     description: `Measure a closed polygon you supply (min 3 vertices, image px): area_sf and perimeter_lf at the sheet's scale. Requires the scale to be set. Pass condition to commit it; role "deduct" subtracts. ${COORDS}`,
@@ -69,7 +74,7 @@ export function registerTools(server: McpServer, session: Session): void {
       condition: z.string().optional(),
       role: roleSchema,
     },
-  }, run((a) => session.measurePolygon(a.sheet, a.verts, { condition: a.condition, role: a.role })));
+  }, run("measure_polygon", (a) => session.measurePolygon(a.sheet, a.verts, { condition: a.condition, role: a.role })));
 
   server.registerTool("measure_line", {
     description: `Measure an open polyline (min 2 points, image px): length_lf at the sheet's scale. Requires the scale to be set. Pass condition to commit it as a linear shape (base, transitions, feature strips). ${COORDS}`,
@@ -78,17 +83,17 @@ export function registerTools(server: McpServer, session: Session): void {
       pts: z.array(pointSchema).min(2),
       condition: z.string().optional(),
     },
-  }, run((a) => session.measureLine(a.sheet, a.pts, { condition: a.condition })));
+  }, run("measure_line", (a) => session.measureLine(a.sheet, a.pts, { condition: a.condition })));
 
   server.registerTool("takeoff_summary", {
     description: `Per-condition totals (floor/wall/border SF, LF, EA, SY, with and without waste) plus grand totals — the Report's numbers, computed by the same rules. ${COORDS}`,
     inputSchema: {},
-  }, run(() => session.summary()));
+  }, run("takeoff_summary", () => session.summary()));
 
   server.registerTool("export_takeoff", {
     description: `The full "opentakeoff.takeoff_canvas.v1" annotations payload — exactly what the app autosaves, importable by it. Returned inline; pass path to also write it to disk as JSON. ${COORDS}`,
     inputSchema: { path: z.string().optional().describe("File path to write the payload to") },
-  }, run(async ({ path: outPath }) => {
+  }, run("export_takeoff", async ({ path: outPath }) => {
     const payload = session.exportPayload();
     if (outPath) {
       const { writeFile } = await import("node:fs/promises");
@@ -100,7 +105,7 @@ export function registerTools(server: McpServer, session: Session): void {
   server.registerTool("delete_shape", {
     description: `Remove a committed shape by the id returned when it was committed. ${COORDS}`,
     inputSchema: { shape_id: z.string() },
-  }, run(({ shape_id }) => session.deleteShape(shape_id)));
+  }, run("delete_shape", ({ shape_id }) => session.deleteShape(shape_id)));
 
   server.registerTool("read_sheet_text", {
     description: `The sheet's text with positions — items [{str, x, y}] in image px plus the joined text. Optionally restrict to a region {x0, y0, x1, y1}. Use it to read title blocks, room labels, finish schedules, and scale notes. ${COORDS}`,
@@ -108,5 +113,5 @@ export function registerTools(server: McpServer, session: Session): void {
       sheet: z.string(),
       region: z.object({ x0: z.number(), y0: z.number(), x1: z.number(), y1: z.number() }).optional(),
     },
-  }, run((a) => session.readSheetText(a.sheet, a.region)));
+  }, run("read_sheet_text", (a) => session.readSheetText(a.sheet, a.region)));
 }

--- a/mcp/src/trace.ts
+++ b/mcp/src/trace.ts
@@ -1,0 +1,25 @@
+import type { ToolReply } from "./format.ts";
+
+const TRACE_ENV = "OPENTAKEOFF_MCP_TRACE";
+
+export function traceToolCall(tool: string, args: unknown, startedAt: bigint, reply: ToolReply): void {
+  if (process.env[TRACE_ENV] !== "1") return;
+
+  const text = reply.content[0]?.text ?? "";
+  const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+  const sheet =
+    args && typeof args === "object" && "sheet" in args
+      ? (args as { sheet?: unknown }).sheet
+      : undefined;
+
+  const event = {
+    event: "opentakeoff_mcp_tool_call",
+    tool,
+    duration_ms: Math.round(durationMs * 100) / 100,
+    sheet: typeof sheet === "string" ? sheet : null,
+    result_size: text.length,
+    is_error: reply.isError === true,
+  };
+
+  process.stderr.write(`${JSON.stringify(event)}\n`);
+}

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -28,6 +28,21 @@ async function call(client: Client, name: string, args: Record<string, unknown> 
   return { isError: !!res.isError, data: JSON.parse(res.content[0].text) };
 }
 
+async function captureStderr(fn: () => Promise<void>): Promise<string> {
+  const originalWrite = process.stderr.write;
+  let output = "";
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    output += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  return output;
+}
+
 test("tools/list: all ten tools, each described with the coordinate contract", async () => {
   const client = await pair();
   const { tools } = await client.listTools();
@@ -88,6 +103,40 @@ test("set_scale: zero or several modes are rejected; one mode works", async () =
   const badLabel = await call(client, "set_scale", { sheet: KEY, label: "3/7\" = 1'-0\"" });
   assert.equal(badLabel.isError, true);
   assert.match(badLabel.data.error, /Unknown scale label/);
+});
+
+test("tool tracing: opt-in structured metadata goes to stderr without result content", async () => {
+  const client = await pair();
+  const originalTrace = process.env.OPENTAKEOFF_MCP_TRACE;
+  try {
+    delete process.env.OPENTAKEOFF_MCP_TRACE;
+    const quiet = await captureStderr(async () => {
+      await call(client, "takeoff_summary");
+    });
+    assert.equal(quiet, "");
+
+    process.env.OPENTAKEOFF_MCP_TRACE = "1";
+    const traced = await captureStderr(async () => {
+      await call(client, "measure_polygon", { sheet: KEY, verts: [[0, 0], [100, 0], [100, 100]] });
+    });
+
+    const lines = traced.trim().split("\n");
+    assert.equal(lines.length, 1);
+    const event = JSON.parse(lines[0]);
+    assert.equal(event.event, "opentakeoff_mcp_tool_call");
+    assert.equal(event.tool, "measure_polygon");
+    assert.equal(event.sheet, KEY);
+    assert.equal(event.is_error, true);
+    assert.equal(typeof event.duration_ms, "number");
+    assert.ok(event.duration_ms >= 0);
+    assert.equal(typeof event.result_size, "number");
+    assert.ok(event.result_size > 0);
+    assert.doesNotMatch(traced, /Set the scale/);
+    assert.doesNotMatch(traced, /verts/);
+  } finally {
+    if (originalTrace === undefined) delete process.env.OPENTAKEOFF_MCP_TRACE;
+    else process.env.OPENTAKEOFF_MCP_TRACE = originalTrace;
+  }
 });
 
 test("delete_shape: removes a committed shape; unknown id is isError", async () => {


### PR DESCRIPTION
## Summary
- add opt-in `OPENTAKEOFF_MCP_TRACE=1` tracing for MCP tool calls
- emit one structured JSON line per tool call to stderr with tool, duration, sheet, result size, and error flag
- avoid tracing document text, shape vertices, or result payload content
- document the trace flag in the MCP README

Fixes #28.

## Testing
- `cd web && npm install`
- `cd mcp && npm install`
- `cd mcp && npm run typecheck`
- `cd mcp && npm test`
- Equivalent Windows build steps for `mcp`: `esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js`, then copy `bin.js` to `dist/server.js`

Note: `npm run build` reaches the esbuild bundle step on Windows, then fails because the package script uses Unix `cp` and `chmod`. The equivalent bundle/copy path was verified locally.