### PR TITLE
fix(mcp): build on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 - **Snapshots modal retired — Revisions is the single surface over saved takeoffs.** The toolbar Snapshots modal and the Revisions rail panel (clock icon) listed the exact same records — both ride the store's `saveSnapshot`/`listSnapshots`/`getSnapshot`/`deleteSnapshot` primitives, so the Drive snapshot-sync layer is untouched. Revisions is a strict superset (compare any two, per-sheet and buy-list deltas, compare CSV, auto-banked restore), so the modal's toolbar button and component are removed; save / compare / restore / delete all live in the Revisions panel.
 
 ### Fixed
+- **MCP package builds on Windows.** The build now uses a small Node script to copy the executable wrapper instead of Unix-only `cp` and `chmod` commands.
 - **Capture server: a wedged synced share can't stall contributions.** A stalled sync client can leave a mirror-folder syscall hanging at the kernel — which no `try/except` catches. The `--mirror` copy now runs on an expendable thread with a wall-clock cap (`OPENTAKEOFF_MIRROR_TIMEOUT_S`, default 15s) and a 3-slot strand budget: a hung share strands at most 3 threads, then further mirror attempts skip outright until it recovers; the corpus write and the `/contribute` response are never held hostage. Selftest gains wedged-share checks.
 
 ## 2026-07-12 — v0.3.0

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "node --import tsx server.ts",
     "start": "node dist/server.js",
-    "build": "esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js && cp bin.js dist/server.js && chmod +x dist/server.js",
+    "build": "esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js && node scripts/finish-build.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test test/*.test.ts"

--- a/mcp/scripts/finish-build.mjs
+++ b/mcp/scripts/finish-build.mjs
@@ -1,0 +1,14 @@
+import { chmodSync, copyFileSync, mkdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageDir = resolve(scriptDir, '..')
+const output = resolve(packageDir, 'dist', 'server.js')
+
+mkdirSync(dirname(output), { recursive: true })
+copyFileSync(resolve(packageDir, 'bin.js'), output)
+
+if (process.platform !== 'win32') {
+  chmodSync(output, 0o755)
+}


### PR DESCRIPTION
## Summary

- Replaces the Unix-only cp and chmod commands in the MCP build with a Node script.
- Preserves executable permissions on POSIX while allowing source builds to complete on Windows.
- Records the Windows build fix in the changelog.

Fixes #34

## Validation

- cd mcp && npm run typecheck
- cd mcp && npm test (20 passing tests)
- cd mcp && npm run build on Windows (reproduced the original cp failure, then verified the build succeeds)
- cd web && npm run typecheck, 
pm run lint, and 
pm run build`n
web/npm run check reaches its test phase but has two pre-existing Windows line-ending (CRLF/LF) golden-file failures. This PR does not modify web source or tests.