### PR TITLE
fix(mcp): use cross-platform script for dist/server.js build step

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "node --import tsx server.ts",
     "start": "node dist/server.js",
-    "build": "esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js && cp bin.js dist/server.js && chmod +x dist/server.js",
+    "build": "esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js && node scripts/finish-build.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test test/*.test.ts"

--- a/mcp/scripts/finish-build.mjs
+++ b/mcp/scripts/finish-build.mjs
@@ -1,0 +1,20 @@
+// Finishes the build after esbuild has produced dist/server-core.js:
+// copies bin.js to dist/server.js as the actual npm "bin" entry point, and
+// marks it executable so `npx opentakeoff-mcp` works on Unix.
+//
+// This replaces a shell tail of `cp bin.js dist/server.js && chmod +x
+// dist/server.js`, which fails on Windows (`cp`/`chmod` aren't shell
+// builtins there). fs.copyFileSync/fs.chmodSync are cross-platform: chmod
+// on Windows is a harmless no-op (Windows doesn't use POSIX permission
+// bits), so this script behaves identically to the old one on Unix while
+// no longer breaking `npm run build` on Windows.
+
+import { chmodSync, copyFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const mcpDir = fileURLToPath(new URL("..", import.meta.url));
+const src = `${mcpDir}bin.js`;
+const dest = `${mcpDir}dist/server.js`;
+
+copyFileSync(src, dest);
+chmodSync(dest, 0o755);


### PR DESCRIPTION
Fixes #34

## fix(mcp): use cross-platform script for dist/server.js build step

### Problem
`mcp/package.json`'s build script ends with a Unix shell tail:
`cp bin.js dist/server.js && chmod +x dist/server.js`

`cp` and `chmod` aren't available in Windows' default shell, so `npm run build` fails for anyone building the MCP server from source on Windows. Published `npx` users are unaffected since they get the prebuilt `dist`.

### Fix
Added `mcp/scripts/finish-build.mjs`, a small Node script using `fs.copyFileSync` + `fs.chmodSync` instead of shell commands:

    import { chmodSync, copyFileSync } from "node:fs";
    import { fileURLToPath } from "node:url";

    const mcpDir = fileURLToPath(new URL("..", import.meta.url));
    const src = `${mcpDir}bin.js`;
    const dest = `${mcpDir}dist/server.js`;

    copyFileSync(src, dest);
    chmodSync(dest, 0o755);

Both are core Node APIs with well-defined cross-platform behavior — `chmodSync` on Windows applies the write-permission bit and is a documented no-op otherwise, so it never throws there. `package.json`'s build script now just calls `node scripts/finish-build.mjs` after the esbuild step, no shell-specific syntax involved.

### Testing
- `npm run typecheck` — clean
- `npm test` — 20/20 passing
- `npm run build` — succeeds; `dist/server.js` comes out `rwxr-xr-x`, byte-identical to `bin.js`
- Ran the built server directly (`node dist/server.js`) — starts cleanly

### Files changed
- `mcp/scripts/finish-build.mjs` (new)
- `mcp/package.json`