### PR TITLE
fix(mcp): make build finish cross-platform

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "node --import tsx server.ts",
     "start": "node dist/server.js",
-    "build": "esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js && cp bin.js dist/server.js && chmod +x dist/server.js",
+    "build": "esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js && node scripts/finish-build.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test test/*.test.ts"

--- a/mcp/scripts/finish-build.mjs
+++ b/mcp/scripts/finish-build.mjs
@@ -1,0 +1,11 @@
+import { chmodSync, copyFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const source = resolve(root, "bin.js");
+const target = resolve(root, "dist", "server.js");
+
+mkdirSync(dirname(target), { recursive: true });
+copyFileSync(source, target);
+chmodSync(target, 0o755);


### PR DESCRIPTION
## Summary
- replace the Unix-only `cp`/`chmod` build tail with a Node finishing script
- copy `bin.js` to `dist/server.js` using `fs.copyFileSync`
- preserve executable permissions with `fs.chmodSync` for Unix installs

Closes #34

## Validation
From `mcp/` on Windows:
- `npm run build`
- `npm run typecheck`
- `npm test`