### PR TITLE
docs: contributor ladder — good first issues + the #29 flagship challenge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,14 @@
 Thanks for helping build a free takeoff tool for flooring contractors. PRs,
 issues, and ideas are all welcome.
 
+## Where to start
+
+- [`good first issue`](https://github.com/Kentucky-ai/opentakeoff/labels/good%20first%20issue)
+  — small, fully specified, exact files named. Claim one in a comment.
+- [The flagship challenge](https://github.com/Kentucky-ai/opentakeoff/issues/29)
+  — an open design-and-build bake-off. Post a design comment first; multiple
+  entries welcome; the best one merges with credit.
+
 ## Dev setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ OpenTakeoff is **Apache-2.0**: fork it, change it, ship it — for your own crew
 
 Run `npm run typecheck && npm test && npm run build` before a PR; keep the geometry libs pure and tested; never commit real plans. See [CONTRIBUTING.md](CONTRIBUTING.md) and the [user guide](docs/USER_GUIDE.md).
 
+## Contributing — there's a ladder
+
+Every open issue is a real need, not a manufactured chore, and there's a rung for wherever you're starting from:
+
+- **First PR:** issues labeled [`good first issue`](https://github.com/Kentucky-ai/opentakeoff/labels/good%20first%20issue) are small, fully specified, and point at the exact files. Claim one in a comment and go.
+- **The flagship:** [#29 — expose plan sheets as MCP resources](https://github.com/Kentucky-ai/opentakeoff/issues/29) is an open design-and-build challenge. Multiple entries welcome; the best one merges with credit in the release notes, and it ships to every client that pulls [`opentakeoff-mcp`](https://www.npmjs.com/package/opentakeoff-mcp) off npm.
+
+Ground rules live in [CONTRIBUTING.md](CONTRIBUTING.md). Tested PRs with green CI merge fast — the last three external PRs did.
+
 ## Tech stack
 
 - **Frontend:** React 18 + Vite, plain JSX


### PR DESCRIPTION
Adds a **Contributing — there's a ladder** section to the README and a **Where to start** block to CONTRIBUTING.md, pointing newcomers at the `good first issue` rung and the pinned #29 flagship (MCP resources design-and-build challenge).

Docs only — no app code touched.