### PR TITLE
Add OIDC release workflow for the MCP registry

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,75 @@
+name: Publish to MCP Registry
+
+# Registry-only release automation. The npm artifact is published manually
+# (hardware-key 2FA) BEFORE the tag is pushed — this workflow refuses to run
+# ahead of it. workflow_dispatch exercises OIDC login without publishing.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  id-token: write # OIDC token for mcp-publisher login github-oidc
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check version consistency
+        run: |
+          PKG=$(jq -r .version package.json)
+          SRV=$(jq -r .version server.json)
+          SRVPKG=$(jq -r '.packages[0].version' server.json)
+          echo "package.json=$PKG server.json=$SRV server.json packages[0]=$SRVPKG"
+          if [ "$PKG" != "$SRV" ] || [ "$PKG" != "$SRVPKG" ]; then
+            echo "::error::version fields disagree — bump package.json and server.json together"
+            exit 1
+          fi
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME#v}"
+            if [ "$PKG" != "$TAG" ]; then
+              echo "::error::tag v$TAG does not match package version $PKG"
+              exit 1
+            fi
+          fi
+
+      - name: Require the npm artifact to exist
+        if: github.ref_type == 'tag'
+        run: |
+          VERSION=$(jq -r .version package.json)
+          if ! npm view "opentakeoff-mcp@${VERSION}" version; then
+            echo "::error::opentakeoff-mcp@${VERSION} is not on npm — npm publish (hardware key) comes before the tag push"
+            exit 1
+          fi
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        if: github.ref_type == 'tag'
+        run: ./mcp-publisher publish
+
+      - name: Verify the registry lists this version
+        if: github.ref_type == 'tag'
+        run: |
+          VERSION=$(jq -r .version package.json)
+          curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=opentakeoff" -o /tmp/registry.json
+          if ! jq -e --arg v "$VERSION" \
+            '[.servers[]? | (.server // .) | select(.name == "io.github.Kentucky-ai/opentakeoff" and .version == $v)] | length > 0' \
+            /tmp/registry.json > /dev/null; then
+            echo "::error::registry does not list io.github.Kentucky-ai/opentakeoff@${VERSION}"
+            cat /tmp/registry.json
+            exit 1
+          fi
+          echo "Registry lists io.github.Kentucky-ai/opentakeoff@${VERSION}"


### PR DESCRIPTION
Automates the registry half of a release. On a \`v*\` tag push:

1. Version-consistency gate — tag, \`mcp/package.json\`, and both \`mcp/server.json\` version fields must agree (the mismatch class that cost us the 0.1.3 release).
2. Requires \`opentakeoff-mcp@<version>\` to already exist on npm — npm publish stays a manual, security-key ceremony and must happen before the tag push.
3. \`mcp-publisher login github-oidc\` + \`publish\` — no stored secrets, no OAuth windows; the short-lived OIDC token proves the job runs in Kentucky-ai/opentakeoff.
4. Post-publish check that the registry actually lists the new version.

\`workflow_dispatch\` runs steps 1 and 3's login only — a dry run to prove the OIDC path without publishing.

Release ceremony becomes: bump versions → npm publish (key) → push tag.