### PR TITLE
MCP resources: browse plan sheets natively (flagship #29 — maintainer reference entry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased
+
+### Added
+- **MCP resources — browse a plan set before measuring** (flagship issue #29, reference implementation). A loaded plan exposes `takeoff://sheets` (index, sensible when empty), `takeoff://sheet/{page}` (metadata), `takeoff://sheet/{page}/text` (joined text), and `takeoff://sheet/{page}/image` (rendered PNG, long edge capped at 1568 px, lazily rendered and cached). `load_plan` announces the new surface via `resources/list_changed`. Rendering rides pdf.js's own optional `@napi-rs/canvas` — zero new dependencies, graceful degradation where the native binary is absent. Conformance suite in `mcp/test/resources.test.ts`.
+
 ## 2026-07-17
 
 ### Fixed

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -88,6 +88,31 @@ includes document text, shape vertices, or result payload content.
 Every reply is one compact JSON text item. Failures come back as
 `isError: true` with `{"error": "..."}` — never a dropped connection.
 
+## Resources — browse before you measure
+
+Tools let an agent act; resources let it **see**. When a plan loads, the sheet
+set becomes browsable natively (`resources/list` re-announces itself via
+`list_changed`):
+
+| URI | Contents |
+|---|---|
+| `takeoff://sheets` | The plan index — file, page count, every sheet's dims, title-block number, detected scale, scale state, shape count. Always listed; before any plan loads it says so and points at `load_plan`. |
+| `takeoff://sheet/{page}` | One sheet's metadata (JSON), addressed by 1-based page number. |
+| `takeoff://sheet/{page}/text` | The sheet's text, joined — title block, room labels, schedules. Positions live in the `read_sheet_text` tool. |
+| `takeoff://sheet/{page}/image` | The page rendered to PNG, long edge capped at **1568 px** — the native resolution of vision-model eyes. Rendered lazily, cached until the next `load_plan`. |
+
+Page numbers — not file-derived sheet keys — address resources, so URIs stay
+clean regardless of the PDF's name; the human-facing key (`plan.pdf#2`) and
+title-block number (`A-101`) ride along as the resource name and title.
+Rendering uses `@napi-rs/canvas` (pdf.js's own optional dependency): on a
+platform without a prebuilt binary every non-raster capability still works and
+the image read explains exactly what's missing.
+
+The intended agent loop: read `takeoff://sheets` → look at
+`takeoff://sheet/{page}/image` → pick click targets → measure with the tools.
+An image coordinate maps to the tool space (image px at render scale 2.0) by
+multiplying by `width_px / <image pixel width>`.
+
 ## The coordinate contract
 
 All coordinates are **image pixels at render scale 2.0**: PDF points × 2,

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -7,11 +7,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { Session } from "./src/session.ts";
 import { registerTools } from "./src/tools.ts";
+import { registerResources } from "./src/resources.ts";
 import pkg from "./package.json" with { type: "json" };
 
 export function buildServer(session: Session = new Session()): McpServer {
   const server = new McpServer({ name: "opentakeoff", version: pkg.version });
   registerTools(server, session);
+  registerResources(server, session);
   return server;
 }
 

--- a/mcp/src/pdf.ts
+++ b/mcp/src/pdf.ts
@@ -27,6 +27,29 @@ export interface PageHandle {
   viewport: ViewportLike;
   textContent: TextContentLike;
   operatorList(): Promise<OpList>;
+  /** Rasterize the page at the given scale (px per PDF pt) to PNG bytes.
+   * Needs @napi-rs/canvas (pdfjs-dist's own optional dependency); throws a
+   * plain Error naming it when the platform has no prebuilt binary. */
+  renderPng(scale: number): Promise<Uint8Array>;
+}
+
+/** pdf.js's modern build renders against DOM canvas globals that bare Node
+ * lacks; @napi-rs/canvas provides them. Loaded lazily so a platform without
+ * the optional native binary still runs every non-raster tool. */
+async function ensureCanvasGlobals(): Promise<void> {
+  const g = globalThis as Record<string, unknown>;
+  if (g.Path2D && g.DOMMatrix && g.ImageData) return;
+  let napi: typeof import("@napi-rs/canvas");
+  try {
+    napi = await import("@napi-rs/canvas");
+  } catch {
+    throw new Error(
+      "Page rendering needs @napi-rs/canvas (pdfjs-dist's optional dependency), which did not install on this platform. Reinstall with optional dependencies enabled.",
+    );
+  }
+  g.Path2D ??= napi.Path2D;
+  g.DOMMatrix ??= napi.DOMMatrix;
+  g.ImageData ??= napi.ImageData;
 }
 
 export interface DocHandle {
@@ -61,6 +84,20 @@ export async function openPdf(filePath: string): Promise<DocHandle> {
         viewport: { width: vp.width, height: vp.height, transform: vp.transform },
         textContent,
         operatorList: async () => (await page.getOperatorList()) as unknown as OpList,
+        async renderPng(scale: number): Promise<Uint8Array> {
+          await ensureCanvasGlobals();
+          const rvp = page.getViewport({ scale });
+          // canvasFactory is the document's NodeCanvasFactory — present on the
+          // proxy at runtime, absent from pdfjs-dist's public types
+          const factory = (doc as unknown as { canvasFactory: { create(w: number, h: number): { canvas: { toBuffer(mime: "image/png"): Buffer }; context: object }; destroy(target: object): void } }).canvasFactory;
+          const target = factory.create(Math.ceil(rvp.width), Math.ceil(rvp.height));
+          try {
+            await page.render({ canvasContext: target.context as never, viewport: rvp }).promise;
+            return new Uint8Array(target.canvas.toBuffer("image/png"));
+          } finally {
+            factory.destroy(target);
+          }
+        },
       };
     },
     destroy: () => doc.destroy().then(() => undefined),

--- a/mcp/src/resources.ts
+++ b/mcp/src/resources.ts
@@ -1,0 +1,94 @@
+// The resource surface — the "agent eyes" half of AI-native: browse a plan
+// set (index → metadata → text → rendered image) before ever measuring.
+//
+// URI scheme (issue #29):
+//   takeoff://sheets              the plan index — always listed, sensible when empty
+//   takeoff://sheet/{page}        one sheet's metadata (JSON), 1-based page number
+//   takeoff://sheet/{page}/text   the sheet's text, joined (text/plain)
+//   takeoff://sheet/{page}/image  the rendered page (PNG, long edge ≤ IMAGE_MAX_EDGE)
+//
+// Pages — not sheet keys — address resources: page numbers are URI-safe no
+// matter what the PDF is named. The human-facing key ("plan.pdf#2") and
+// title-block number ("A-101") ride along as resource name/title instead.
+import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Session } from "./session.ts";
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("base64");
+}
+
+function parsePage(session: Session, raw: string | string[]) {
+  const s = Array.isArray(raw) ? raw[0] : raw;
+  if (!/^\d+$/.test(s ?? "")) throw new Error(`Sheet resources are addressed by page number — got ${JSON.stringify(s)}.`);
+  return session.sheetForPage(Number(s));
+}
+
+export function registerResources(server: McpServer, session: Session): void {
+  const sheetEntries = (suffix: string, mimeType: string, what: string) => () => ({
+    resources: session.sheetList().map((s) => ({
+      uri: `takeoff://sheet/${s.pageNum}${suffix}`,
+      name: `${s.key}${suffix.replace("/", " · ")}`,
+      ...(s.sheetNumber ? { title: `${s.sheetNumber} — ${what}` } : { title: `page ${s.pageNum} — ${what}` }),
+      description: `${what} for ${s.key}${s.sheetNumber ? ` (${s.sheetNumber})` : ""}`,
+      mimeType,
+    })),
+  });
+
+  server.registerResource(
+    "sheet-index",
+    "takeoff://sheets",
+    {
+      title: "Sheet index",
+      description: "The loaded plan set at a glance: file, page count, and every sheet's dims, title-block number, detected scale, scale state, and shape count. Read this first.",
+      mimeType: "application/json",
+    },
+    async (uri) => ({
+      contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify(session.index()) }],
+    }),
+  );
+
+  server.registerResource(
+    "sheet",
+    new ResourceTemplate("takeoff://sheet/{page}", { list: sheetEntries("", "application/json", "sheet metadata") }),
+    {
+      title: "Sheet metadata",
+      description: "One sheet: dims (px and pt), title-block sheet number, detected scale, scale state, committed shape count. JSON.",
+      mimeType: "application/json",
+    },
+    async (uri, { page }) => {
+      const s = parsePage(session, page);
+      const idx = session.index();
+      const row = idx.sheets.find((x) => x.page === s.pageNum);
+      return { contents: [{ uri: uri.href, mimeType: "application/json", text: JSON.stringify(row) }] };
+    },
+  );
+
+  server.registerResource(
+    "sheet-text",
+    new ResourceTemplate("takeoff://sheet/{page}/text", { list: sheetEntries("/text", "text/plain", "sheet text") }),
+    {
+      title: "Sheet text",
+      description: "The sheet's text content, reading order, joined — title block, room labels, schedules, scale notes. For positions use the read_sheet_text tool.",
+      mimeType: "text/plain",
+    },
+    async (uri, { page }) => {
+      const s = parsePage(session, page);
+      return { contents: [{ uri: uri.href, mimeType: "text/plain", text: session.readSheetText(s.key).text }] };
+    },
+  );
+
+  server.registerResource(
+    "sheet-image",
+    new ResourceTemplate("takeoff://sheet/{page}/image", { list: sheetEntries("/image", "image/png", "rendered page") }),
+    {
+      title: "Rendered page",
+      description: "The page rendered to PNG, long edge capped at 1568 px — sized for vision-model eyes. Coordinates in the image scale linearly to the tool coordinate space (image px at render scale 2.0).",
+      mimeType: "image/png",
+    },
+    async (uri, { page }) => {
+      const s = parsePage(session, page);
+      const png = await session.renderSheetPng(s.pageNum);
+      return { contents: [{ uri: uri.href, mimeType: "image/png", blob: toBase64(png) }] };
+    },
+  );
+}

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -7,7 +7,7 @@
 import path from "node:path";
 import { openPdf, positionedText, OPS, type DocHandle, type PageHandle } from "./pdf.ts";
 import { UserError, round1, round2 } from "./format.ts";
-import { STANDARD_SCALES, detectScale, extractSheetNumber, type DetectedScale } from "../../web/src/lib/sheets.ts";
+import { STANDARD_SCALES, RENDER_SCALE, detectScale, extractSheetNumber, type DetectedScale } from "../../web/src/lib/sheets.ts";
 import {
   extractVectorGeometry, buildMask, floodRegion, traceRegion, snapVertices, ringArea,
   MASK_MAX_DIM, type MaskObj, type VectorGeometry, type Point,
@@ -68,7 +68,14 @@ interface SheetState {
   snap?: ReturnType<typeof buildSnapGrid>;
   /** undefined = not built yet; null = sheet has zero vector segments (a scan) */
   mask?: MaskObj | null;
+  /** rendered-page PNG at IMAGE_MAX_EDGE, built on first resource read */
+  png?: Uint8Array;
 }
+
+/** Resource images cap their long edge here: the largest edge the mainstream
+ * vision models take without downscaling — these renders exist to be looked at
+ * by agents, so this is the native resolution of that audience. */
+export const IMAGE_MAX_EDGE = 1568;
 
 export interface SheetSummary {
   sheet: string;
@@ -147,6 +154,45 @@ export class Session {
     const wanted = name.toUpperCase().replace(/\s+/g, "");
     for (const s of this.sheets.values()) if (s.sheetNumber === wanted) return s;
     throw new UserError(`Unknown sheet "${name}" — loaded sheets: ${[...this.sheets.keys()].join(", ")}.`);
+  }
+
+  /** Resource-URI addressing: sheets by 1-based page number. */
+  sheetForPage(page: number): SheetState {
+    if (!this.doc) throw new UserError("No plan loaded — call load_plan first.");
+    for (const s of this.sheets.values()) if (s.pageNum === page) return s;
+    throw new UserError(`No page ${page} — the loaded plan has pages 1–${this.sheets.size}.`);
+  }
+
+  /** Every loaded sheet, in page order — [] before any plan loads. */
+  sheetList(): SheetState[] {
+    return [...this.sheets.values()].sort((a, b) => a.pageNum - b.pageNum);
+  }
+
+  /** The takeoff://sheets index payload — cheap (no geometry is built). */
+  index() {
+    if (!this.doc) {
+      return { file: null, page_count: 0, sheets: [], hint: "No plan loaded — call the load_plan tool with a PDF path, then list resources again." };
+    }
+    return {
+      file: this.file,
+      page_count: this.sheets.size,
+      sheets: this.sheetList().map((s) => ({
+        ...sheetSummary(s),
+        scale_set: s.upp != null,
+        shape_count: this.shapes.filter((x) => x.sheet_id === s.key).length,
+      })),
+    };
+  }
+
+  /** Rendered-page PNG, long edge capped at IMAGE_MAX_EDGE (never above the
+   * canvas-native RENDER_SCALE), cached per sheet until the next load_plan. */
+  async renderSheetPng(page: number): Promise<Uint8Array> {
+    const s = this.sheetForPage(page);
+    if (!s.png) {
+      const scale = Math.min(RENDER_SCALE, IMAGE_MAX_EDGE / Math.max(s.widthPt, s.heightPt));
+      s.png = await s.page.renderPng(scale);
+    }
+    return s.png;
   }
 
   private async ensureGeometry(s: SheetState): Promise<VectorGeometry> {

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -29,9 +29,13 @@ const run = (tool: string, fn: (args: any) => unknown | Promise<unknown>) =>
 
 export function registerTools(server: McpServer, session: Session): void {
   server.registerTool("load_plan", {
-    description: `Open a plan PDF from disk and replace the whole session (previous document, scales, conditions, and shapes are cleared). Returns file, page_count, and one entry per sheet: dims, title-block sheet_number, and the detected drawn scale where present. ${COORDS}`,
+    description: `Open a plan PDF from disk and replace the whole session (previous document, scales, conditions, and shapes are cleared). Returns file, page_count, and one entry per sheet: dims, title-block sheet_number, and the detected drawn scale where present. The loaded sheets also become browsable resources (takeoff://sheets). ${COORDS}`,
     inputSchema: { path: z.string().describe("Path to a plan PDF on disk") },
-  }, run("load_plan", ({ path }) => session.loadPlan(path)));
+  }, run("load_plan", async ({ path }) => {
+    const loaded = await session.loadPlan(path);
+    server.sendResourceListChanged(); // the resource surface just changed under every subscriber
+    return loaded;
+  }));
 
   server.registerTool("sheet_info", {
     description: `Sheet detail: dims (px and pt), vector segment count, whether the sheet has vector linework (one_click needs it), scale status, the detected scale suggestion, and this sheet's committed shape count. ${COORDS}`,

--- a/mcp/test/resources.test.ts
+++ b/mcp/test/resources.test.ts
@@ -1,0 +1,100 @@
+// Conformance tests for the resource surface (issue #29): list/read behavior
+// empty and loaded, list_changed on load_plan, PNG integrity, and clean errors
+// on bad URIs — all over the real wire (in-memory transport, real client).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ResourceListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import { buildServer } from "../server.ts";
+import { Session } from "../src/session.ts";
+
+const PLAN = fileURLToPath(new URL("../../demo/sample-plan.pdf", import.meta.url));
+const KEY = "sample-plan.pdf";
+
+async function connect() {
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  await buildServer(new Session()).connect(st);
+  const client = new Client({ name: "resources-test", version: "0.0.0" });
+  await client.connect(ct);
+  return client;
+}
+
+test("empty session: index lists alone and reads sensibly", async () => {
+  const client = await connect();
+
+  const { resources } = await client.listResources();
+  assert.deepEqual(resources.map((r) => r.uri), ["takeoff://sheets"], "no plan → only the index is listed");
+
+  const read: any = await client.readResource({ uri: "takeoff://sheets" });
+  const index = JSON.parse(read.contents[0].text);
+  assert.equal(index.file, null);
+  assert.deepEqual(index.sheets, []);
+  assert.match(index.hint, /load_plan/);
+
+  await assert.rejects(client.readResource({ uri: "takeoff://sheet/1" }), /No plan loaded/, "sheet read before load names the fix");
+});
+
+test("loaded session: list_changed fires, sheets browse as index → metadata → text → image", async () => {
+  const client = await connect();
+
+  let listChanged = 0;
+  client.setNotificationHandler(ResourceListChangedNotificationSchema, () => { listChanged++; });
+
+  const res: any = await client.callTool({ name: "load_plan", arguments: { path: PLAN } });
+  assert.ok(!res.isError, "load_plan succeeded");
+  assert.equal(listChanged, 1, "load_plan announced the new resource surface");
+
+  const { resources } = await client.listResources();
+  assert.deepEqual(
+    resources.map((r) => r.uri).sort(),
+    ["takeoff://sheet/1", "takeoff://sheet/1/image", "takeoff://sheet/1/text", "takeoff://sheets"],
+    "index + metadata/text/image per sheet",
+  );
+  const meta = resources.find((r) => r.uri === "takeoff://sheet/1")!;
+  assert.match(meta.title ?? "", /A-101/, "title-block number surfaces in the listing");
+
+  const index = JSON.parse(((await client.readResource({ uri: "takeoff://sheets" })) as any).contents[0].text);
+  assert.equal(index.file, KEY);
+  assert.equal(index.page_count, 1);
+  assert.equal(index.sheets[0].sheet_number, "A-101");
+  assert.equal(index.sheets[0].scale_set, false);
+
+  const sheet = JSON.parse(((await client.readResource({ uri: "takeoff://sheet/1" })) as any).contents[0].text);
+  assert.equal(sheet.sheet, KEY);
+  assert.equal(sheet.page, 1);
+  assert.equal(sheet.detected_scale, '1/4" = 1\'-0"');
+  assert.equal(sheet.shape_count, 0);
+
+  const text: any = await client.readResource({ uri: "takeoff://sheet/1/text" });
+  assert.equal(text.contents[0].mimeType, "text/plain");
+  assert.match(text.contents[0].text, /OFFICE 101/);
+  assert.match(text.contents[0].text, /SCALE/);
+
+  const image: any = await client.readResource({ uri: "takeoff://sheet/1/image" });
+  assert.equal(image.contents[0].mimeType, "image/png");
+  const png = Buffer.from(image.contents[0].blob, "base64");
+  assert.equal(png.subarray(0, 8).toString("hex"), "89504e470d0a1a0a", "a real PNG signature");
+  assert.ok(png.length > 1000, `render is not a stub (${png.length} bytes)`);
+  // long edge ≤ 1568: PNG IHDR carries width/height at fixed offsets 16/20
+  const w = png.readUInt32BE(16), h = png.readUInt32BE(20);
+  assert.ok(Math.max(w, h) <= 1568, `long edge capped (${w}x${h})`);
+
+  // second read serves the cached render — same bytes, no re-rasterize
+  const again: any = await client.readResource({ uri: "takeoff://sheet/1/image" });
+  assert.equal(again.contents[0].blob, image.contents[0].blob);
+});
+
+test("bad URIs fail with named errors, not crashes", async () => {
+  const client = await connect();
+  await client.callTool({ name: "load_plan", arguments: { path: PLAN } });
+
+  await assert.rejects(client.readResource({ uri: "takeoff://sheet/99" }), /No page 99/);
+  await assert.rejects(client.readResource({ uri: "takeoff://sheet/99/image" }), /No page 99/);
+  await assert.rejects(client.readResource({ uri: "takeoff://sheet/abc" }), /page number/);
+
+  // the wire stayed healthy after every rejection
+  const ok: any = await client.readResource({ uri: "takeoff://sheets" });
+  assert.equal(JSON.parse(ok.contents[0].text).page_count, 1);
+});


### PR DESCRIPTION
**Draft on purpose — this is the maintainer's reference entry in the #29 bake-off, posted per its own ground rules (design first, draft PRs welcome). The challenge stays open; competing entries are still invited, and the best entry merges.**

## Design

**URI scheme** — four concepts, page-number addressed:

| URI | Contents |
|---|---|
| `takeoff://sheets` | Plan index (JSON) — always listed; before any plan loads it says so and points at `load_plan` |
| `takeoff://sheet/{page}` | One sheet's metadata (JSON), 1-based page number |
| `takeoff://sheet/{page}/text` | The sheet's text, joined (text/plain) |
| `takeoff://sheet/{page}/image` | Rendered page (PNG) |

Page numbers, not file-derived sheet keys, address resources — URIs stay clean regardless of the PDF's name. The human-facing key (`plan.pdf#2`) and title-block number (`A-101`) ride along as resource name/title, so a client listing reads like a drawing set.

**Image strategy** — one variant: long edge capped at **1568 px**, the largest edge mainstream vision models accept without downscaling. These renders exist to be looked at by agents; that cap is their native resolution. Rendered lazily on first read, cached until the next `load_plan`, never above the canvas-native render scale 2.0. Image coordinates map to the tool space by `width_px / image_width`.

**Zero new dependencies** — rendering rides `@napi-rs/canvas`, which pdf.js already declares as its own optional dependency. The modern build's missing DOM globals (`Path2D`, `DOMMatrix`, `ImageData`) are polyfilled lazily from it at first render. On a platform with no prebuilt binary, every non-raster capability still works and the image read explains exactly what's missing.

**Empty session** — `resources/list` returns just the index; reading it returns `{file: null, sheets: [], hint}`. `load_plan` fires `resources/list_changed`.

## Conformance (`mcp/test/resources.test.ts`)

- Empty-session list/read behavior, and sheet reads before load name the fix
- `list_changed` observed on the client after `load_plan`
- Full browse loop: index → metadata (detected scale surfaces) → text (room labels present) → image (PNG signature, long-edge cap asserted from IHDR, cache identity on second read)
- Bad URIs (`page 99`, non-numeric) fail with named errors and the wire stays healthy after every rejection

`npm run typecheck` + `npm test` green (23/23); built `dist` announces `tools` + `resources` capabilities over real stdio.
