### PR TITLE
Release polish: GitHub releases + registry metadata

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   id-token: write # OIDC token for mcp-publisher login github-oidc
-  contents: read
+  contents: write # tag checkout + GitHub release creation
 
 jobs:
   publish:
@@ -73,3 +73,12 @@ jobs:
             exit 1
           fi
           echo "Registry lists io.github.Kentucky-ai/opentakeoff@${VERSION}"
+
+      - name: Create the GitHub release
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
+            || gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
+                 --title "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Kentucky-ai/opentakeoff",
+  "title": "OpenTakeoff",
   "description": "Construction takeoff for AI agents: load plans, set scale, measure, count, export with provenance.",
+  "websiteUrl": "https://opentakeoff.netlify.app",
   "repository": {
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"


### PR DESCRIPTION
Two small finishers for the release pipeline:

1. **publish-mcp.yml creates the GitHub release** after a successful registry publish — `--generate-notes` from the tag, idempotent (view-or-create), token scoped by the workflow's own permissions block (`contents: write`).
2. **server.json gains `title` and `websiteUrl`** — both valid fields in the 2025-12-11 registry schema; aggregators surface them on the listing.