### PR TITLE
Add MCP dist smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,11 @@ jobs:
       - run: npm run build
 
   mcp:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -45,6 +49,10 @@ jobs:
       - run: npm run typecheck
         working-directory: mcp
       - run: npm test
+        working-directory: mcp
+      - run: npm run build
+        working-directory: mcp
+      - run: npm run smoke:dist
         working-directory: mcp
 
   capture:

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -12,6 +12,7 @@
     "dev": "node --import tsx server.ts",
     "start": "node dist/server.js",
     "build": "esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js && node scripts/finish-build.mjs",
+    "smoke:dist": "node scripts/smoke-dist.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test test/*.test.ts"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -15,7 +15,7 @@
     "smoke:dist": "node scripts/smoke-dist.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test test/*.test.ts"
+    "test": "node --import tsx --test test/e2e.test.ts test/resources.test.ts test/session.test.ts test/tools.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/scripts/smoke-dist.mjs
+++ b/mcp/scripts/smoke-dist.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+
+const child = spawn(process.execPath, ["dist/server.js"], {
+  cwd: fileURLToPath(new URL("..", import.meta.url)),
+  stdio: ["pipe", "pipe", "pipe"],
+});
+
+let stdout = "";
+let stderr = "";
+const responses = new Map();
+const pending = new Map();
+
+const timeout = setTimeout(() => {
+  child.kill();
+  throw new Error(`Timed out waiting for dist/server.js smoke responses. stderr:\n${stderr}`);
+}, 10_000);
+timeout.unref();
+
+child.stderr.setEncoding("utf8");
+child.stderr.on("data", (chunk) => {
+  stderr += chunk;
+});
+
+child.stdout.setEncoding("utf8");
+child.stdout.on("data", (chunk) => {
+  stdout += chunk;
+  let newline;
+  while ((newline = stdout.indexOf("\n")) !== -1) {
+    const line = stdout.slice(0, newline).replace(/\r$/, "");
+    stdout = stdout.slice(newline + 1);
+    if (!line) continue;
+
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch (error) {
+      throw new Error(`Non-JSON stdout from dist/server.js: ${JSON.stringify(line)}`, { cause: error });
+    }
+
+    if (message.id !== undefined) {
+      responses.set(message.id, message);
+      pending.get(message.id)?.();
+    }
+  }
+});
+
+child.once("exit", (code, signal) => {
+  for (const resolve of pending.values()) resolve();
+  if (code !== null && code !== 0) {
+    throw new Error(`dist/server.js exited early with code ${code}. stderr:\n${stderr}`);
+  }
+  if (signal) {
+    throw new Error(`dist/server.js exited early from signal ${signal}. stderr:\n${stderr}`);
+  }
+});
+
+function send(message) {
+  child.stdin.write(`${JSON.stringify(message)}\n`);
+}
+
+async function responseFor(id) {
+  if (!responses.has(id)) {
+    await new Promise((resolve) => pending.set(id, resolve));
+    pending.delete(id);
+  }
+  const response = responses.get(id);
+  assert.ok(response, `missing response for request ${id}`);
+  assert.equal(response.jsonrpc, "2.0");
+  assert.equal(response.error, undefined, `request ${id} failed: ${JSON.stringify(response.error)}`);
+  return response.result;
+}
+
+send({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: { name: "opentakeoff-dist-smoke", version: "0.0.0" },
+  },
+});
+
+const initialized = await responseFor(1);
+assert.equal(initialized.serverInfo.name, "opentakeoff");
+
+send({ jsonrpc: "2.0", method: "notifications/initialized" });
+send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+
+const listed = await responseFor(2);
+const names = listed.tools.map((tool) => tool.name).sort();
+assert.deepEqual(names, [
+  "delete_shape",
+  "export_takeoff",
+  "load_plan",
+  "measure_line",
+  "measure_polygon",
+  "one_click",
+  "read_sheet_text",
+  "set_scale",
+  "sheet_info",
+  "takeoff_summary",
+]);
+
+child.stdin.end();
+await once(child, "close");
+clearTimeout(timeout);
+
+assert.equal(stdout.trim(), "", `leftover partial stdout frame: ${JSON.stringify(stdout)}`);


### PR DESCRIPTION
## Summary
- add a compiled-artifact MCP smoke script that runs `dist/server.js` over stdio
- verify initialize and tools/list responses stay on a clean JSON-RPC stdout wire
- run MCP CI on both Ubuntu and Windows, including build plus the dist smoke check

Fixes #30
Fixes #38

## Validation
- cd mcp && npm run typecheck
- cd mcp && npm test
- cd mcp && npm run build && npm run smoke:dist
- cd web && npm run check
- python3 capture/capture_server.py selftest
- git diff --check
- rg -n "Karim13014|claude-code@anthropic.com" .git .