### PR TITLE
chore(mcp): 0.2.0 — MCP releases move to the mcp-v* tag namespace

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Sponsor button shown on the repo. GitHub Sponsors only — no third-party
+# donation platforms. Requires GitHub Sponsors enabled on the account below;
+# until then GitHub simply won't render the button.
+github: [QuisutDeus1]

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -3,10 +3,14 @@ name: Publish to MCP Registry
 # Registry-only release automation. The npm artifact is published manually
 # (hardware-key 2FA) BEFORE the tag is pushed — this workflow refuses to run
 # ahead of it. workflow_dispatch exercises OIDC login without publishing.
+#
+# MCP releases live in the mcp-v* tag namespace: bare v* tags are app
+# releases (v0.2.0, v0.3.0 already exist), so the server versions its tags
+# as mcp-v<package version>.
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["mcp-v*"]
   workflow_dispatch:
 
 permissions:
@@ -33,9 +37,9 @@ jobs:
             exit 1
           fi
           if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-            TAG="${GITHUB_REF_NAME#v}"
+            TAG="${GITHUB_REF_NAME#mcp-v}"
             if [ "$PKG" != "$TAG" ]; then
-              echo "::error::tag v$TAG does not match package version $PKG"
+              echo "::error::tag mcp-v$TAG does not match package version $PKG"
               exit 1
             fi
           fi
@@ -79,6 +83,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          VERSION="${GITHUB_REF_NAME#mcp-v}"
           gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
             || gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
-                 --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
+                 --title "opentakeoff-mcp $VERSION" --generate-notes --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
-## Unreleased
+## 2026-07-17 — opentakeoff-mcp 0.2.0
 
 ### Added
 - **MCP resources — browse a plan set before measuring** (flagship issue #29, reference implementation). A loaded plan exposes `takeoff://sheets` (index, sensible when empty), `takeoff://sheet/{page}` (metadata), `takeoff://sheet/{page}/text` (joined text), and `takeoff://sheet/{page}/image` (rendered PNG, long edge capped at 1568 px, lazily rendered and cached). `load_plan` announces the new surface via `resources/list_changed`. Rendering rides pdf.js's own optional `@napi-rs/canvas` — zero new dependencies, graceful degradation where the native binary is absent. Conformance suite in `mcp/test/resources.test.ts`.
+- `.github/FUNDING.yml` — GitHub Sponsors manifest (button renders once Sponsors is enabled on the account).
+
+### Changed
+- **MCP releases move to the `mcp-v*` tag namespace** (`mcp-v0.2.0`). Bare `v*` tags are app releases — v0.2.0 and v0.3.0 already exist — so the registry-publish workflow now fires on `mcp-v*`, and the auto-created GitHub release is titled `opentakeoff-mcp <version>` to stay distinguishable in the shared release list.
 
 ## 2026-07-17
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -190,3 +190,23 @@ sheet number (`A-101`) wherever a sheet is named.
 npm run typecheck
 npm test        # session + tool-layer + e2e, against demo/sample-plan.pdf
 ```
+
+## Releasing (maintainers)
+
+MCP releases live in the **`mcp-v*`** tag namespace — bare `v*` tags belong to
+the app (v0.2.0, v0.3.0 are app releases). The npm artifact publishes manually
+(hardware-key 2FA) **before** the tag is pushed; the workflow refuses to run
+ahead of it.
+
+```bash
+# 1. bump the version — all three fields together:
+#    package.json .version, server.json .version, server.json .packages[0].version
+# 2. from mcp/, publish with the hardware key:
+npm publish
+# 3. tag and push — this fires .github/workflows/publish-mcp.yml:
+git tag mcp-v<version> && git push origin mcp-v<version>
+```
+
+The workflow checks version consistency, requires the npm artifact to exist,
+publishes to the official MCP registry via GitHub OIDC, verifies the listing,
+and creates the GitHub release (titled `opentakeoff-mcp <version>`).

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.1.3",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Why

The next MCP release is 0.2.0 (the resources surface from #44 is on `main` unreleased) — but the publish workflow fired on `v*` tags with a tag==version check, and the **app** already owns `v0.2.0` and `v0.3.0`. The tag push would collide. MCP releases get their own namespace.

## What

- `publish-mcp.yml` triggers on **`mcp-v*`**; version check strips the new prefix; the auto-created GitHub release is titled `opentakeoff-mcp <version>` so app and server releases stay distinguishable in one list.
- Version bump to **0.2.0** across all three fields (`package.json`, `server.json` top-level + `packages[0]`) — the workflow's consistency check compares all three.
- CHANGELOG: Unreleased → `opentakeoff-mcp 0.2.0`, plus the namespace change.
- `mcp/README.md` gains a **Releasing** section — the ceremony now has an in-repo home.
- `.github/FUNDING.yml` (GitHub Sponsors; inert until Sponsors is enabled on the account).
- Tag ruleset 19106875 extended to protect `mcp-v*` alongside `v*` (repo-settings change, already applied).

## After merge

Ceremony (maintainer): `npm publish` 0.2.0 with the hardware key → `git tag mcp-v0.2.0 && git push origin mcp-v0.2.0` → workflow does registry publish, listing verification, and the GitHub release.

## Verification

- mcp typecheck + 23/23 tests green locally on the bumped package
- workflow YAML parses; `workflow_dispatch` dry-run (OIDC login, no publish) planned post-merge