### PR TITLE
chore: Sponsors funding points at the Kentucky-ai org

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # Sponsor button shown on the repo. GitHub Sponsors only — no third-party
 # donation platforms. Requires GitHub Sponsors enabled on the account below;
 # until then GitHub simply won't render the button.
-github: [QuisutDeus1]
+github: [Kentucky-ai]


### PR DESCRIPTION
Sponsorship belongs to the org, not the personal account — the Sponsor button and any sponsors badge should read Kentucky-ai. One-line FUNDING.yml change; inert until Sponsors enrollment completes on the org.