### PR TITLE
feat(mcp): typed tool results — outputSchema on all ten tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased
+
+### Added
+- **MCP: typed tool results — `outputSchema` on all ten tools.** Every tool now declares its result schema (`mcp/src/outputs.ts`, mirrored from the session layer), and every reply carries the payload as `structuredContent` alongside the back-compat JSON text item. The SDK validates each reply against its schema on every call, so a reply that drifts from its contract fails loudly in the server's own test suite instead of silently in a client. Conformance test added: all ten schemas present, structured/text parity, error replies stay plain `isError`.
+
 ## 2026-07-17 — opentakeoff-mcp 0.2.0
 
 ### Added

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -104,8 +104,11 @@ includes document text, shape vertices, or result payload content.
 | `delete_shape` | Remove a committed shape by id. |
 | `read_sheet_text` | Positioned page text (image px), optionally restricted to a region — title blocks, room labels, finish schedules. |
 
-Every reply is one compact JSON text item. Failures come back as
-`isError: true` with `{"error": "..."}` — never a dropped connection.
+Every tool declares an **`outputSchema`**, and every reply carries the payload
+as **`structuredContent`** — typed, machine-validated on every call — alongside
+the same compact JSON in a single text item for clients that predate structured
+output. Failures come back as `isError: true` with `{"error": "..."}` — never a
+dropped connection.
 
 ## Resources — browse before you measure
 

--- a/mcp/src/format.ts
+++ b/mcp/src/format.ts
@@ -1,6 +1,8 @@
-// Reply and error helpers. Every tool reply is a single content text item of
-// compact JSON (no pretty-print); every failure is { isError: true, ... } —
-// never a thrown protocol error.
+// Reply and error helpers. Every tool reply carries the payload twice, per the
+// spec's back-compat rule for tools with an output schema: structuredContent
+// (typed, validated against the tool's outputSchema) plus a single content text
+// item of the same compact JSON. Failures are { isError: true, ... } — never a
+// thrown protocol error, and exempt from the structuredContent requirement.
 
 /** A message meant for the calling agent (bad input, missing scale, …). */
 export class UserError extends Error {}
@@ -8,10 +10,12 @@ export class UserError extends Error {}
 export interface ToolReply {
   [k: string]: unknown;
   content: { type: "text"; text: string }[];
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 
 export const ok = (payload: unknown): ToolReply => ({
+  structuredContent: payload as Record<string, unknown>,
   content: [{ type: "text", text: JSON.stringify(payload) }],
 });
 

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -1,0 +1,153 @@
+// Output schemas — the typed half of the tool contract. Each tool declares
+// outputSchema at registration and returns the same payload as structuredContent
+// (format.ts ok()), so clients get machine-validated results instead of parsing
+// JSON out of a text item. The SDK enforces these on every call: a reply that
+// drifts from its schema is a server bug and fails loudly, not silently.
+//
+// Shapes mirror session.ts exactly. Objects that mirror the web engine's JS
+// output (summary rows, export payload) use .passthrough() so a field added
+// upstream widens the reply instead of failing validation.
+import { z } from "zod";
+
+const point = z.tuple([z.number(), z.number()]);
+
+/** sheetSummary in session.ts — one sheet's identity + dims. */
+const sheetSummary = {
+  sheet: z.string().describe('Sheet key: page 1 is the bare file name ("plan.pdf"), pages 2+ are "plan.pdf#2"'),
+  page: z.number().int().describe("1-based page number"),
+  width_pt: z.number(),
+  height_pt: z.number(),
+  width_px: z.number().describe("Image px at render scale 2.0 — the coordinate space every tool speaks"),
+  height_px: z.number(),
+  sheet_number: z.string().optional().describe('Title-block sheet number ("A-101") where detected'),
+  detected_scale: z.string().optional().describe("Drawn scale note read off the sheet — a suggestion, never auto-applied"),
+};
+
+export const loadPlanOutput = {
+  file: z.string(),
+  page_count: z.number().int(),
+  sheets: z.array(z.object(sheetSummary)),
+  note: z.string(),
+};
+
+export const sheetInfoOutput = {
+  ...sheetSummary,
+  seg_count: z.number().int().describe("Vector segment count"),
+  has_vector_linework: z.boolean().describe("one_click needs vector linework"),
+  scale_set: z.boolean(),
+  upp: z.number().optional().describe("Real feet per image px at render scale 2.0 — present once the scale is set"),
+  shape_count: z.number().int().describe("Committed shapes on this sheet"),
+};
+
+export const setScaleOutput = {
+  sheet: z.string(),
+  upp: z.number().describe("Real feet per image px at render scale 2.0"),
+  label: z.string().optional().describe("The standard scale label, when set by label or detected note"),
+  source: z.enum(["label", "upp", "calibrate", "detected"]),
+};
+
+/** one_click replies in one of two modes: with the sheet's scale set,
+ * area_sf/perimeter_lf (+ shape_id when committed); without it, a px-only
+ * preview (area_px2/perimeter_px + warning) that commits nothing. */
+export const oneClickOutput = {
+  status: z.literal("ok"),
+  nverts: z.number().int().describe("Vertex count of the traced polygon"),
+  hatch_filtered: z.literal(true).optional().describe("Present when hatch/pattern linework was classified out of the boundary"),
+  verts: z.array(point).optional().describe("Traced polygon vertices (image px), when return_verts was set"),
+  area_sf: z.number().optional().describe("Scaled mode: traced area in SF"),
+  perimeter_lf: z.number().optional().describe("Scaled mode: traced perimeter in LF"),
+  shape_id: z.string().optional().describe("Scaled mode: id of the committed shape, when condition was passed"),
+  area_px2: z.number().optional().describe("Preview mode (no scale): raw area in px²"),
+  perimeter_px: z.number().optional().describe("Preview mode (no scale): raw perimeter in px"),
+  warning: z.string().optional().describe("Preview mode (no scale): why quantities are unavailable and what to do"),
+};
+
+export const measurePolygonOutput = {
+  area_sf: z.number(),
+  perimeter_lf: z.number(),
+  nverts: z.number().int(),
+  shape_id: z.string().optional().describe("Present when condition was passed and the shape committed"),
+};
+
+export const measureLineOutput = {
+  length_lf: z.number(),
+  npts: z.number().int(),
+  shape_id: z.string().optional().describe("Present when condition was passed and the shape committed"),
+};
+
+/** conditionTotals row (web/src/lib/totals.js) minus presentation fields —
+ * *_net = waste-adjusted order quantities. */
+const summaryRow = z.object({
+  id: z.string(),
+  finish_tag: z.string(),
+  multiplier: z.number(),
+  waste_pct: z.number(),
+  shape_count: z.number().int(),
+  floor_sf: z.number(),
+  wall_sf: z.number(),
+  border_sf: z.number(),
+  lf: z.number(),
+  ea: z.number(),
+  total_sf: z.number(),
+  floor_sf_net: z.number(),
+  wall_sf_net: z.number(),
+  border_sf_net: z.number(),
+  lf_net: z.number(),
+  total_sf_net: z.number(),
+  sy_net: z.number(),
+}).passthrough();
+
+export const takeoffSummaryOutput = {
+  conditions: z.array(summaryRow),
+  totals: z.object({
+    total_sf: z.number(),
+    total_sf_net: z.number(),
+    lf: z.number(),
+    lf_net: z.number(),
+    ea: z.number(),
+    sy_net: z.number(),
+  }).passthrough(),
+};
+
+/** The app's exact save payload (opentakeoff.takeoff_canvas.v1). */
+export const exportTakeoffOutput = {
+  schema: z.string(),
+  project_name: z.string(),
+  units: z.string(),
+  sheets: z.array(z.object({ sheet_id: z.string(), units_per_px: z.number() })),
+  conditions: z.array(z.object({
+    id: z.string(),
+    finish_tag: z.string(),
+    color: z.string(),
+    fill: z.string(),
+    hatch: z.string(),
+    multiplier: z.number(),
+    waste_pct: z.number(),
+    materials: z.array(z.unknown()),
+  }).passthrough()),
+  shapes: z.array(z.object({
+    id: z.string(),
+    sheet_id: z.string(),
+    condition_id: z.string(),
+    measure_role: z.enum(["floor_area", "deduct", "linear"]),
+    verts_norm: z.array(point).describe("Vertices normalized to sheet dims (0–1)"),
+    computed: z.object({ area_sf: z.number(), perimeter_lf: z.number() }).passthrough(),
+    origin: z.object({}).passthrough().optional().describe("Provenance for one-click traces"),
+  }).passthrough()),
+  markups: z.array(z.unknown()),
+  sheet_group: z.array(z.unknown()),
+  last_group: z.array(z.unknown()),
+  sheet_tabs: z.array(z.unknown()),
+  sheet_levels: z.object({}).passthrough(),
+};
+
+export const deleteShapeOutput = {
+  deleted: z.string().describe("The removed shape's id"),
+  shape_count: z.number().int().describe("Committed shapes remaining"),
+};
+
+export const readSheetTextOutput = {
+  sheet: z.string(),
+  items: z.array(z.object({ str: z.string(), x: z.number(), y: z.number() })).describe("Positioned text items (image px)"),
+  text: z.string().describe("The items joined with spaces"),
+};

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -6,6 +6,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ok, fail, UserError, type ToolReply } from "./format.ts";
 import type { Session } from "./session.ts";
 import { traceToolCall } from "./trace.ts";
+import {
+  loadPlanOutput, sheetInfoOutput, setScaleOutput, oneClickOutput,
+  measurePolygonOutput, measureLineOutput, takeoffSummaryOutput,
+  exportTakeoffOutput, deleteShapeOutput, readSheetTextOutput,
+} from "./outputs.ts";
 
 // The coordinate contract, stated on every tool so any agent reading any one
 // description knows the space it is working in.
@@ -31,6 +36,7 @@ export function registerTools(server: McpServer, session: Session): void {
   server.registerTool("load_plan", {
     description: `Open a plan PDF from disk and replace the whole session (previous document, scales, conditions, and shapes are cleared). Returns file, page_count, and one entry per sheet: dims, title-block sheet_number, and the detected drawn scale where present. The loaded sheets also become browsable resources (takeoff://sheets). ${COORDS}`,
     inputSchema: { path: z.string().describe("Path to a plan PDF on disk") },
+    outputSchema: loadPlanOutput,
   }, run("load_plan", async ({ path }) => {
     const loaded = await session.loadPlan(path);
     server.sendResourceListChanged(); // the resource surface just changed under every subscriber
@@ -40,6 +46,7 @@ export function registerTools(server: McpServer, session: Session): void {
   server.registerTool("sheet_info", {
     description: `Sheet detail: dims (px and pt), vector segment count, whether the sheet has vector linework (one_click needs it), scale status, the detected scale suggestion, and this sheet's committed shape count. ${COORDS}`,
     inputSchema: { sheet: z.string().describe('Sheet key ("plan.pdf", "plan.pdf#2") or title-block number ("A-101")') },
+    outputSchema: sheetInfoOutput,
   }, run("sheet_info", ({ sheet }) => session.sheetInfo(sheet)));
 
   server.registerTool("set_scale", {
@@ -52,6 +59,7 @@ export function registerTools(server: McpServer, session: Session): void {
         .describe("Two points (image px) a known real distance apart, and that distance in feet"),
       use_detected: z.boolean().optional().describe("true = adopt the sheet's detected scale"),
     },
+    outputSchema: setScaleOutput,
   }, run("set_scale", (a) => {
     const given = [a.label !== undefined, a.upp !== undefined, a.calibrate !== undefined, a.use_detected !== undefined].filter(Boolean).length;
     if (given !== 1) throw new UserError("Provide exactly one of: label, upp, calibrate, use_detected.");
@@ -68,6 +76,7 @@ export function registerTools(server: McpServer, session: Session): void {
       role: roleSchema,
       return_verts: z.boolean().default(false).describe("Include the traced polygon's vertices (image px)"),
     },
+    outputSchema: oneClickOutput,
   }, run("one_click", (a) => session.oneClick(a.sheet, a.x, a.y, { condition: a.condition, role: a.role, returnVerts: a.return_verts })));
 
   server.registerTool("measure_polygon", {
@@ -78,6 +87,7 @@ export function registerTools(server: McpServer, session: Session): void {
       condition: z.string().optional(),
       role: roleSchema,
     },
+    outputSchema: measurePolygonOutput,
   }, run("measure_polygon", (a) => session.measurePolygon(a.sheet, a.verts, { condition: a.condition, role: a.role })));
 
   server.registerTool("measure_line", {
@@ -87,16 +97,19 @@ export function registerTools(server: McpServer, session: Session): void {
       pts: z.array(pointSchema).min(2),
       condition: z.string().optional(),
     },
+    outputSchema: measureLineOutput,
   }, run("measure_line", (a) => session.measureLine(a.sheet, a.pts, { condition: a.condition })));
 
   server.registerTool("takeoff_summary", {
     description: `Per-condition totals (floor/wall/border SF, LF, EA, SY, with and without waste) plus grand totals — the Report's numbers, computed by the same rules. ${COORDS}`,
     inputSchema: {},
+    outputSchema: takeoffSummaryOutput,
   }, run("takeoff_summary", () => session.summary()));
 
   server.registerTool("export_takeoff", {
     description: `The full "opentakeoff.takeoff_canvas.v1" annotations payload — exactly what the app autosaves, importable by it. Returned inline; pass path to also write it to disk as JSON. ${COORDS}`,
     inputSchema: { path: z.string().optional().describe("File path to write the payload to") },
+    outputSchema: exportTakeoffOutput,
   }, run("export_takeoff", async ({ path: outPath }) => {
     const payload = session.exportPayload();
     if (outPath) {
@@ -109,6 +122,7 @@ export function registerTools(server: McpServer, session: Session): void {
   server.registerTool("delete_shape", {
     description: `Remove a committed shape by the id returned when it was committed. ${COORDS}`,
     inputSchema: { shape_id: z.string() },
+    outputSchema: deleteShapeOutput,
   }, run("delete_shape", ({ shape_id }) => session.deleteShape(shape_id)));
 
   server.registerTool("read_sheet_text", {
@@ -117,5 +131,6 @@ export function registerTools(server: McpServer, session: Session): void {
       sheet: z.string(),
       region: z.object({ x0: z.number(), y0: z.number(), x1: z.number(), y1: z.number() }).optional(),
     },
+    outputSchema: readSheetTextOutput,
   }, run("read_sheet_text", (a) => session.readSheetText(a.sheet, a.region)));
 }

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -154,3 +154,22 @@ test("delete_shape: removes a committed shape; unknown id is isError", async () 
   assert.equal(gone.isError, true);
   assert.match(gone.data.error, /No shape with id/);
 });
+
+test("output contract: every tool declares outputSchema; structuredContent mirrors the text item", async () => {
+  const client = await pair();
+  const { tools } = await client.listTools();
+  for (const t of tools) {
+    const schema: any = (t as any).outputSchema;
+    assert.ok(schema && schema.type === "object", `${t.name} declares an object outputSchema`);
+    assert.ok(schema.properties && Object.keys(schema.properties).length > 0, `${t.name} outputSchema has properties`);
+  }
+  // A structured reply validates AND byte-matches the back-compat text item.
+  const res: any = await client.callTool({ name: "load_plan", arguments: { path: PLAN } });
+  assert.equal(!!res.isError, false);
+  assert.ok(res.structuredContent, "structuredContent present");
+  assert.deepEqual(res.structuredContent, JSON.parse(res.content[0].text), "structuredContent === parsed text content");
+  // Error replies stay plain isError results — no structuredContent required.
+  const bad: any = await client.callTool({ name: "sheet_info", arguments: { sheet: "no-such-sheet" } });
+  assert.equal(!!bad.isError, true);
+  assert.equal(bad.structuredContent, undefined);
+});


### PR DESCRIPTION
## What

The typed half of the tool contract. Every tool now declares an `outputSchema` (new `mcp/src/outputs.ts`, shapes mirrored 1:1 from the session layer) and every success reply carries the payload as `structuredContent` alongside the same compact JSON text item (the spec's back-compat rule). Error replies stay plain `isError` results, which the spec exempts.

The SDK validates each reply against its declared schema **on every call** — the existing 23-test suite became schema enforcement for free, plus a new conformance test: all ten schemas present, `structuredContent` === parsed text content, errors carry no structured payload.

Design notes:
- `one_click` keeps one flat object schema covering both modes (scaled vs px-preview) with per-field descriptions, rather than a top-level `anyOf` some clients choke on.
- Rows that originate in the web engine's JS (`takeoff_summary`, `export_takeoff`) use `.passthrough()` so an upstream field addition widens the reply instead of failing validation.
- #27's remaining per-tool conformance rungs stay open for contributors — this PR adds the schema layer, not those cases.

## Verify

- typecheck + 24/24 tests green
- compiled `dist/server.js` smoke: `tools/list` shows 10/10 tools with `outputSchema` over the real wire