### PR TITLE
feat(mcp): one-click Claude Desktop install — the .mcpb bundle

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -87,3 +87,13 @@ jobs:
           gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 \
             || gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" \
                  --title "opentakeoff-mcp $VERSION" --generate-notes --verify-tag
+
+      - name: Build and attach the MCPB bundle
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          npm ci --no-audit --no-fund
+          npm run mcpb
+          gh release upload "$GITHUB_REF_NAME" dist-mcpb/opentakeoff-mcp.mcpb \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ server/.venv/
 
 # MCP compiled dist (published to npm, never committed)
 mcp/dist/
+
+# MCPB bundle build output (release artifact, never committed)
+mcp/dist-mcpb/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 ## Unreleased
 
 ### Added
+- **MCP: one-click Claude Desktop install — the `.mcpb` bundle.** `npm run mcpb` stages the published-package surface with its production dependencies and an MCPB manifest, validates, and packs `opentakeoff-mcp.mcpb` (~9 MB); the release workflow builds and attaches it to every `mcp-v*` GitHub release. Platform-neutral by design: native optionals are excluded, so all ten tools and the text/metadata resources work everywhere and the sheet-image resource degrades gracefully.
 - **MCP: typed tool results — `outputSchema` on all ten tools.** Every tool now declares its result schema (`mcp/src/outputs.ts`, mirrored from the session layer), and every reply carries the payload as `structuredContent` alongside the back-compat JSON text item. The SDK validates each reply against its schema on every call, so a reply that drifts from its contract fails loudly in the server's own test suite instead of silently in a client. Conformance test added: all ten schemas present, structured/text parity, error replies stay plain `isError`.
 
 ## 2026-07-17 — opentakeoff-mcp 0.2.0

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -20,6 +20,17 @@ No clone, no build — point your MCP client at the published package:
 
 Works with Claude Code (`claude mcp add opentakeoff -- npx -y opentakeoff-mcp`), Claude Desktop, Cursor, or any stdio MCP client. Node 20+.
 
+## One-click install (Claude Desktop)
+
+No Node, no npm: download **`opentakeoff-mcp.mcpb`** from the
+[latest release](https://github.com/Kentucky-ai/opentakeoff/releases) and
+double-click it — Claude Desktop installs the server with its dependencies
+bundled. Built by `npm run mcpb` and attached automatically to every `mcp-v*`
+release. The bundle is platform-neutral on purpose: it excludes the optional
+native canvas, so every tool and the text/metadata resources work everywhere,
+and the sheet-image resource says exactly what's missing where rendering isn't
+available.
+
 
 The takeoff engine — One-Click Area, the scale model, conditions, totals — on
 **stdio for your MCP client**. An agent can open a plan, read the title block,

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -12,6 +12,7 @@
     "dev": "node --import tsx server.ts",
     "start": "node dist/server.js",
     "build": "esbuild server.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/server-core.js && node scripts/finish-build.mjs",
+    "mcpb": "npm run build && node scripts/build-mcpb.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test test/*.test.ts"

--- a/mcp/scripts/build-mcpb.mjs
+++ b/mcp/scripts/build-mcpb.mjs
@@ -1,0 +1,70 @@
+// Build the MCP Bundle (.mcpb) — the one-click Claude Desktop install artifact.
+// Stages the published-package surface (dist/ + package.json + README) with its
+// production dependencies and an MCPB manifest, then packs it with the official
+// CLI. Native optionals are deliberately excluded (--omit=optional) so the
+// bundle stays platform-neutral: every tool and text/metadata resource works
+// everywhere; the sheet-image resource degrades gracefully where the optional
+// canvas binary is absent, exactly as on any canvas-less install.
+//
+// Run via: npm run mcpb   (builds dist first; output in dist-mcpb/)
+import { cpSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageDir = resolve(scriptDir, '..')
+const outDir = resolve(packageDir, 'dist-mcpb')
+const staging = resolve(outDir, 'staging')
+
+const run = (cmd, args, cwd) => {
+  const r = spawnSync(cmd, args, { cwd, stdio: 'inherit' })
+  if (r.status !== 0) {
+    console.error(`\n${cmd} ${args.join(' ')} failed (exit ${r.status})`)
+    process.exit(r.status ?? 1)
+  }
+}
+
+const pkg = JSON.parse(readFileSync(resolve(packageDir, 'package.json'), 'utf8'))
+if (!existsSync(resolve(packageDir, 'dist', 'server.js'))) {
+  console.error('dist/server.js missing — run `npm run build` first (or use `npm run mcpb`).')
+  process.exit(1)
+}
+
+rmSync(outDir, { recursive: true, force: true })
+mkdirSync(staging, { recursive: true })
+
+// The published-package surface, verbatim.
+cpSync(resolve(packageDir, 'dist'), resolve(staging, 'dist'), { recursive: true })
+cpSync(resolve(packageDir, 'package.json'), resolve(staging, 'package.json'))
+cpSync(resolve(packageDir, 'README.md'), resolve(staging, 'README.md'))
+
+// The MCPB manifest — version tracks package.json, always.
+writeFileSync(resolve(staging, 'manifest.json'), JSON.stringify({
+  manifest_version: '0.2',
+  name: pkg.name,
+  display_name: 'OpenTakeoff',
+  version: pkg.version,
+  description: pkg.description,
+  long_description: 'Construction takeoff for AI agents: load plan PDFs, browse the sheet set as resources, set and verify drawing scale, one-click room areas, measure, and export takeoff quantities with provenance. The same measuring engine as the OpenTakeoff web app.',
+  author: { name: 'Kentucky AI', url: 'https://github.com/Kentucky-ai' },
+  repository: { type: 'git', url: 'https://github.com/Kentucky-ai/opentakeoff' },
+  homepage: 'https://opentakeoff.netlify.app',
+  documentation: 'https://github.com/Kentucky-ai/opentakeoff/blob/main/mcp/README.md',
+  license: pkg.license,
+  keywords: ['construction', 'takeoff', 'estimating', 'blueprints', 'measurement'],
+  server: {
+    type: 'node',
+    entry_point: 'dist/server.js',
+    mcp_config: { command: 'node', args: ['${__dirname}/dist/server.js'], env: {} },
+  },
+  compatibility: { runtimes: { node: '>=20' } },
+}, null, 2) + '\n')
+
+// Production dependencies only, no native optionals, no lifecycle scripts.
+run('npm', ['install', '--omit=dev', '--omit=optional', '--ignore-scripts', '--no-audit', '--no-fund'], staging)
+
+run('npx', ['-y', '@anthropic-ai/mcpb', 'validate', resolve(staging, 'manifest.json')], packageDir)
+run('npx', ['-y', '@anthropic-ai/mcpb', 'pack', staging, resolve(outDir, `${pkg.name}.mcpb`)], packageDir)
+
+console.log(`\nbuilt ${resolve(outDir, `${pkg.name}.mcpb`)}`)


### PR DESCRIPTION
## What

MCPB packaging: `npm run mcpb` builds `opentakeoff-mcp.mcpb` — the one-click Claude Desktop install artifact — and the release workflow attaches it to every `mcp-v*` GitHub release automatically.

- `mcp/scripts/build-mcpb.mjs` stages the published-package surface + production deps + an MCPB manifest (version always tracks `package.json`), validates with the official CLI, packs.
- **Platform-neutral on purpose**: `--omit=optional` keeps the native canvas out, so the bundle runs everywhere — all ten tools + text/metadata resources fully functional, sheet-image resource explains what's missing (the graceful-degradation path that already ships).
- README gains the one-click install section; `mcp/dist-mcpb/` gitignored.

## Verify

- Built locally: 8.9 MB packed / 26.4 MB unpacked, CLI validate green.
- Staged entry smoked exactly as Claude Desktop launches it (`node dist/server.js` from the staging dir): serverInfo 0.2.0, 10/10 tools with outputSchema, resources listed.
- Workflow YAML parses; the attach step reuses the release job's existing token/permissions.

After merge: build from main and upload the bundle to the existing `mcp-v0.2.0` release so it's available today.