### PR TITLE
chore(mcp): 0.3.0 — typed tool results, one-click Claude Desktop bundle, dist smoke CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
-## Unreleased
+## 2026-07-17 — opentakeoff-mcp 0.3.0
 
 ### Added
+- **MCP: dist smoke harness in CI, on Ubuntu and Windows** (@pollychen-lab, closes #30 and #38). `npm run smoke:dist` drives the compiled `dist/server.js` over stdio — initialize, tools/list, all ten tools by name, and a clean-JSON-RPC-stdout-wire assertion — and the mcp CI job now builds and smokes on both platforms.
 - **MCP: one-click Claude Desktop install — the `.mcpb` bundle.** `npm run mcpb` stages the published-package surface with its production dependencies and an MCPB manifest, validates, and packs `opentakeoff-mcp.mcpb` (~9 MB); the release workflow builds and attaches it to every `mcp-v*` GitHub release. Platform-neutral by design: native optionals are excluded, so all ten tools and the text/metadata resources work everywhere and the sheet-image resource degrades gracefully.
 - **MCP: typed tool results — `outputSchema` on all ten tools.** Every tool now declares its result schema (`mcp/src/outputs.ts`, mirrored from the session layer), and every reply carries the payload as `structuredContent` alongside the back-compat JSON text item. The SDK validates each reply against its schema on every call, so a reply that drifts from its contract fails loudly in the server's own test suite instead of silently in a client. Conformance test added: all ten schemas present, structured/text parity, error replies stay plain `isError`.
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Bumps package.json + server.json (all three fields). The release ships
outputSchema on all ten tools with structuredContent replies, the .mcpb
one-click Claude Desktop install (auto-attached to the GitHub release by
the workflow from this tag on), and the cross-platform dist smoke
harness contributed in #46.
