### PR TITLE
MCP: truthful shape origin — agent actor, no phantom review (contribution.v2 PR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased
+
+### Changed
+- **MCP: shapes the server commits now tell the truth about who made them.** Previously, agent work banked as human work: one-click commits stamped `origin.reviewed: true` even though no human ever reviewed them, and `measure_polygon` / `measure_line` commits carried no `origin` at all — so downstream consumers (the capture/contribution pipeline included) defaulted them to human demonstrations. Now every shape the MCP server commits carries `actor: "agent"`; one-click commits stamp `reviewed: false` (an agent's un-reviewed trace is machine-proposed, exactly like a pending binder shape), and measure commits carry `origin: { method: "manual", actor: "agent" }` — agent-supplied coordinates are a hand trace by a machine hand. `Shape.origin` in `mcp/src/session.ts` is widened to the full contribution.v2 vocabulary (`method`, `actor`, `reviewed`, correction fields). **Behavioral change for anyone trusting `reviewed` or the human-by-default origin convention**: MCP-produced shapes no longer masquerade as human-reviewed work in exports or contributed corpora.
+
 ## 2026-07-17 — opentakeoff-mcp 0.3.0
 
 ### Added

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -132,7 +132,7 @@ export const exportTakeoffOutput = {
     measure_role: z.enum(["floor_area", "deduct", "linear"]),
     verts_norm: z.array(point).describe("Vertices normalized to sheet dims (0–1)"),
     computed: z.object({ area_sf: z.number(), perimeter_lf: z.number() }).passthrough(),
-    origin: z.object({}).passthrough().optional().describe("Provenance for one-click traces"),
+    origin: z.object({}).passthrough().optional().describe("Provenance: method (manual|one_click_v1), actor (omitted=human, 'agent'=MCP/automation), reviewed (human affirmed at an explicit gate), and correction fields (edited, edited_before_create, copied, proposed_verts_norm, edits)"),
   }).passthrough()),
   markups: z.array(z.unknown()),
   sheet_group: z.array(z.unknown()),

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -46,6 +46,31 @@ export interface Condition {
   materials: unknown[];
 }
 
+/** Shape provenance (contribution.v2 vocabulary — mirrors the canvas +
+ * web/src/lib/provenance.js). Truthfulness rules: `actor` is omitted for a
+ * human at the canvas and "agent" for MCP/automation; `reviewed` is true ONLY
+ * after a human affirmed the shape at an explicit review gate — this server
+ * has no such gate, so everything it commits is reviewed: false. */
+export interface ShapeOrigin {
+  method: "manual" | "one_click_v1";
+  /** Omitted = human. "agent" = the shape was produced by MCP/automation. */
+  actor?: "agent";
+  /** A human affirmed this shape at an explicit review gate. */
+  reviewed?: boolean;
+  /** one_click: the flood-fill seed, normalized to sheet dims. */
+  seed_norm?: [number, number];
+  hatch_filtered?: true;
+  raster_traced?: true;
+  fill_sensitivity?: number;
+  /** Machine's original trace, frozen on first human edit (provenance.js). */
+  proposed_verts_norm?: [number, number][];
+  edited?: boolean;
+  edited_before_create?: boolean;
+  copied?: boolean;
+  /** Per-kind tally of human corrections (provenance.js). */
+  edits?: Record<string, number>;
+}
+
 export interface Shape {
   id: string;
   sheet_id: string;
@@ -53,7 +78,7 @@ export interface Shape {
   measure_role: MeasureRole;
   verts_norm: [number, number][];
   computed: { area_sf: number; perimeter_lf: number };
-  origin?: { method: "one_click_v1"; seed_norm: [number, number]; reviewed: true; hatch_filtered?: true };
+  origin?: ShapeOrigin;
 }
 
 interface SheetState {
@@ -339,10 +364,13 @@ export class Session {
     const perimeter_lf = round2(perimPx * upp);
     let shape_id: string | undefined;
     if (opts.condition) {
+      // actor + reviewed: false — this is a machine-proposed trace no human
+      // has affirmed; only an explicit human review gate may set reviewed.
       shape_id = this.commit(s, opts.condition, opts.role, ring, { area_sf, perimeter_lf }, {
         method: "one_click_v1",
+        actor: "agent",
         seed_norm: [x / s.widthPx, y / s.heightPx],
-        reviewed: true,
+        reviewed: false,
         ...(f.hatchFiltered ? { hatch_filtered: true as const } : {}),
       }).id;
     }
@@ -356,7 +384,9 @@ export class Session {
     const area_sf = round2(met.area * s.upp * s.upp);
     const perimeter_lf = round2(met.perim * s.upp);
     let shape_id: string | undefined;
-    if (opts.condition) shape_id = this.commit(s, opts.condition, opts.role, verts, { area_sf, perimeter_lf }).id;
+    // agent-supplied coordinates are a hand trace by a machine hand: manual
+    // method, agent actor — and never reviewed (no human affirmed anything).
+    if (opts.condition) shape_id = this.commit(s, opts.condition, opts.role, verts, { area_sf, perimeter_lf }, { method: "manual", actor: "agent" }).id;
     return { area_sf, perimeter_lf, nverts: verts.length, ...(shape_id ? { shape_id } : {}) };
   }
 
@@ -366,7 +396,7 @@ export class Session {
     const length_lf = round2(openLen(pts) * s.upp);
     let shape_id: string | undefined;
     // area_sf stays 0 — the canvas only mints border SF when the condition has a thickness
-    if (opts.condition) shape_id = this.commit(s, opts.condition, "linear", pts, { area_sf: 0, perimeter_lf: length_lf }).id;
+    if (opts.condition) shape_id = this.commit(s, opts.condition, "linear", pts, { area_sf: 0, perimeter_lf: length_lf }, { method: "manual", actor: "agent" }).id;
     return { length_lf, npts: pts.length, ...(shape_id ? { shape_id } : {}) };
   }
 

--- a/mcp/test/e2e.test.ts
+++ b/mcp/test/e2e.test.ts
@@ -71,6 +71,8 @@ test("e2e: load → set_scale(detected) → one_click × 4 rooms → summary →
     assert.equal(exported.sheets[0].sheet_id, KEY);
     for (const shp of exported.shapes) {
       assert.equal(shp.origin.method, "one_click_v1");
+      assert.equal(shp.origin.actor, "agent", "agent commits are labeled agent in the export");
+      assert.equal(shp.origin.reviewed, false, "nothing this server commits was human-reviewed");
       for (const [vx, vy] of shp.verts_norm) assert.ok(vx >= 0 && vx <= 1 && vy >= 0 && vy <= 1);
     }
   } finally {

--- a/mcp/test/session.test.ts
+++ b/mcp/test/session.test.ts
@@ -115,8 +115,9 @@ test("commit: verts_norm in [0,1], origin receipt, condition minted like the can
     assert.ok(x >= 0 && x <= 1 && y >= 0 && y <= 1, `verts_norm out of [0,1]: ${x},${y}`);
   }
   assert.equal(shp.origin?.method, "one_click_v1");
-  assert.equal(shp.origin?.reviewed, true);
-  assert.ok(shp.origin?.seed_norm[0]! > 0 && shp.origin?.seed_norm[0]! < 1);
+  assert.equal(shp.origin?.actor, "agent", "MCP commits are agent work, never human");
+  assert.equal(shp.origin?.reviewed, false, "no human review gate exists in this server");
+  assert.ok(shp.origin?.seed_norm?.[0]! > 0 && shp.origin?.seed_norm?.[0]! < 1);
   assert.equal(s.conditions.length, 1);
   const c = s.conditions[0];
   assert.equal(c.finish_tag, "CPT-1");
@@ -149,6 +150,12 @@ test("measure: polygon SF and line LF at scale; deletion removes the shape", asy
   assert.equal(s.shapes.length, 2);
   assert.equal(s.shapes[1].measure_role, "linear");
   assert.equal(s.shapes[1].computed.area_sf, 0);
+  // agent-supplied coordinates: a hand trace by a machine hand, never human
+  for (const shp of s.shapes) {
+    assert.equal(shp.origin?.method, "manual");
+    assert.equal(shp.origin?.actor, "agent");
+    assert.equal(shp.origin?.reviewed, undefined, "measure commits claim no review state");
+  }
   s.deleteShape(poly.shape_id!);
   assert.equal(s.shapes.length, 1);
   await assert.rejects(async () => s.deleteShape("shp-nope"), /No shape with id/);


### PR DESCRIPTION
Third PR of the contribution.v2 series. Agent work no longer banks as human demonstrations.

- One-click commits stamped \`origin.reviewed: true\` with no human in the loop → now \`reviewed: false\` + \`actor: "agent"\` (an agent's un-reviewed trace is machine-proposed, exactly like a pending binder shape).
- \`measure_polygon\` / \`measure_line\` commits carried no origin at all, so downstream capture defaulted them to human → now \`origin: { method: "manual", actor: "agent" }\` — agent-supplied coordinates are a hand trace by a machine hand.
- \`Shape.origin\` widened to the typed contribution.v2 vocabulary (\`ShapeOrigin\`); the export outputSchema description names it.
- Tests pin the new stamps end to end (24/24; typecheck/build/smoke green).

**Behavioral change** for anyone trusting \`reviewed\` or the human-by-default origin convention — see CHANGELOG.