### PR TITLE
opentakeoff-mcp 0.4.0 — truthful origin release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
-## Unreleased
+## 2026-07-18 — opentakeoff-mcp 0.4.0
 
 ### Changed
 - **MCP: shapes the server commits now tell the truth about who made them.** Previously, agent work banked as human work: one-click commits stamped `origin.reviewed: true` even though no human ever reviewed them, and `measure_polygon` / `measure_line` commits carried no `origin` at all — so downstream consumers (the capture/contribution pipeline included) defaulted them to human demonstrations. Now every shape the MCP server commits carries `actor: "agent"`; one-click commits stamp `reviewed: false` (an agent's un-reviewed trace is machine-proposed, exactly like a pending binder shape), and measure commits carry `origin: { method: "manual", actor: "agent" }` — agent-supplied coordinates are a hand trace by a machine hand. `Shape.origin` in `mcp/src/session.ts` is widened to the full contribution.v2 vocabulary (`method`, `actor`, `reviewed`, correction fields). **Behavioral change for anyone trusting `reviewed` or the human-by-default origin convention**: MCP-produced shapes no longer masquerade as human-reviewed work in exports or contributed corpora.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,9 +1,9 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
-  "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",
+  "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Version bump + CHANGELOG date for the PR #55 behavioral change (agent shapes no longer bank as human-reviewed). Gates: typecheck clean, 24/24 tests, build + smoke:dist green at 0.4.0.