### PR TITLE
contribution.v2: provenance on the wire, capture.v2 rows, normative spec (PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-07-18
+
+### Added
+- **`opentakeoff.contribution.v2` — contributions carry provenance** (contribution.v2 PR-2, on the PR-1 provenance primitives). The Contribute payload now sends each shape's `id` (opaque durable UUID), `created_at`, and a **whitelisted** `origin` object (`pickOrigin` — registered keys only, never a spread): method, actor, reviewed/edited/edited-before-create/copied flags, one-click seed + trace parameters, per-kind correction tallies, and — for corrected machine shapes — the frozen `proposed_verts_norm`, so the machine's trace and the expert's fix ride side by side. New envelope fields: `generator_version` (inlined from `package.json` at build), per-sheet `scale_source` (provenance only — scale *values* never leave, and v1's `units_per_px`-free discipline tightens into an explicit MUST NOT), and aggregate `counters` (e.g. shapes deleted by origin method). The never-sent list is unchanged and now normative: no PDF, file names, project/client names, markup or label text, absolute coordinates, scale values, or edit timing beyond `created_at`.
+- **`docs/CONTRIBUTION_SPEC.md`** — the normative wire + row contract: privacy invariants (including explicit disclosure of the durable-id linkage), field tables for `contribution.v2` and the `capture.v2` row, the provenance vocabulary registry with an IoU correction-magnitude recipe, dedup semantics, and the versioning policy (additive within a version; servers accept N and N−1).
+- **Capture server banks `opentakeoff.capture.v2` rows** and accepts both `contribution.v2` and `contribution.v1` (anything else still 400s). Rows gain `shape_id`, `created_at`, verbatim `origin`, `scale_source` (joined from the payload's sheets), `generator_version`, and `contribution_schema` — all key-omitted when the wire didn't carry them; the row fingerprint is unchanged, so existing corpora can't double-bank. `summary`/`/health` gain an `origin_methods` count map, and the selftest grows a v2 triad (manual / clean one-click / corrected one-click must stay distinguishable), a v1-still-ingests check, and an unknown-schema rejection check.
+
+### Changed
+- **Capture rows default `origin_method` to `"unknown"`, not `"human"`.** A shape that recorded no provenance is a shape whose provenance we don't know — defaulting it to human would corrupt any human-vs-machine split trained on the corpus. Treat `"unknown"` as unlabeled.
+
 ## 2026-07-18 — opentakeoff-mcp 0.4.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Here's the part of a takeoff nobody talks about: every one you finish is a set o
 
 OpenTakeoff ships an optional **capture layer** so you can keep it:
 
-- The **Contribute** button in the Report builds a derived-only payload — condition labels, shape roles, quantities, normalized geometry. Never the PDF, file names, project/client names, markups, or absolute coordinates. The builder is ~70 audited lines: [`web/src/lib/contribute.js`](web/src/lib/contribute.js).
-- The bundled **capture server** ([`capture/`](capture/README.md)) — one stdlib-only Python file, no pip install — receives it on localhost and banks one training row per labeled shape, hash-gated so re-contributions never duplicate. Point it at a synced folder with `--mirror` and the corpus rides your existing OneDrive/SharePoint/Dropbox sync into company storage, atomically, ready to train on.
+- The **Contribute** button in the Report builds a derived-only payload — condition labels, shape roles, quantities, normalized geometry, and per-shape provenance (hand-traced vs. machine-proposed, and whether a human corrected it). Never the PDF, file names, project/client names, markups, absolute coordinates, or scale values. The builder is ~150 audited lines: [`web/src/lib/contribute.js`](web/src/lib/contribute.js); the normative wire contract is [`docs/CONTRIBUTION_SPEC.md`](docs/CONTRIBUTION_SPEC.md).
+- The bundled **capture server** ([`capture/`](capture/README.md)) — one stdlib-only Python file, no pip install — receives it on localhost and banks one training row per labeled shape, hash-gated so re-contributions never duplicate. v2 rows distinguish what the machine got right from what an expert had to fix — the exact signal a takeoff model trains on. Point it at a synced folder with `--mirror` and the corpus rides your existing OneDrive/SharePoint/Dropbox sync into company storage, atomically, ready to train on.
 
 ```bash
 python3 capture/capture_server.py    # then, in the app's browser console:

--- a/capture/README.md
+++ b/capture/README.md
@@ -13,7 +13,7 @@ evaporates when the bid goes out. The capture layer is how you keep it.
 
 ## What it is
 
-One stdlib-only Python file — no pip install, ~350 lines, audit it in a
+One stdlib-only Python file — no pip install, ~500 lines, audit it in a
 sitting. It listens on localhost for the app's opt-in **Contribute** payload
 and banks each labeled shape as one training row:
 
@@ -24,16 +24,27 @@ corpus/
   state.json             fingerprints already banked (ingest is idempotent)
 ```
 
-A row is the WHERE and the WHAT: normalized polygon + bbox, sheet, measure
-role, then the label — finish tag, hatch, waste %, multiplier, height — plus
-the quantities you accepted and how the shape was made (`origin_method:
-"oneclick"` vs `"human"`). Re-contributing an unchanged takeoff appends
-nothing; retag or redraw a shape and it re-captures. Rows are hash-gated by
-content, so the corpus only ever grows by real signal.
+A row is the WHERE, the WHAT, and the HOW: normalized polygon + bbox, sheet,
+measure role, then the label — finish tag, hatch, waste %, multiplier, height —
+the quantities you accepted, and the shape's provenance. Current builds send
+`opentakeoff.contribution.v2`, and those rows carry the full origin record:
+hand-traced (`manual`) vs. machine-proposed (`one_click_v1`), whether a human
+corrected it, and — for corrected shapes — the machine's original trace
+(`proposed_verts_norm`) alongside the final geometry, so what the machine got
+right and what an expert had to fix stay distinguishable. Rows also carry the
+shape's durable id, `created_at`, and the sheet's `scale_source` (provenance
+only — never a scale value). Older v1 payloads still ingest; their rows just
+lack the v2 columns, and a shape that recorded no provenance banks as
+`origin_method: "unknown"` — not `"human"`, because absence of evidence isn't
+a hand trace. Re-contributing an unchanged takeoff appends nothing; retag or
+redraw a shape and it re-captures. Rows are hash-gated by content, so the
+corpus only ever grows by real signal. The full row format and field tables
+live in [`docs/CONTRIBUTION_SPEC.md`](../docs/CONTRIBUTION_SPEC.md).
 
 What it receives is the same audited, derived-only payload the app builds for
 any Contribute endpoint (`web/src/lib/contribute.js`): **never** the PDF, file
-names, project or client names, markups, or absolute coordinates.
+names, project or client names, markups, absolute coordinates, or scale
+values.
 
 ## Run it
 

--- a/capture/capture_server.py
+++ b/capture/capture_server.py
@@ -14,9 +14,13 @@ Wire-up (one line, in the browser console of any OpenTakeoff build):
 
 Then hit **Contribute** in the Report. Self-hosted builds can bake it in with
 `VITE_CONTRIBUTE_ENDPOINT` instead. The payload is the same audited, derived-only
-`opentakeoff.contribution.v1` the app builds for any endpoint: condition labels,
-shape roles, quantities, and normalized (0..1) geometry — never the PDF, file
-names, project/client names, markups, or absolute coordinates.
+contribution the app builds for any endpoint — `opentakeoff.contribution.v2`
+from current builds, `opentakeoff.contribution.v1` from older ones (both
+accepted; anything else is rejected): condition labels, shape roles,
+quantities, normalized (0..1) geometry, and per-shape provenance — never the
+PDF, file names, project/client names, markups, absolute coordinates, or scale
+values. Rows bank as `opentakeoff.capture.v2` either way; see
+docs/CONTRIBUTION_SPEC.md for the normative wire and row contracts.
 
 What lands on disk (all human-readable):
 
@@ -39,12 +43,16 @@ import json
 import os
 import sys
 import threading
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 MAX_BODY = 32 * 1024 * 1024  # a contribution is text; anything near this is not one
-CAPTURE_SCHEMA = "opentakeoff.capture.v1"
+CAPTURE_SCHEMA = "opentakeoff.capture.v2"
+# Wire schemas this server ingests: current and previous (N and N−1 — the
+# versioning policy in docs/CONTRIBUTION_SPEC.md). Anything else 400s.
+ACCEPTED = {"opentakeoff.contribution.v1", "opentakeoff.contribution.v2"}
 
 # A synced share can wedge at the KERNEL level — a stalled sync client can leave
 # open()/stat() on a placeholder file hanging indefinitely, which no try/except
@@ -87,8 +95,19 @@ def payload_rows(payload: dict) -> list[dict]:
     """Flatten one contribution into (geometry → label) rows, one per labeled
     shape. The condition IS the label: finish tag plus the hatch/waste/multiplier
     the estimator tuned. Shapes without a resolvable condition carry no label
-    and are skipped."""
+    and are skipped.
+
+    Version-aware over one code path: v2 shapes carry a whitelisted `origin`
+    object (banked verbatim) plus `id`/`created_at`, and v2 payloads carry
+    per-sheet `scale_source`; v1 shapes carry a flat `origin_method` string.
+    `origin_method` derives from whichever is present — and defaults to
+    "unknown" (NOT the old "human"): a shape that recorded nothing is a shape
+    whose provenance we don't know, and pretending otherwise would poison any
+    human-vs-machine split trained on the corpus. v2-only fields are simply
+    omitted from rows a v1 payload produces."""
     conds = {c.get("finish"): c for c in (payload.get("conditions") or []) if c.get("finish")}
+    scale_by_sheet = {sh.get("sheet"): sh.get("scale_source")
+                      for sh in (payload.get("sheets") or []) if sh.get("sheet")}
     ts = datetime.now(timezone.utc).isoformat()
     rows = []
     for s in (payload.get("shapes") or []):
@@ -96,7 +115,7 @@ def payload_rows(payload: dict) -> list[dict]:
         if not cond:
             continue
         verts = s.get("verts_norm") or []
-        rows.append({
+        row = {
             "ts": ts,
             "schema": CAPTURE_SCHEMA,
             "sheet": s.get("sheet"),
@@ -109,9 +128,19 @@ def payload_rows(payload: dict) -> list[dict]:
             "multiplier": cond.get("multiplier", 1),
             "height_ft": s.get("height_ft"),
             "computed": s.get("computed") or {}, # the SF / LF / EA the estimator accepted
-            "origin_method": s.get("origin_method", "human"),
+            "origin_method": (s.get("origin") or {}).get("method") or s.get("origin_method") or "unknown",
             "contributor": payload.get("contributor") or "",
-        })
+        }
+        extras = {                               # v2 signal — key-omitted when absent
+            "shape_id": s.get("id"),             # opaque durable id — links re-contributions
+            "created_at": s.get("created_at"),
+            "origin": s.get("origin"),           # verbatim — the client already whitelists
+            "scale_source": scale_by_sheet.get(s.get("sheet")),
+            "generator_version": payload.get("generator_version"),
+            "contribution_schema": payload.get("schema"),  # the wire schema this row came from
+        }
+        row.update({k: v for k, v in extras.items() if v is not None})
+        rows.append(row)
     return rows
 
 
@@ -209,6 +238,7 @@ class Corpus:
     def summary(self) -> dict:
         rows = contributions = 0
         finishes: dict[str, int] = {}
+        origin_methods: dict[str, int] = {}
         last_ts = None
         seen_contrib = set()
         try:
@@ -222,13 +252,15 @@ class Corpus:
                         continue
                     rows += 1
                     finishes[r.get("finish_tag", "?")] = finishes.get(r.get("finish_tag", "?"), 0) + 1
+                    om = r.get("origin_method") or "unknown"
+                    origin_methods[om] = origin_methods.get(om, 0) + 1
                     seen_contrib.add(r.get("contribution"))
                     last_ts = r.get("ts") or last_ts
         except OSError:
             pass
         contributions = len(seen_contrib - {None})
         return {"rows": rows, "contributions": contributions,
-                "finishes": finishes, "last_ts": last_ts}
+                "finishes": finishes, "origin_methods": origin_methods, "last_ts": last_ts}
 
 
 # --- server ------------------------------------------------------------------
@@ -273,7 +305,7 @@ def make_handler(corpus: Corpus):
                     return self._respond(413 if length > MAX_BODY else 400,
                                          {"ok": False, "error": "bad content length"})
                 payload = json.loads(self.rfile.read(length))
-                if payload.get("schema") != "opentakeoff.contribution.v1":
+                if payload.get("schema") not in ACCEPTED:
                     return self._respond(400, {"ok": False, "error": "unknown schema"})
             except (ValueError, OSError):
                 return self._respond(400, {"ok": False, "error": "invalid JSON"})
@@ -306,8 +338,10 @@ def serve(corpus: Corpus, port: int):
 
 def selftest() -> int:
     """End-to-end over the wire: start the server on an ephemeral port, POST a
-    sample contribution twice (second must dedup), retag a shape (must
-    re-capture), and check the mirror copy. Exits non-zero on any failure."""
+    v1 sample twice (second must dedup), retag a shape (must re-capture), check
+    the mirror copy, reject an unknown schema, then POST a v2 sample carrying
+    the manual / clean one-click / corrected one-click triad and assert the
+    banked rows keep them distinguishable. Exits non-zero on any failure."""
     import shutil
     import tempfile
     import threading
@@ -359,6 +393,81 @@ def selftest() -> int:
     mirrored = os.path.join(corpus.mirror, "takeoff_labels.jsonl")
     with open(mirrored) as fh:
         check("mirror is a whole consistent copy", sum(1 for l in fh if l.strip()), 3)
+
+    # unknown schemas still 400 — accepting v1 AND v2 is not accepting anything
+    def post_status(payload):
+        req = urllib.request.Request(f"{base}/contribute", json.dumps(payload).encode(),
+                                     {"Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(req) as res:
+                return res.status
+        except urllib.error.HTTPError as e:
+            return e.code
+
+    check("unknown schema rejected", post_status({**sample, "schema": "opentakeoff.contribution.v99"}), 400)
+
+    # contribution.v2 — the provenance triad: a hand-traced shape, a one-click
+    # accepted verbatim, and a one-click the estimator corrected. The corpus
+    # must keep all three distinguishable, or the "what did the machine get
+    # right vs. what did a human fix" signal is lost at the door.
+    proposed = [[.61, .60], [.79, .60], [.79, .83], [.60, .84]]
+    v2 = {
+        "schema": "opentakeoff.contribution.v2", "generator": "opentakeoff",
+        "generator_version": "0.1.0", "contributor": "selftest-v2",
+        "sheets": [{"sheet": "sheet_1", "scale_source": "detected"}],
+        "conditions": [{"finish": "LVT-9", "hatch": "plank", "multiplier": 1, "waste_pct": 10}],
+        "shapes": [
+            {"role": "floor_area", "finish": "LVT-9", "sheet": "sheet_1",
+             "id": "0f7b8f9e-0000-4000-8000-000000000001", "created_at": "2026-07-18T12:00:00.000Z",
+             "verts_norm": [[.05, .05], [.20, .05], [.20, .20], [.05, .20]],
+             "computed": {"sf": 88.0}, "origin": {"method": "manual"}},
+            {"role": "floor_area", "finish": "LVT-9", "sheet": "sheet_1",
+             "id": "0f7b8f9e-0000-4000-8000-000000000002", "created_at": "2026-07-18T12:01:00.000Z",
+             "verts_norm": [[.30, .30], [.45, .30], [.45, .50], [.30, .50]],
+             "computed": {"sf": 120.0},
+             "origin": {"method": "one_click_v1", "seed_norm": [.37, .40], "reviewed": True}},
+            {"role": "floor_area", "finish": "LVT-9", "sheet": "sheet_1",
+             "id": "0f7b8f9e-0000-4000-8000-000000000003", "created_at": "2026-07-18T12:02:00.000Z",
+             "verts_norm": [[.60, .60], [.80, .60], [.80, .85], [.60, .85]],
+             "computed": {"sf": 260.0},
+             "origin": {"method": "one_click_v1", "seed_norm": [.70, .70], "reviewed": True,
+                        "edited": True, "edits": {"vertex": 2, "move": 1},
+                        "proposed_verts_norm": proposed}},
+        ],
+        "totals": [],
+        "counters": {"shapes_deleted": {"one_click_v1": 1}},
+    }
+    check("v2 triad banks three rows", post(v2)["rows_added"], 3)
+    check("v2 re-contribution dedups", post(v2)["rows_added"], 0)
+
+    with open(corpus.labels) as fh:
+        v2rows = [r for line in fh if line.strip()
+                  for r in [json.loads(line)] if r.get("contributor") == "selftest-v2"]
+    by_id = {r["shape_id"]: r for r in v2rows}
+    manual = by_id["0f7b8f9e-0000-4000-8000-000000000001"]
+    clean = by_id["0f7b8f9e-0000-4000-8000-000000000002"]
+    fixed = by_id["0f7b8f9e-0000-4000-8000-000000000003"]
+    check("v2 rows carry shape_id + created_at + scale_source",
+          all(r.get("shape_id") and r.get("created_at") and r.get("scale_source") == "detected"
+              for r in v2rows), True)
+    check("v2 rows bank as capture.v2 tagged with their wire schema",
+          all(r.get("schema") == CAPTURE_SCHEMA
+              and r.get("contribution_schema") == "opentakeoff.contribution.v2"
+              and r.get("generator_version") == "0.1.0" for r in v2rows), True)
+    check("manual row: hand-traced, uncorrected",
+          (manual["origin_method"], manual["origin"].get("edited")), ("manual", None))
+    check("clean one-click row: machine trace accepted verbatim",
+          (clean["origin_method"], clean["origin"].get("edited"),
+           clean["origin"].get("proposed_verts_norm")), ("one_click_v1", None, None))
+    check("corrected row: machine trace preserved, differs from final",
+          (fixed["origin_method"], fixed["origin"]["edited"],
+           fixed["origin"]["proposed_verts_norm"] != fixed["verts_norm"],
+           fixed["origin"]["edits"]), ("one_click_v1", True, True, {"vertex": 2, "move": 1}))
+    with urllib.request.urlopen(f"{base}/health") as res:
+        health = json.load(res)
+    check("summary counts origin methods",
+          (health["origin_methods"].get("manual"), health["origin_methods"].get("one_click_v1")),
+          (1, 2))
 
     # a wedged share (sync client stalled mid-syscall) may cost a contribution
     # at most the mirror timeout — the corpus row still banks, the POST returns

--- a/docs/CONTRIBUTION_SPEC.md
+++ b/docs/CONTRIBUTION_SPEC.md
@@ -1,0 +1,264 @@
+# The contribution wire format — `opentakeoff.contribution.v2`
+
+This is the normative contract for what leaves the app when a user clicks
+**Contribute**, and for what the bundled capture server banks. Two audited
+files implement it end to end — [`web/src/lib/contribute.js`](../web/src/lib/contribute.js)
+(builds the payload) and [`capture/capture_server.py`](../capture/capture_server.py)
+(receives it) — and this document is the ruler both are held to. If the code
+and this spec disagree, one of them has a bug.
+
+## 1. Expert demonstrations, not takeoffs
+
+A contribution is not a takeoff — it is a set of **expert demonstrations**: an
+estimator (or an agent acting for one) looked at a region, decided what it is,
+traced or accepted its boundary, and stood behind the quantities. Humans and
+agents both produce demonstrations, and the wire records which was which. The
+highest-value rows are the **corrections**: a machine proposed a boundary, a
+human fixed it, and both the machine's trace and the expert's final answer
+survive side by side. That pair — what the model would have said vs. what the
+expert made it say — is precisely the supervision a takeoff model trains on,
+and v2 exists to stop flattening it.
+
+## 2. Privacy invariants (normative)
+
+A conforming contribution **MUST NOT** contain:
+
+- the raw PDF, or any rendered image of it;
+- file names, sheet names, or any raw sheet identifier (sheets go out as
+  `sheet_1`, `sheet_2`, … — positional tokens minted per payload);
+- project, client, or customer names;
+- markup text or shape-label text (any free text a user typed onto the plan);
+- absolute coordinates (geometry is normalized 0..1 against the sheet);
+- scale values (`units_per_px` or anything derived from it — only the scale's
+  *provenance* rides, e.g. `"calibrated"`);
+- edit timing of any kind beyond each shape's `created_at` — no `updated_at`,
+  no per-edit timestamps, no gesture data, no dwell times.
+
+One linkage is deliberate and disclosed: shapes and payloads carry **opaque
+durable UUIDs**, so repeated contributions from the same document link over
+time — a re-contribution after an addendum supersedes rather than duplicates,
+and a corpus can follow one shape across revisions. The ids are minted
+locally, contain no content, and reverse to nothing; the linkage is the
+feature, and this paragraph is its disclosure.
+
+The builder enforces the origin whitelist mechanically (`pickOrigin` in
+`contribute.js`): only registered provenance keys leave the machine, never a
+spread of whatever a build happened to store.
+
+## 3. `opentakeoff.contribution.v2`
+
+### Envelope
+
+| field | type | presence | meaning |
+|---|---|---|---|
+| `schema` | string | required | `"opentakeoff.contribution.v2"` |
+| `generator` | string | required | `"opentakeoff"` |
+| `generator_version` | string | when known | app version inlined at build time |
+| `sheets` | array | required | one entry per sheet that carries shapes (below) |
+| `conditions` | array | required | anonymized condition labels (below) |
+| `shapes` | array | required | the demonstrations (below) |
+| `totals` | array | required | per-condition quantity rollup, ids/colors stripped |
+| `counters` | object | when non-empty | aggregate provenance tallies, e.g. `{"shapes_deleted": {"one_click_v1": 2}}` |
+| `contributor` | string | optional | free-text credit the user typed at the gate |
+
+### `sheets[]`
+
+| field | type | presence | meaning |
+|---|---|---|---|
+| `sheet` | string | required | positional token (`"sheet_1"`) — never a file name |
+| `scale_source` | string | when recorded | how the sheet's scale was established: `"calibrated"` (user drew a known length), `"detected"` (read from the sheet's text and explicitly adopted), `"standard"` (picked from the standard-scale list), `"unknown"` (predates recording). Newer builds may write other strings; consumers treat unrecognized values as opaque. |
+
+No scale *value* ever appears — a sheet's `units_per_px` stays local.
+
+### `conditions[]`
+
+| field | type | meaning |
+|---|---|---|
+| `finish` | string | the finish tag (`"LVT-9"`) — the label vocabulary |
+| `hatch` | string | fill pattern name |
+| `multiplier` | number | condition multiplier |
+| `waste_pct` | number | waste percentage the estimator tuned |
+
+### `shapes[]`
+
+| field | type | presence | meaning |
+|---|---|---|---|
+| `role` | string | required | `floor_area` \| `surface_area` \| `linear` \| `count` \| `deduct` |
+| `finish` | string | required | joins the shape to its condition label |
+| `sheet` | string | required | positional sheet token |
+| `verts_norm` | number[][] | required | final geometry, normalized 0..1 |
+| `computed` | object | required | the quantities the expert accepted (SF / LF / EA) |
+| `height_ft` | number | when set | wall height override |
+| `id` | string | when present | opaque durable UUID (see §2) |
+| `created_at` | string | when present | ISO-8601 UTC creation stamp; legacy shapes predate stamping and omit it |
+| `origin` | object | when present | whitelisted provenance (§5); absent on legacy shapes |
+
+v1's flat `origin_method` string is gone from the wire — the server derives it
+from `origin.method` (§4).
+
+### Full example — the provenance triad
+
+One hand-traced shape, one machine proposal accepted verbatim, one machine
+proposal the estimator corrected:
+
+```json
+{
+  "schema": "opentakeoff.contribution.v2",
+  "generator": "opentakeoff",
+  "generator_version": "0.1.0",
+  "sheets": [{ "sheet": "sheet_1", "scale_source": "detected" }],
+  "conditions": [
+    { "finish": "LVT-9", "hatch": "plank", "multiplier": 1, "waste_pct": 10 }
+  ],
+  "shapes": [
+    {
+      "role": "floor_area", "finish": "LVT-9", "sheet": "sheet_1",
+      "id": "0f7b8f9e-0000-4000-8000-000000000001",
+      "created_at": "2026-07-18T12:00:00.000Z",
+      "verts_norm": [[0.05, 0.05], [0.20, 0.05], [0.20, 0.20], [0.05, 0.20]],
+      "computed": { "area_sf": 88.0, "perimeter_lf": 40.0 },
+      "origin": { "method": "manual" }
+    },
+    {
+      "role": "floor_area", "finish": "LVT-9", "sheet": "sheet_1",
+      "id": "0f7b8f9e-0000-4000-8000-000000000002",
+      "created_at": "2026-07-18T12:01:00.000Z",
+      "verts_norm": [[0.30, 0.30], [0.45, 0.30], [0.45, 0.50], [0.30, 0.50]],
+      "computed": { "area_sf": 120.0, "perimeter_lf": 48.0 },
+      "origin": { "method": "one_click_v1", "seed_norm": [0.37, 0.40], "reviewed": true }
+    },
+    {
+      "role": "floor_area", "finish": "LVT-9", "sheet": "sheet_1",
+      "id": "0f7b8f9e-0000-4000-8000-000000000003",
+      "created_at": "2026-07-18T12:02:00.000Z",
+      "verts_norm": [[0.60, 0.60], [0.80, 0.60], [0.80, 0.85], [0.60, 0.85]],
+      "computed": { "area_sf": 260.0, "perimeter_lf": 62.0 },
+      "origin": {
+        "method": "one_click_v1", "seed_norm": [0.70, 0.70], "reviewed": true,
+        "edited": true, "edits": { "vertex": 2, "move": 1 },
+        "proposed_verts_norm": [[0.61, 0.60], [0.79, 0.60], [0.79, 0.83], [0.60, 0.84]]
+      }
+    }
+  ],
+  "totals": [],
+  "counters": { "shapes_deleted": { "one_click_v1": 1 } }
+}
+```
+
+### `opentakeoff.contribution.v1` (accepted legacy)
+
+The previous wire: no `sheets` array (a `sheet_count` integer instead), no
+per-shape `id`/`created_at`/`origin`, provenance flattened to an optional
+`origin_method` string. Servers keep accepting it (§6); rows derived from it
+simply lack the v2 columns.
+
+## 4. The capture row — `opentakeoff.capture.v2`
+
+The capture server flattens each contribution into one JSONL row per labeled
+shape (`corpus/takeoff_labels.jsonl`). Both wire versions produce v2 rows;
+v2-only columns are **key-omitted** on rows a v1 payload produced — absence
+means "the wire didn't carry it", never an empty-string placeholder.
+
+| field | presence | meaning |
+|---|---|---|
+| `ts` | always | server-side ingest time (UTC ISO-8601) |
+| `schema` | always | `"opentakeoff.capture.v2"` |
+| `sheet` | always | positional sheet token from the payload |
+| `measure_role` | always | shape role |
+| `verts_norm` / `bbox_norm` | always | WHERE — normalized polygon + its bbox |
+| `finish_tag` | always | WHAT — the condition is the label |
+| `hatch` / `waste_pct` / `multiplier` | always | the label's tuned parameters |
+| `height_ft` | always (may be null) | wall height override |
+| `computed` | always | accepted quantities |
+| `origin_method` | always | derived: `origin.method`, else v1's flat `origin_method`, else `"unknown"` (§5) |
+| `contributor` | always | credit string, `""` if none |
+| `contribution` | always | 12-hex prefix of the payload hash — joins the row to its `raw/` archive file |
+| `shape_id` | v2, when present | the shape's opaque durable UUID |
+| `created_at` | v2, when present | the shape's creation stamp |
+| `origin` | v2, when present | the whitelisted origin object, verbatim |
+| `scale_source` | v2, when present | joined from the payload's `sheets[]` by the shape's sheet token |
+| `generator_version` | v2, when present | app version that built the payload |
+| `contribution_schema` | v2, when present | the wire schema the row came from |
+
+### Fingerprint / dedup semantics
+
+Rows are hash-gated by `_fingerprint` — a SHA-1 over the label-relevant tuple
+(`verts_norm`, `measure_role`, `finish_tag`, `computed`, `hatch`, `waste_pct`,
+`multiplier`, `height_ft`). Re-contributing an unchanged takeoff appends
+nothing; retag or reshape and it re-captures. The fingerprint is **deliberately
+unchanged from v1** so the upgrade can't double-bank existing corpora — with
+one documented consequence: a v2 re-contribution of a shape already banked
+from a v1 payload is dup-skipped, so its JSONL row keeps the v1-era columns.
+The full v2 payload still lands verbatim in the `raw/` archive, so the richer
+provenance is recoverable by re-deriving (delete `state.json` and replay
+`raw/` if you want a corpus rebuilt at full v2 fidelity).
+
+### `raw/` archive and mirror discipline
+
+Every distinct payload is archived verbatim at `corpus/raw/<hash>.json` —
+the row format can evolve and old contributions re-derive. The optional
+`--mirror` copies the label file into a synced share **whole and atomically**
+after each write, never live-appending inside a sync folder (append churn
+there breeds conflict copies); a wedged share can strand an expendable mirror
+thread, never the capture itself.
+
+## 5. Provenance vocabulary
+
+The `origin` object is a registry, not a convention — these are the only keys
+the client will send (`pickOrigin` whitelist), and the only keys a consumer
+should rely on:
+
+| key | type | meaning |
+|---|---|---|
+| `method` | string | how the geometry came to exist: `"manual"` (hand-traced) or `"one_click_v1"` (machine flood-fill proposal); `"import"` reserved |
+| `actor` | string | omitted = a human at the canvas; `"agent"` = an MCP client committed it |
+| `reviewed` | bool | a human affirmed the shape at an explicit gate (e.g. clicked Create on a proposal) |
+| `edited` | bool | corrected after Create |
+| `edited_before_create` | bool | corrected between proposal and Create (grip drags on the live region) |
+| `copied` | bool | pasted clone — carries its source's lineage but no fresh evidence; excluded from correction stats |
+| `seed_norm` | [x, y] | normalized one-click seed point |
+| `proposed_verts_norm` | number[][] | the machine's original trace, frozen at the first human correction |
+| `hatch_filtered` | bool | one-click ran with hatch filtering |
+| `raster_traced` | bool | traced from scan pixels rather than vector linework |
+| `fill_sensitivity` | number | non-default one-click fill sensitivity |
+| `edits` | object | per-kind correction tally, e.g. `{"vertex": 2, "move": 1}` |
+
+**Computing correction magnitude.** For a corrected machine shape
+(`proposed_verts_norm` present), the standard measure is **IoU between the
+polygon of `proposed_verts_norm` and the polygon of `verts_norm`**: 1.0 means
+the human accepted the machine's boundary exactly (only possible on
+`edited_before_create` round-trips that ended where they started); lower IoU
+means a heavier correction. `edits` gives the gesture-count view of the same
+fact; the geometry is the ground truth.
+
+**`origin_method: "unknown"` semantics.** A row whose shape carried neither an
+`origin` object nor a v1 `origin_method` string banks as `"unknown"` — the
+shape predates provenance stamping, or came from a build that didn't record
+it. This is a deliberate change from the v1 server's default of `"human"`:
+absence of evidence is not evidence of a hand trace, and a corpus that
+defaults unknowns to human would corrupt any human-vs-machine split trained
+on it. Treat `"unknown"` as unlabeled, not as manual.
+
+## 6. Versioning policy
+
+- **Within a version, changes are additive.** New optional fields may appear
+  on `contribution.v2` payloads and `capture.v2` rows without a schema bump;
+  consumers ignore keys they don't know. No field is renamed, retyped, or
+  removed within a version.
+- **Anything non-additive is a new version** — a new schema string, never a
+  mutation of the old one.
+- **Servers accept N and N−1.** The bundled capture server accepts
+  `contribution.v2` and `contribution.v1` and rejects everything else with
+  HTTP 400. When v3 exists, v1 falls off.
+
+## 7. Scope boundary
+
+This spec covers exactly what the explicit **Contribute** gate emits: a
+final-state snapshot, sent only when a user clicks the button, containing only
+the fields above. The ambient event-stream edition — rows banking on autosave
+and commit, deletion records with geometry, decision trails, rejected
+proposals and their dismissal context, per-edit timing — is the commercial
+capture layer inside [Spline](https://spline.quisutdeus.io), and its schemas
+are deliberately not specified here. The boundary is drawn on purpose and
+we'd rather say so than blur it: OpenTakeoff's gate gives you (and the open
+corpus) the demonstration; the behavioral stream around it is the product.

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -36,7 +36,9 @@ export default [
       ecmaVersion: 2024,
       sourceType: "module",
       parserOptions: { ecmaFeatures: { jsx: true } },
-      globals: { ...globals.browser },
+      // __APP_VERSION__ is a build-time define (vite.config.js) — a real global
+      // in the bundle, absent under Node (use sites carry a typeof guard).
+      globals: { ...globals.browser, __APP_VERSION__: "readonly" },
     },
     plugins: { "react-hooks": reactHooks },
     rules: {

--- a/web/src/components/ReportPanel.jsx
+++ b/web/src/components/ReportPanel.jsx
@@ -44,7 +44,7 @@ const sheetNum = (v, d = 1) => {
   return num(r, d);
 };
 
-export default function ReportPanel({ projectName, onProjectName, conditions, shapes, sheetLabel, onMarkedSet, markedSetDark, onClose, markups = [], rfis = [], scaleInfo = [], clientInfo = {}, onClientInfo, conditionColumns = [], shapeLabels = [], units = "imperial" }) {
+export default function ReportPanel({ projectName, onProjectName, conditions, shapes, sheetLabel, onMarkedSet, markedSetDark, onClose, markups = [], rfis = [], scaleInfo = [], provenanceCounters = null, clientInfo = {}, onClientInfo, conditionColumns = [], shapeLabels = [], units = "imperial" }) {
   // memoized on the source arrays: project-name/client-info keystrokes re-render
   // the panel without touching conditions/shapes, so the totaling passes skip
   // imported report theme → { vars, name, warnings }. vars are spread onto this
@@ -856,7 +856,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
       </div>
 
       {showContribute && (
-        <ContributeModal conditions={conditions} shapes={shapes} onClose={() => setShowContribute(false)} />
+        <ContributeModal conditions={conditions} shapes={shapes} scaleInfo={scaleInfo} provenanceCounters={provenanceCounters} onClose={() => setShowContribute(false)} />
       )}
       {showInfo && (
         <ProjectInfoModal clientInfo={clientInfo} onClientInfo={onClientInfo}
@@ -1060,7 +1060,7 @@ function ProjectInfoModal({ clientInfo = {}, onClientInfo, onSaved, onClose }) {
   );
 }
 
-function ContributeModal({ conditions, shapes, onClose }) {
+function ContributeModal({ conditions, shapes, scaleInfo = [], provenanceCounters = null, onClose }) {
   const [attest, setAttest] = useState(false);
   const [contributor, setContributor] = useState("");
   const [state, setState] = useState("idle"); // idle | sending | done | error
@@ -1071,7 +1071,7 @@ function ContributeModal({ conditions, shapes, onClose }) {
     if (!attest || !configured) return;
     setState("sending"); setMsg("");
     try {
-      await sendContribution(buildContribution({ conditions, shapes }), contributor.trim());
+      await sendContribution(buildContribution({ conditions, shapes, scaleInfo, counters: provenanceCounters }), contributor.trim());
       setState("done"); setMsg("Thank you — your takeoff is now helping train the open flooring model.");
     } catch (e) {
       setState("error"); setMsg(e.message || String(e));
@@ -1090,6 +1090,7 @@ function ContributeModal({ conditions, shapes, onClose }) {
           <ul style={{ margin: "0 0 10px", paddingLeft: 18 }}>
             <li>condition labels, shape types, and quantities (SF / LF / EA)</li>
             <li>normalized room geometry (shape only — no scale, no location)</li>
+            <li>how each shape was made (hand-traced vs. machine-proposed) and whether you corrected it</li>
           </ul>
           <p style={{ margin: "0 0 10px", color: "var(--c-positive)", fontWeight: 600 }}>
             Never sent: the PDF itself, file names, project or client names, your markups, or any absolute coordinates.

--- a/web/src/lib/contribute.js
+++ b/web/src/lib/contribute.js
@@ -2,9 +2,14 @@
 //
 // The pitch: grow a shared, flooring-tuned open dataset/model the community is
 // proud to feed. What's sent is the DERIVED takeoff only — condition labels,
-// per-shape roles + quantities, and NORMALIZED (0..1) geometry. What is NEVER
-// sent: the raw PDF, file names, project/customer names, markup text, or any
-// absolute coordinates. The code is open so anyone can audit exactly this.
+// per-shape roles + quantities, NORMALIZED (0..1) geometry, and each shape's
+// provenance (hand-traced vs. machine-proposed, and whether a human corrected
+// it). What is NEVER sent: the raw PDF, file names, project/customer names,
+// markup or shape-label text, absolute coordinates, scale values, or any edit
+// timing beyond each shape's created_at. Shape/sheet identifiers go out as
+// opaque tokens (UUIDs / sheet_N) that carry no content. The code is open so
+// anyone can audit exactly this; the normative contract — every MUST NOT, the
+// field tables, the provenance vocabulary — lives in docs/CONTRIBUTION_SPEC.md.
 //
 // The collection endpoint is configured at deploy time (VITE_CONTRIBUTE_ENDPOINT)
 // or per-browser (localStorage), and can be left unset — in which case the
@@ -37,21 +42,77 @@ export function endpointSource() {
   return (import.meta.env && import.meta.env.VITE_CONTRIBUTE_ENDPOINT) ? "build" : "";
 }
 
+// Vite inlines the app version at build (vite.config.js `define`); under the
+// Node test runner the identifier simply doesn't exist, hence the typeof guard.
+const APP_VERSION = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "";
+
+// The ONLY origin keys that ever leave the machine. A whitelist, never a
+// spread: any key a newer (or patched) build adds to origin stays local until
+// it is deliberately added here AND documented in docs/CONTRIBUTION_SPEC.md.
+const ORIGIN_FIELDS = [
+  "method",               // how the geometry came to exist: "manual" | "one_click_v1" | ...
+  "actor",                // omitted = human at the canvas; "agent" = MCP client
+  "reviewed",             // a human affirmed the shape at an explicit gate
+  "edited",               // corrected after Create
+  "edited_before_create", // corrected between proposal and Create
+  "copied",               // pasted clone — lineage without fresh evidence
+  "seed_norm",            // normalized one-click seed point
+  "proposed_verts_norm",  // the machine's original trace, frozen at first correction
+  "hatch_filtered",       // one-click ran with hatch filtering
+  "raster_traced",        // traced from scan pixels, not vector linework
+  "fill_sensitivity",     // non-default one-click fill sensitivity
+  "edits",                // per-kind correction tally, e.g. { vertex: 2, move: 1 }
+];
+
+/** @returns {Record<string, any> | null} the whitelisted origin, or null when nothing survives */
+export function pickOrigin(origin) {
+  if (!origin || typeof origin !== "object") return null;
+  /** @type {Record<string, any>} */
+  const out = {};
+  for (const k of ORIGIN_FIELDS) if (origin[k] !== undefined) out[k] = origin[k];
+  return Object.keys(out).length ? out : null;
+}
+
+// Omit-when-empty for the provenance counters: an all-empty tally says nothing.
+const hasCounts = (c) => !!c && Object.values(c).some((v) =>
+  typeof v === "number" ? v > 0 : !!v && typeof v === "object" && Object.keys(v).length > 0);
+
 // Build the anonymized, derived-only payload. No raw plan, no identifiers.
-export function buildContribution({ conditions, shapes }) {
+/**
+ * @param {{
+ *   conditions: Array<Record<string, unknown>>,
+ *   shapes: Array<Record<string, any>>,
+ *   scaleInfo?: Array<{ sheet_id: string, units_per_px?: number, scale_source?: string }>,
+ *   counters?: Record<string, number | Record<string, number>> | null,
+ * }} takeoff — scaleInfo's units_per_px is accepted (it's what the canvas has) and NEVER read
+ */
+export function buildContribution({ conditions, shapes, scaleInfo = [], counters = null }) {
   const sheetIds = [...new Set(shapes.map((s) => s.sheet_id))];
   const sheetIndex = new Map(sheetIds.map((k, i) => [k, `sheet_${i + 1}`])); // strip file names
   const tagOf = Object.fromEntries((conditions || []).map((c) => [c.id, c.finish_tag]));
 
-  const anonShapes = shapes.map((s) => ({
-    role: s.measure_role,
-    finish: tagOf[s.condition_id] || "?",
-    sheet: sheetIndex.get(s.sheet_id),
-    verts_norm: s.verts_norm,          // normalized 0..1 — shape only, no scale/location
-    computed: s.computed,              // SF / LF / EA
-    ...(s.height_ft ? { height_ft: s.height_ft } : {}),
-    ...(s.origin?.method ? { origin_method: s.origin.method } : {}),
+  // Per-sheet scale PROVENANCE only ("calibrated" / "detected" / "standard" /
+  // "unknown") — never units_per_px or any other scale value.
+  const bySheet = new Map((scaleInfo || []).map((si) => [si.sheet_id, si.scale_source]));
+  const sheets = sheetIds.map((sid) => ({
+    sheet: sheetIndex.get(sid),
+    ...(bySheet.get(sid) ? { scale_source: bySheet.get(sid) } : {}),
   }));
+
+  const anonShapes = shapes.map((s) => {
+    const origin = pickOrigin(s.origin);
+    return {
+      role: s.measure_role,
+      finish: tagOf[s.condition_id] || "?",
+      sheet: sheetIndex.get(s.sheet_id),
+      verts_norm: s.verts_norm,          // normalized 0..1 — shape only, no scale/location
+      computed: s.computed,              // SF / LF / EA
+      ...(s.height_ft ? { height_ft: s.height_ft } : {}),
+      ...(s.id ? { id: s.id } : {}),     // opaque UUID — links re-contributions, carries no content
+      ...(s.created_at ? { created_at: s.created_at } : {}), // legacy shapes predate stamping — omitted
+      ...(origin ? { origin } : {}),     // whitelisted provenance; updated_at/edit timing NEVER ride
+    };
+  });
 
   const anonConditions = (conditions || []).map((c) => ({
     finish: c.finish_tag,
@@ -66,12 +127,14 @@ export function buildContribution({ conditions, shapes }) {
   );
 
   return {
-    schema: "opentakeoff.contribution.v1",
+    schema: "opentakeoff.contribution.v2",
     generator: "opentakeoff",
-    sheet_count: sheetIds.length,
+    ...(APP_VERSION ? { generator_version: APP_VERSION } : {}),
+    sheets,
     conditions: anonConditions,
     shapes: anonShapes,
     totals,
+    ...(hasCounts(counters) ? { counters } : {}), // aggregate tallies (e.g. shapes_deleted by origin method)
   };
 }
 

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -5116,6 +5116,7 @@ export default function TakeoffCanvas() {
           conditions={conditions} shapes={shapes} markups={markups} rfis={rfis}
           conditionColumns={conditionColumns} shapeLabels={shapeLabels}
           scaleInfo={Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px, scale_source: scaleSources[sheet_id] || "unknown" }))}
+          provenanceCounters={provCounters}
           sheetLabel={(k) => tabLabel(k)}
           onMarkedSet={exportMarkedSet} markedSetDark={darkMode}
           onClose={() => setShowReport(false)}

--- a/web/test/contribute.test.ts
+++ b/web/test/contribute.test.ts
@@ -1,0 +1,129 @@
+// contribution.v2 wire builder (lib/contribute.js) — the privacy contract and
+// the provenance triad. The invariants:
+//   - the serialized payload NEVER contains sheet file names, label text,
+//     units_per_px (or any scale value), or updated_at — the hard cut-lines
+//     documented in docs/CONTRIBUTION_SPEC.md;
+//   - the manual / clean one-click / corrected one-click triad stays
+//     distinguishable on the wire (origin.method, edited, proposed_verts_norm,
+//     edits);
+//   - pickOrigin is a WHITELIST — unknown origin keys never ride;
+//   - v1-era shapes (no id vocabulary, no created_at, no origin) still
+//     serialize as valid rows with those keys simply absent.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildContribution, pickOrigin } from "../src/lib/contribute.js";
+
+// A workspace as the canvas would hand it over — deliberately salted with
+// everything that must NOT leak: a real-looking file name in sheet_id, a shape
+// label, condition color, updated_at stamps, and a units_per_px scale value.
+const SHEET = "Westside Elementary - floorplan.pdf#2";
+const fixture = () => {
+  const conditions = [
+    { id: "cnd-1", finish_tag: "LVT-9", color: "#123456", fill: "#123456", hatch: "plank", multiplier: 1, waste_pct: 10, created_at: "2026-07-18T11:00:00.000Z" },
+  ];
+  const shapes = [
+    { // hand-traced
+      id: "0f7b8f9e-0000-4000-8000-000000000001", created_at: "2026-07-18T12:00:00.000Z",
+      updated_at: "2026-07-18T12:30:00.000Z", sheet_id: SHEET, condition_id: "cnd-1",
+      measure_role: "floor_area", label: "Rm 204 Classroom",
+      verts_norm: [[0.05, 0.05], [0.2, 0.05], [0.2, 0.2], [0.05, 0.2]],
+      computed: { area_sf: 88, perimeter_lf: 40 }, origin: { method: "manual" },
+    },
+    { // one-click accepted verbatim
+      id: "0f7b8f9e-0000-4000-8000-000000000002", created_at: "2026-07-18T12:01:00.000Z",
+      sheet_id: SHEET, condition_id: "cnd-1", measure_role: "floor_area",
+      verts_norm: [[0.3, 0.3], [0.45, 0.3], [0.45, 0.5], [0.3, 0.5]],
+      computed: { area_sf: 120, perimeter_lf: 48 },
+      origin: { method: "one_click_v1", seed_norm: [0.37, 0.4], reviewed: true },
+    },
+    { // one-click the estimator corrected after Create
+      id: "0f7b8f9e-0000-4000-8000-000000000003", created_at: "2026-07-18T12:02:00.000Z",
+      updated_at: "2026-07-18T12:40:00.000Z", sheet_id: SHEET, condition_id: "cnd-1",
+      measure_role: "floor_area",
+      verts_norm: [[0.6, 0.6], [0.8, 0.6], [0.8, 0.85], [0.6, 0.85]],
+      computed: { area_sf: 260, perimeter_lf: 62 },
+      origin: {
+        method: "one_click_v1", seed_norm: [0.7, 0.7], reviewed: true, edited: true,
+        edits: { vertex: 2, move: 1 },
+        proposed_verts_norm: [[0.61, 0.6], [0.79, 0.6], [0.79, 0.83], [0.6, 0.84]],
+      },
+    },
+  ];
+  const scaleInfo = [{ sheet_id: SHEET, units_per_px: 0.020833, scale_source: "detected" }];
+  return { conditions, shapes, scaleInfo };
+};
+
+test("privacy: the serialized payload carries no file names, label text, scale values, or edit timing", () => {
+  const { conditions, shapes, scaleInfo } = fixture();
+  const wire = JSON.stringify(buildContribution({
+    conditions, shapes, scaleInfo, counters: { shapes_deleted: { one_click_v1: 1 } },
+  }));
+  for (const leak of ["Westside", "floorplan", ".pdf", "sheet_id", // file names / raw sheet keys
+                      "Rm 204", "Classroom", "label",              // user label text
+                      "units_per_px", "0.020833",                  // scale values
+                      "updated_at",                                // edit timing beyond created_at
+                      "#123456", "condition_id"]) {                // styling / internal joins
+    assert.ok(!wire.includes(leak), `payload leaked ${JSON.stringify(leak)}`);
+  }
+  // …while the disclosed fields DO ride: opaque sheet token + scale provenance.
+  const p = JSON.parse(wire);
+  assert.equal(p.schema, "opentakeoff.contribution.v2");
+  assert.deepEqual(p.sheets, [{ sheet: "sheet_1", scale_source: "detected" }]);
+  assert.deepEqual(p.counters, { shapes_deleted: { one_click_v1: 1 } });
+});
+
+test("triad: manual / clean one-click / corrected one-click stay distinguishable on the wire", () => {
+  const { conditions, shapes, scaleInfo } = fixture();
+  const [manual, clean, fixed] = buildContribution({ conditions, shapes, scaleInfo }).shapes;
+  assert.equal(manual.origin!.method, "manual");
+  assert.equal("edited" in manual.origin!, false);
+  assert.equal(clean.origin!.method, "one_click_v1");
+  assert.equal("edited" in clean.origin!, false);
+  assert.equal("proposed_verts_norm" in clean.origin!, false);     // accepted verbatim → no correction pair
+  assert.equal(fixed.origin!.edited, true);
+  assert.deepEqual(fixed.origin!.edits, { vertex: 2, move: 1 });
+  assert.notDeepEqual(fixed.origin!.proposed_verts_norm, fixed.verts_norm); // the machine's trace ≠ the expert's fix
+  for (const s of [manual, clean, fixed]) {
+    assert.match(s.id, /^[0-9a-f-]{36}$/);
+    assert.match(s.created_at, /^\d{4}-/);
+  }
+});
+
+test("pickOrigin: whitelist — unknown keys are dropped, never spread", () => {
+  assert.deepEqual(
+    pickOrigin({
+      method: "one_click_v1", reviewed: true, edits: { vertex: 1 },
+      secret_sauce: 42, note: "call the GC about the vestibule", updated_at: "2026-07-18T12:00:00.000Z",
+    }),
+    { method: "one_click_v1", reviewed: true, edits: { vertex: 1 } },
+  );
+  assert.equal(pickOrigin(null), null);
+  assert.equal(pickOrigin({ someday_field: 1 }), null); // nothing whitelisted → origin omitted entirely
+});
+
+test("legacy v1-era shapes (no created_at, no origin) still serialize", () => {
+  const { conditions } = fixture();
+  const legacy = [{
+    id: "shp-1700000000000-1", sheet_id: SHEET, condition_id: "cnd-1",
+    measure_role: "floor_area", verts_norm: [[0.1, 0.1], [0.2, 0.1], [0.2, 0.2]],
+    computed: { area_sf: 50, perimeter_lf: 30 },
+  }];
+  const p = buildContribution({ conditions, shapes: legacy });
+  assert.equal(p.shapes.length, 1);
+  const s = p.shapes[0];
+  assert.equal(s.role, "floor_area");
+  assert.equal(s.finish, "LVT-9");
+  assert.equal(s.sheet, "sheet_1");
+  assert.equal("created_at" in s, false);
+  assert.equal("origin" in s, false);
+  assert.equal("counters" in p, false);           // nothing passed → omitted
+  assert.deepEqual(p.sheets, [{ sheet: "sheet_1" }]); // no scaleInfo → provenance simply absent
+});
+
+test("counters: an all-empty tally is omitted; a real one rides", () => {
+  const { conditions, shapes } = fixture();
+  const empty = buildContribution({ conditions, shapes, counters: { shapes_deleted: {} } });
+  assert.equal("counters" in empty, false);
+  const real = buildContribution({ conditions, shapes, counters: { shapes_deleted: { manual: 2 } } });
+  assert.deepEqual(real.counters, { shapes_deleted: { manual: 2 } });
+});

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,5 +1,12 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+
+// The one source of truth for the app version — package.json — inlined as
+// __APP_VERSION__ so contributions can carry generator_version without a
+// runtime fetch. Guarded with `typeof` at the use site so the Node test
+// runner (no Vite, no define) sees plain undefined instead of a crash.
+const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
 
 // OpenTakeoff is a client-only static app: the takeoff canvas runs entirely in
 // the browser (pdf.js + canvas + the geometry libs), persists to IndexedDB /
@@ -11,6 +18,7 @@ import react from "@vitejs/plugin-react";
 // works fully; the AI hooks just stay dormant.
 export default defineConfig({
   plugins: [react()],
+  define: { __APP_VERSION__: JSON.stringify(pkg.version) },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
Second PR of the contribution.v2 series, on the PR-1 provenance primitives.

- **\`opentakeoff.contribution.v2\`**: per-shape \`id\` (opaque durable UUID) + \`created_at\` + whitelisted \`origin\` (\`pickOrigin\` — registered keys only, never a spread; corrected machine shapes carry the frozen \`proposed_verts_norm\` beside the expert's final geometry). Envelope gains \`generator_version\`, per-sheet \`scale_source\` (provenance only — scale values never leave), aggregate \`counters\`. \`updated_at\`/edit timing NEVER ride — that's the explicit-gate vs. ambient boundary.
- **Capture server** banks \`capture.v2\` rows, accepts v1 AND v2 (unknown schemas still 400), fingerprint unchanged (no double-banking), \`origin_method\` defaults to honest \`"unknown"\`, \`/health\` gains an origin_methods map, selftest grows the triad + v1-legacy + rejection checks (16/16).
- **\`docs/CONTRIBUTION_SPEC.md\`** — the normative wire + row contract: privacy MUST-NOTs (durable-id linkage disclosed), field tables, provenance vocabulary + IoU correction-magnitude recipe, versioning policy, and the honest scope boundary (ambient event-stream = commercial).
- Contribute modal names the new provenance bullet; README line-count claims updated honestly.

## Verified live
Dev app + local capture server: detected-scale sample plan, drew the triad (manual / clean one-click / corrected one-click with a vertex drag), contributed — three \`capture.v2\` rows banked fully distinguishable (corrected row: \`edited\` + \`edits:{vertex:1}\` + 25-vertex frozen ring ≠ final verts), \`scale_source:"detected"\` joined, raw payload leak-checked (no units_per_px / updated_at / label text). \`npm run check\` green (683 tests); selftest 16/16.