### PR TITLE
Add Flip Horizontal/Vertical to the Edit menu; label Redo

### DIFF
--- a/web/src/lib/geometry.js
+++ b/web/src/lib/geometry.js
@@ -113,6 +113,18 @@ export function cloudBezier(x0, y0, x1, y1) {
   return { start: [ax0, ay0], segments };
 }
 
+// Mirror a normalized vertex ring about its OWN bbox center on one axis.
+// axis "h" flips left↔right (reflects X), "v" flips top↔bottom (reflects Y).
+// Isometry: perimeter/area are invariant, so quantities never change.
+export function reflectVertsNorm(verts, axis) {
+  if (!Array.isArray(verts) || verts.length < 2) return verts;
+  const ax = axis === "v" ? 1 : 0;
+  let lo = Infinity, hi = -Infinity;
+  for (const v of verts) { if (v[ax] < lo) lo = v[ax]; if (v[ax] > hi) hi = v[ax]; }
+  const s = lo + hi;
+  return verts.map((v) => (ax === 0 ? [s - v[0], v[1]] : [v[0], s - v[1]]));
+}
+
 // ── snap-to-vector spatial hash. The op-list walk that feeds it (endpoints +
 // line segments for One-Click Area) lives in lib/oneclick: extractVectorGeometry.
 // `cell` is the caller's tuning (raster px per bucket) — see SNAP_CELL in the canvas.

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -45,7 +45,7 @@ import { sanitizeShapeLabels, sanitizeShapeLabelsOnShapes, renameShapeLabel, sha
 import { buildMarkedSetPdf, downloadBytes } from "../lib/markedset.js";
 import { loadProfiles } from "../lib/identity.js";
 import { resolveBranding, loadBrandingSelection } from "../lib/branding.js";
-import { starPath, cloudPath, thinStroke, strokePathD, chiselRibbon, buildSnapGrid, nearestSnap, ANGLE_TOL, angleSnap, closedMetrics, openLen, pointInPoly, hitShape, arrowheadPath, distToSeg } from "../lib/geometry.js";
+import { starPath, cloudPath, thinStroke, strokePathD, chiselRibbon, buildSnapGrid, nearestSnap, ANGLE_TOL, angleSnap, closedMetrics, openLen, pointInPoly, hitShape, arrowheadPath, distToSeg, reflectVertsNorm } from "../lib/geometry.js";
 import { dashArrayFor, boostForDark, clampWeight, snapWeight, LINE_STYLES, LINE_STYLE_IDS, WEIGHT_STEPS } from "../lib/lineStyles.js";
 import { nextRfiNumber } from "../lib/rfi.js";
 import { libFields, matFieldOverridden, libPushPatch, libRevertPatch, libEntryPatch, matEditPatch } from "../lib/materials.js";
@@ -2955,6 +2955,20 @@ export default function TakeoffCanvas() {
     clipRef.current = [clipEntry(sel)];
     pasteClipboard();
   }
+  // Mirror the selected shape about its own bbox center — an isometry, so SF/LF
+  // never change. Routes through the same geom/vertex command path as a manual
+  // vertex drag, which gives correct undo/redo and provenance stamping for free.
+  function flipSelected(axis) {
+    const sel = shapes.find((s) => s.id === selectedId);
+    if (!sel || !Array.isArray(sel.verts_norm) || sel.verts_norm.length < 2) {
+      setCommitMsg("Select an area or linear takeoff to flip."); return;
+    }
+    const vn = reflectVertsNorm(sel.verts_norm, axis);
+    dispatchShape({
+      type: "geom", id: sel.id, editKind: "vertex",
+      verts_norm: vn, computed: recomputeShape({ ...sel, verts_norm: vn }), prev: geomSnapshot(sel),
+    });
+  }
   // ── markup (cloud / callout / text) — annotations, not measurements ─────────
   // markupDraft holds STAGE px (so the live preview spans panels); a markup
   // belongs to the panel of its FIRST click and normalizes against that panel.
@@ -4501,9 +4515,13 @@ export default function TakeoffCanvas() {
               { id: "paste", icon: "paste", label: "Paste", shortcut: "⌘V", disabled: !clipRef.current.length, onSelect: () => pasteClipboard() },
               { id: "dup", icon: "duplicate", label: "Duplicate", shortcut: "⌘D", disabled: !selectedId, onSelect: duplicateSelected },
               "divider",
+              { id: "flipH", label: "Flip Horizontal", disabled: !selectedId, onSelect: () => flipSelected("h") },
+              { id: "flipV", label: "Flip Vertical", disabled: !selectedId, onSelect: () => flipSelected("v") },
+              "divider",
               { id: "finish", icon: "check", label: `Finish shape${poly.length ? ` (${poly.length} pts)` : ""}`, shortcut: "↵", disabled: !finishOk, onSelect: finishShape },
               { id: "undopt", icon: "undo", label: "Undo last point", shortcut: "⌘Z", disabled: !poly.length, onSelect: () => setPoly((q) => q.slice(0, -1)) },
               { id: "undoshape", icon: "undo", label: "Undo last shape", disabled: !visibleShapes.length, onSelect: undoLast },
+              { id: "redo", label: "Redo", shortcut: "⇧⌘Z", onSelect: redoShapeCommand },
               "divider",
               { id: "del", icon: "close", label: "Delete selected", shortcut: "⌫", disabled: !selectedId, tint: "var(--c-danger)", onSelect: deleteSelected },
             ]}

--- a/web/test/geometry.test.ts
+++ b/web/test/geometry.test.ts
@@ -8,7 +8,7 @@ import {
   SENS_STRICT, SENS_BALANCED, SENS_AGGRESSIVE,
   type Point, type MaskObj,
 } from "../src/lib/oneclick.ts";
-import { cloudBezier, cloudPath, arrowheadPath } from "../src/lib/geometry.js";
+import { cloudBezier, cloudPath, arrowheadPath, reflectVertsNorm, closedMetrics } from "../src/lib/geometry.js";
 
 // a closed square room, as flat boundary segments in image px
 function squareSegs(x0: number, y0: number, x1: number, y1: number): number[] {
@@ -335,6 +335,45 @@ test("cloudBezier: degenerate zero-size box yields finite points", () => {
   assert.ok(Number.isFinite(start[0]) && Number.isFinite(start[1]), "start finite");
   for (const seg of segments) for (const [x, y] of seg) {
     assert.ok(Number.isFinite(x) && Number.isFinite(y), "control/end finite");
+  }
+});
+
+// ── Flip Horizontal/Vertical (reflectVertsNorm) ─────────────────────────────
+const L_SHAPE: Point[] = [[0.1, 0.1], [0.5, 0.1], [0.5, 0.3], [0.3, 0.3], [0.3, 0.5], [0.1, 0.5]];
+
+test("reflectVertsNorm: horizontal flip mirrors X about the ring's own bbox center, area/perimeter unchanged", () => {
+  const flipped = reflectVertsNorm(L_SHAPE, "h");
+  const before = closedMetrics(L_SHAPE), after = closedMetrics(flipped);
+  assert.ok(Math.abs(before.area - after.area) < 1e-9, "area invariant under flip");
+  assert.ok(Math.abs(before.perim - after.perim) < 1e-9, "perimeter invariant under flip");
+  const xs = L_SHAPE.map((p) => p[0]), lo = Math.min(...xs), hi = Math.max(...xs), s = lo + hi;
+  for (let i = 0; i < L_SHAPE.length; i++) {
+    assert.ok(Math.abs(flipped[i][0] - (s - L_SHAPE[i][0])) < 1e-9, "X mirrors about bbox center");
+    assert.equal(flipped[i][1], L_SHAPE[i][1], "Y untouched by a horizontal flip");
+  }
+});
+
+test("reflectVertsNorm: vertical flip mirrors Y, area/perimeter unchanged, X untouched", () => {
+  const flipped = reflectVertsNorm(L_SHAPE, "v");
+  const before = closedMetrics(L_SHAPE), after = closedMetrics(flipped);
+  assert.ok(Math.abs(before.area - after.area) < 1e-9);
+  assert.ok(Math.abs(before.perim - after.perim) < 1e-9);
+  for (let i = 0; i < L_SHAPE.length; i++) {
+    assert.equal(flipped[i][0], L_SHAPE[i][0], "X untouched by a vertical flip");
+  }
+});
+
+test("reflectVertsNorm: a single-vertex ring (count marker) is a safe no-op", () => {
+  const pt: Point[] = [[0.4, 0.6]];
+  assert.deepEqual(reflectVertsNorm(pt, "h"), pt);
+  assert.deepEqual(reflectVertsNorm(pt, "v"), pt);
+});
+
+test("reflectVertsNorm: applying the same flip twice returns the original ring", () => {
+  const twice = reflectVertsNorm(reflectVertsNorm(L_SHAPE, "h"), "h");
+  for (let i = 0; i < L_SHAPE.length; i++) {
+    assert.ok(Math.abs(twice[i][0] - L_SHAPE[i][0]) < 1e-9);
+    assert.ok(Math.abs(twice[i][1] - L_SHAPE[i][1]) < 1e-9);
   }
 });
 


### PR DESCRIPTION
## Summary
- A Spline-parity toolbar review turned up one real gap out of four candidates: **Flip Horizontal / Flip Vertical**. (The other three — a pinned 1-9 condition quick-palette, reusable assembly templates, and Regroup — already exist and are fully wired in OpenTakeoff.)
- `reflectVertsNorm(verts, axis)` (`web/src/lib/geometry.js`) mirrors a shape's normalized vertex ring about its own bbox center — an isometry, so SF/LF never change. `flipSelected(axis)` (`TakeoffCanvas.jsx`) routes the result through the existing `dispatchShape` `geom`/vertex command path — the same one a manual vertex drag uses — so undo/redo and provenance stamping come for free, no parallel state update.
- Added to the Edit menu only: **Flip Horizontal** / **Flip Vertical**, disabled without a selection, matching the existing Copy/Duplicate/Delete pattern. No keyboard shortcut — the single-letter tool hotkeys don't guard Shift, so a Figma-style ⇧H/⇧V would collide with existing tool letters.
- Folded in a small mid-session ask: the Edit menu had no visible **Redo** entry even though ⇧⌘Z already worked via keyboard. Added a "Redo" label pointing at the existing `redoShapeCommand()`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 723/727 pass; same 4 pre-existing Node-version `localStorage` test failures as the last two PRs on this branch (unrelated files — see `reference_ot_node_version_gap`), not a regression. 4 new `reflectVertsNorm` unit tests pass (horizontal mirror, vertical mirror, area/perimeter invariance, single-vertex no-op, double-flip returns original).
- [x] `npm run build` — clean, 291 modules
- [x] Manually verified in the running app: traced an asymmetric polygon, Flip Horizontal correctly mirrored it left↔right (confirmed visually — the angled edge moved from bottom-right to bottom-left) with SF unchanged (57.8); Flip Vertical mirrored top↔bottom; ⌘Z undo and ⇧⌘Z redo both correctly stepped through the flip history; clicking the new **Redo** menu item (not just the keyboard shortcut) correctly redid the last flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)