### PR TITLE
docs: fix production-URL attribution — this repo deploys to opentakeoff.netlify.app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,18 +16,22 @@ npm run check    # typecheck + lint + test + build — exactly what CI runs; gre
 
 ## Shipping — the required steps, every change
 
-`main` is protected on GitHub (PRs only, green `web` check, branch up to date,
-no force-pushes — admins included) and a local pre-commit hook rejects commits
-made on `main`. **Merging to `main` deploys to production**
-(<https://takeoff.345flooring.com>) via `.github/workflows/deploy.yml`, which
+`main` is protected on GitHub via a ruleset (PR-only, one approving review,
+green `web` check, branch up to date — the repo owner has a standing bypass
+as the solo maintainer). **Merging to `main` deploys to production**
+(<https://opentakeoff.netlify.app>) via `.github/workflows/deploy.yml`, which
 re-runs `npm run check` and publishes `web/dist` to Netlify with `--no-build`
 — Netlify never builds anything itself.
 
-> **Production is <https://takeoff.345flooring.com> — nothing else.**
-> <https://opentakeoff.netlify.app> is the *parent repo's*
-> (Kentucky-ai/opentakeoff) demo deployment; the inherited README badge and
-> links still point there, but this fork does not serve it. Verify deploys
-> against takeoff.345flooring.com only.
+> **This is the canonical `Kentucky-ai/opentakeoff` repo — production is
+> <https://opentakeoff.netlify.app>, nothing else.** A downstream fork
+> (`knmurphy/opentakeoff`) tracks this repo as its own upstream and deploys
+> separately to `takeoff.345flooring.com` — that URL belongs to *that* fork,
+> not this repo. If you're seeing `takeoff.345flooring.com` referenced
+> elsewhere in this repo's docs (`docs/DEPLOYMENT.md`,
+> `docs/PARENT_FORK_PORTS.md`), it's leftover content from that fork's own
+> `AGENTS.md`/docs that rode along in a wholesale history merge (2026-07-13) —
+> treat it as describing the *downstream* fork's deployment, not this one's.
 
 So:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,8 +2,13 @@
 
 How OpenTakeoff ships: every change lands on `main` through a pull request,
 and every merge to `main` is automatically deployed to production at
-<https://takeoff.345flooring.com>. There is no manual deploy step and no
+<https://opentakeoff.netlify.app>. There is no manual deploy step and no
 "deploy later" state — **a merge is a deploy**.
+
+(This file's mechanism description is accurate for this repo — it originally
+came in from a downstream fork's own docs during the 2026-07-13 history
+merge, which is why earlier revisions named that fork's own deployment,
+`takeoff.345flooring.com`, instead of this repo's. See `AGENTS.md`.)
 
 ## The pipeline
 
@@ -15,7 +20,7 @@ branch → npm run check (local) → PR → CI (`web` check) → squash-merge
                                           npm ci → npm run check → netlify deploy
                                                              │
                                                              ▼
-                                          https://takeoff.345flooring.com
+                                          https://opentakeoff.netlify.app
 ```
 
 - **CI** (`.github/workflows/ci.yml`) runs on every PR: `npm ci` then


### PR DESCRIPTION
## Summary

`AGENTS.md` and `docs/DEPLOYMENT.md` both claimed this repo's production is `takeoff.345flooring.com`. That's a real URL, but it belongs to a downstream fork (`knmurphy/opentakeoff`) — its own fork-specific docs rode along into this repo during the 2026-07-13 wholesale history merge (PR #26) and never got re-scoped for their new home.

Confirmed against every one of tonight's 5 merged PRs: every CI deploy-preview and the actual Netlify site tied to `Kentucky-ai/opentakeoff` is `opentakeoff.netlify.app`.

`docs/PARENT_FORK_PORTS.md` has the same provenance (also written in the downstream fork's own voice, describing its port backlog from this repo) but is a live, dated status list rather than a simple wrong-fact fix — left alone pending a decision on whether to keep it (as this repo's own view of what the fork still lacks), rewrite it from this repo's perspective, or retire it.

## Verification
- [x] Docs-only change — `npm run typecheck` / `npm run lint` clean (no code touched)
- [x] Grepped the whole repo for `345flooring` after the fix — only the two illustrative "example Google Workspace domain" mentions in `docs/GLIDE_INTEGRATION.md`/`docs/GOOGLE_SETUP.md` remain, which are fine (generic tutorial examples), plus the flagged `docs/PARENT_FORK_PORTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)