### PR TITLE
Fix jagged blocky rendering of very large ingested images (compositor-degraded oversized canvas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
 ## 2026-07-20
 
+### Fixed
+- **Jagged, blocky linework on very large ingested images.** An ingested image becomes a 1 px = 1 pt PDF page, so a 7920×5280 scan minted a 7920-point-wide page — and the base raster's fixed ×2 scale then built a 15840×10560 canvas (669 MB backing store). The pixels in it were actually crisp, but a canvas that size blows past Chrome's GPU budget, so the compositor silently displays a degraded low-res proxy: giant nearest-neighbor blocks at any zoom, on that sheet only. `autoRenderScale`'s floor no longer overrides the physical caps — oversized pages now render below the ×2 baseline, inside the 28 MP panel budget (the existing `factorFor` scale plumbing already handles non-baseline rasters), and deep zoom stays sharp through the detail-view re-render as usual. Regression-tested in `web/test/renderBudget.test.ts`.
+
 ### Tests
 - **MCP tool-conformance suite — every tool, both directions** (`mcp/test/conformance.test.ts`, closes #27). Each of the eleven tools now has: a canonical valid call whose `structuredContent` is validated against the tool's declared output schema and byte-checked against the back-compat text item; semantic-misuse cases proving a clean `isError` + JSON `{error}` reply (no-plan gates, unknown sheets, degenerate calibrations, unenclosed one-click seeds, non-PDF documents, unwritable export paths); and schema-invalid-argument cases pinning the SDK's `-32602` input-validation surface — with follow-up calls proving the session survives every failure. Also covers title-block sheet addressing, exact scale math on the demo plan, deduct-role subtraction, provenance receipts on export, and `read_sheet_text` region windows.
 

--- a/web/src/lib/canvasUtil.js
+++ b/web/src/lib/canvasUtil.js
@@ -17,12 +17,16 @@ import {
 } from "./canvasConstants.js";
 
 // Largest pdf.js render scale a wPt×hPt-point page can use within the base budget;
-// never below the baseline RENDER_SCALE, never above the ceiling.
+// prefers the baseline RENDER_SCALE, never above the ceiling — and never above the
+// physical caps: an oversized page (an ingested image is a 1px=1pt page, so a
+// 7920×5280 scan is a 7920pt page) must render BELOW baseline or the canvas blows
+// the budget (669MB at ×2) and Chrome's compositor degrades it to a blocky proxy.
 export const autoRenderScale = (wPt, hPt) => {
   if (!(wPt > 0 && hPt > 0)) return RENDER_SCALE;
   const byDim  = Math.min(MAX_CANVAS_DIM / wPt, MAX_CANVAS_DIM / hPt);
   const byArea = Math.sqrt(MAX_PANEL_AREA / (wPt * hPt));
-  return Math.max(RENDER_SCALE, Math.min(QUALITY_CEILING, byDim, byArea));
+  const cap = Math.min(byDim, byArea);
+  return Math.min(Math.max(RENDER_SCALE, Math.min(QUALITY_CEILING, cap)), cap);
 };
 
 // Invert a canvas's pixels in place: one difference-with-white pass (an

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -1121,7 +1121,10 @@ export default function TakeoffCanvas() {
         const pageNum = Math.min(Math.max(1, pn), pdf.numPages || 1);
         const pageObj = await pdf.getPage(pageNum); if (stale()) return;
         const base = pageObj.getViewport({ scale: 1 });   // page size in PDF points
-        const rs = hiResKeys.includes(key) ? autoRenderScale(base.width, base.height) : RENDER_SCALE;
+        // base raster obeys the same budget cap: for oversized pages (image ingest
+        // mints 1px=1pt pages) autoRenderScale lands below RENDER_SCALE and wins
+        const auto = autoRenderScale(base.width, base.height);
+        const rs = hiResKeys.includes(key) ? auto : Math.min(RENDER_SCALE, auto);
         const viewport = pageObj.getViewport({ scale: rs });
         pageObjsRef.current.set(key, pageObj);     // kept for on-demand detail-view re-render
         renderScalesRef.current.set(key, rs);      // base raster scale — detail view renders at a multiple of it

--- a/web/test/renderBudget.test.ts
+++ b/web/test/renderBudget.test.ts
@@ -1,0 +1,37 @@
+// autoRenderScale — the base-raster budget contract. The floor at RENDER_SCALE
+// must never override the physical caps: an ingested image is a 1px=1pt page,
+// so a large scan mints a page thousands of points wide, and rendering it at
+// the ×2 baseline builds a canvas past the panel budget — Chrome then composites
+// a degraded low-res proxy (the "jagged linework" bug, 2026-07-20).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { autoRenderScale } from "../src/lib/canvasUtil.js";
+import { RENDER_SCALE } from "../src/lib/sheets";
+import { MAX_PANEL_AREA, MAX_CANVAS_DIM, QUALITY_CEILING } from "../src/lib/canvasConstants.js";
+
+const areaAt = (w: number, h: number, s: number) => w * s * (h * s);
+
+test("normal plan pages keep the ×2 baseline (budget cap far above it)", () => {
+  // ARCH D 36×24in = 2592×1728 pt
+  assert.equal(Math.min(RENDER_SCALE, autoRenderScale(2592, 1728)), RENDER_SCALE);
+  assert.ok(autoRenderScale(2592, 1728) >= RENDER_SCALE);
+});
+
+test("small pages ride the quality ceiling, not the floor", () => {
+  // 500×600 pt: the area budget would allow >8× — the ceiling binds instead
+  assert.equal(autoRenderScale(500, 600), QUALITY_CEILING);
+});
+
+test("an oversized 1px=1pt image page renders BELOW baseline, inside the panel budget", () => {
+  // the finishplan-17 case: a 7920×5280 px scan → 7920×5280 pt page
+  const s = autoRenderScale(7920, 5280);
+  assert.ok(s < RENDER_SCALE, `scale ${s} must drop below the ×2 baseline`);
+  assert.ok(areaAt(7920, 5280, s) <= MAX_PANEL_AREA * 1.0001, "canvas area within MAX_PANEL_AREA");
+  assert.ok(7920 * s <= MAX_CANVAS_DIM && 5280 * s <= MAX_CANVAS_DIM, "within the per-side cap");
+  assert.ok(s > 0.5, "still a usable working resolution");
+});
+
+test("degenerate dims fall back to the baseline", () => {
+  assert.equal(autoRenderScale(0, 0), RENDER_SCALE);
+  assert.equal(autoRenderScale(-1, 100), RENDER_SCALE);
+});


### PR DESCRIPTION
Field report: one sheet in a project rendered as giant nearest-neighbor blocks at any zoom while every other sheet was crisp.

**Root cause.** The bad sheet was an ingested image. `imageToPdf` wraps images at 1 px = 1 pt, so a 7920×5280 scan mints a 7920-point-wide page. The base raster path pins scale ×2 (`autoRenderScale` floors at `RENDER_SCALE`, and the non-hi-res branch uses `RENDER_SCALE` outright), so that page built a 15840×10560 canvas — a 669 MB backing store. The drawn pixels were verifiably crisp (`getImageData` shows 2–4-px line runs), but a canvas that size exceeds Chrome's GPU budget and the compositor silently displays a degraded low-res proxy. Blocky on screen, sharp in memory, no console error — and only on 1 px = 1 pt image pages, because real PDF pages are ~2000–3000 pt wide and never trip it.

**Fix.** `autoRenderScale`'s baseline floor now yields to the physical caps (`MAX_CANVAS_DIM`, `MAX_PANEL_AREA`), and the base branch takes `min(RENDER_SCALE, autoRenderScale(...))`. Normal pages are byte-identical (their cap sits far above ×2). The oversized page renders at ~×0.82 into a 6481×4321 canvas — exactly the 28 MP panel budget — and the existing `factorFor` plumbing handles the non-baseline scale (hi-res already exercises it). Deep zoom stays sharp through the detail-view crop re-render, which has a live pdf.js page for ingested images too.

**Verified in the running app** with the exact problem file: canvas allocation 167 MP → 28.0 MP, fit view clean, deep zoom shows thin continuous anti-aliased lines where prod shows the staircase. Regression contract in `web/test/renderBudget.test.ts` (4 tests: normal pages keep baseline, ceiling binds on small pages, oversized pages drop below baseline inside budget, degenerate dims).