### PR TITLE
opentakeoff-mcp 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-07-21 — opentakeoff-mcp 0.5.0
+
+### Added
+- **`detect_rooms` — the eleventh tool: batch room detection from the sheet's own labels.** One call reads every room-number label off the sheet's text layer and runs the One-Click flood at each; only cleanly-traced rooms return (a leaking or dense-linework label is silently withheld, matching `one_click`'s precision stance). Same contract as `one_click`: px-only preview without a scale, per-room `area_sf`/`perimeter_lf` with one, `condition` commits every detected room with the standard agent/unreviewed provenance stamp, and a declared `outputSchema` like the other ten.
+- **A per-tool conformance suite backs the whole surface** (`mcp/test/conformance.test.ts`, closes #27): every tool's valid replies are schema-validated, every misuse path is a clean `isError` + JSON `{error}`, schema-invalid arguments pin the SDK's `-32602` surface, and the session is proven to survive every failure. Runs in CI on Ubuntu and Windows.
+
 ## 2026-07-20
 
 ### Fixed

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Release bump: detect_rooms (11th tool, merged in #72) has been sitting unreleased on main — npx users still get 10 tools. Version 0.5.0 across mcp/package.json + mcp/server.json (both fields), CHANGELOG release section (detect_rooms + the #27 conformance suite now backing the surface). Local gate green: typecheck, 36/36 tests, build, dist smoke. Ceremony after merge: npm publish (security-key touch) then tag mcp-v0.5.0 for the OIDC registry publish + GitHub release + .mcpb attach.