### PR TITLE
feat(voice): wire intents into canvas actions (RFC #59 slice 2)

### DIFF
--- a/web/src/lib/voiceActions.ts
+++ b/web/src/lib/voiceActions.ts
@@ -1,0 +1,105 @@
+// Voice intent → app action dispatcher (RFC #59, slice 2). PURE and DOM-free.
+// Routes each parsed intent through an injected capability object that the
+// canvas builds from the SAME functions its own buttons call (mintCondition /
+// activateCondition / updateCondById / addLabel / activateLabel / addMarkup) —
+// the agentTools.js precedent: no voice-only code path may touch shapes or
+// conditions directly (RFC #59 testing bar, mutation safety). The capability
+// seam is also what makes bullet-7's proof testable: tests drive a state model
+// through this dispatcher and through the equivalent UI call sequence and
+// assert the results deep-equal.
+//
+// Outcome messages follow the commitMsg bar's convention: failures start with
+// "Couldn't" (isDangerMsg renders them red + sticky), successes are short
+// green confirmations.
+import { parseVoiceIntent, type Intent, type RejectReason } from "./voiceIntent.ts";
+
+export type VoiceCapabilities = {
+  getConditions(): Array<{ id: string; finish_tag: string }>;
+  getShapeLabels(): string[];
+  /** Active condition id, "" when none — the set_waste guard. */
+  getActiveConditionId(): string;
+  /** Canvas binds {reassign:false} — programmatic activation never reassigns a selected shape. */
+  activateCondition(id: string): void;
+  /** mintCondition — the one shared minting path (UI +condition and the #63 agent use it too). */
+  createCondition(tag: string): { id: string; finish_tag: string };
+  /** BY ID, not active-based: combo intents patch a condition activated in the same handler,
+   *  before React re-renders, so the active-based updateCond would hit the OLD active. */
+  updateCondition(id: string, patch: { waste_pct: number }): void;
+  addLabel(label: string): void;
+  activateLabel(label: string | null): void;
+  /** Canvas anchors the note (text markup on the focused sheet). */
+  addNote(text: string): void;
+};
+
+export type VoiceOutcome = { ok: boolean; message: string };
+
+/** Every value MUST start with "Couldn't" — that prefix is what the commitMsg
+ *  bar's isDangerMsg keys on to render red + sticky. */
+export const REJECTION_MESSAGES: Record<RejectReason, string> = {
+  empty: "Couldn't hear a command.",
+  unrecognized: 'Couldn\'t parse that — try "CPT-1", "waste 7", "label Phase 1", or "note …".',
+  unknown_tag: "Couldn't match that tag — say a live condition tag, or a Div-9 code like CPT-2 to create one.",
+  bad_number: 'Couldn\'t read the waste number — say 0–100, e.g. "waste 7" or "waste 7.5".',
+  trailing_words: "Couldn't parse — extra words after the command. One command at a time.",
+};
+
+const fail = (message: string): VoiceOutcome => ({ ok: false, message });
+const done = (message: string): VoiceOutcome => ({ ok: true, message });
+
+/** Apply one parsed intent through the capabilities. Never throws; a failed
+ *  precondition returns ok:false with a "Couldn't …" message and NO calls. */
+export function applyVoiceIntent(caps: VoiceCapabilities, intent: Intent): VoiceOutcome {
+  switch (intent.kind) {
+    case "activate_condition": {
+      let cond: { id: string; finish_tag: string } | undefined;
+      if (intent.known) {
+        // the parser returned the ctx literal, so exact finish_tag lookup holds
+        cond = caps.getConditions().find((c) => c.finish_tag === intent.tag);
+        if (!cond) return fail(`Couldn't find condition ${intent.tag}.`);
+      } else {
+        // defensive dedup (agentTools create_condition precedent) before minting
+        cond =
+          caps.getConditions().find((c) => c.finish_tag.toUpperCase() === intent.tag.toUpperCase()) ??
+          caps.createCondition(intent.tag);
+      }
+      caps.activateCondition(cond.id);
+      if (intent.waste !== undefined) {
+        caps.updateCondition(cond.id, { waste_pct: intent.waste });
+        return done(
+          intent.known
+            ? `${cond.finish_tag} active — waste ${intent.waste}%.`
+            : `Created ${cond.finish_tag} — active, waste ${intent.waste}%.`,
+        );
+      }
+      return done(intent.known ? `${cond.finish_tag} active.` : `Created ${cond.finish_tag} — active.`);
+    }
+    case "set_waste": {
+      const id = caps.getActiveConditionId();
+      if (!id) return fail("Couldn't set waste — no active condition.");
+      caps.updateCondition(id, { waste_pct: intent.waste });
+      const tag = caps.getConditions().find((c) => c.id === id)?.finish_tag ?? "active condition";
+      return done(`Waste ${intent.waste}% on ${tag}.`);
+    }
+    case "set_label": {
+      if (!intent.known) caps.addLabel(intent.label);
+      caps.activateLabel(intent.label);
+      return done(intent.known ? `Label ${intent.label} active.` : `Added label ${intent.label} — active.`);
+    }
+    case "clear_label":
+      caps.activateLabel(null);
+      return done("Label cleared.");
+    case "add_note":
+      caps.addNote(intent.text);
+      return done("Note added — see Markups.");
+  }
+}
+
+/** Parse + apply in one call — the canvas's single entry point. */
+export function runVoiceCommand(caps: VoiceCapabilities, transcript: string): VoiceOutcome {
+  const parsed = parseVoiceIntent(transcript, {
+    conditionTags: caps.getConditions().map((c) => c.finish_tag),
+    shapeLabels: caps.getShapeLabels(),
+  });
+  if (!parsed.ok) return fail(REJECTION_MESSAGES[parsed.reason]);
+  return applyVoiceIntent(caps, parsed.intent);
+}

--- a/web/src/lib/voiceIntent.ts
+++ b/web/src/lib/voiceIntent.ts
@@ -219,7 +219,8 @@ function ctxTagLookup(ctx: VoiceContext): Map<string, string> {
 //   • prefix token + integer, e.g. "cpt one", "cpt 1"
 //   • pre-joined token, e.g. "cpt-1" / "cpt1"
 //   • any ctx tag spoken plainly, e.g. "p two", bare "c"
-// Returns the canonical tag plus whether it is live in ctx; null if nothing
+// Returns the ctx LITERAL for live tags (so callers can look conditions up by
+// exact finish_tag) or the canonical tag for create-offers; null if nothing
 // tag-shaped starts here.
 function takeTag(
   tokens: string[],
@@ -231,7 +232,7 @@ function takeTag(
   const finish = (prefix: string, num: number | null, next: number) => {
     const canon = num === null ? prefix.toUpperCase() : canonTag(`${prefix}-${num}`);
     const hit = live.get(canon);
-    if (hit !== undefined) return { tag: canonTag(hit), known: true, next };
+    if (hit !== undefined) return { tag: hit, known: true, next };
     const bare = canon.split("-")[0];
     if (num !== null && Number.isInteger(num) && num >= 1 && num <= 99 && DIV9_PREFIXES.has(bare))
       return { tag: canon, known: false, next };

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -62,6 +62,7 @@ import AgentPanel from "../components/AgentPanel.jsx";
 import AiSettings from "../components/AiSettings.jsx";
 import { AGENT_TOOL_DEFS, executeAgentTool, agentScaleGate } from "../lib/agentTools.js";
 import { runAgentLoop } from "../lib/agentLoop.js";
+import { runVoiceCommand } from "../lib/voiceActions";
 import { aiConfig, isAiConfigured } from "../lib/ai.js";
 import AccountChip from "../components/AccountChip.jsx";
 import { useGoogleAuth } from "../lib/google/AuthContext.jsx";
@@ -3638,6 +3639,34 @@ export default function TakeoffCanvas() {
     };
   }
 
+  // Voice-command capabilities (RFC #59 slice 2) — every entry binds an action
+  // the UI already exposes; the dispatcher (voiceActions.ts) never touches
+  // state directly. getConditions reads the live mirror (mintCondition updates
+  // it mid-handler); the rest are safe render closures because the voice path
+  // is fully synchronous, unlike the agent loop. Programmatic activation
+  // passes {reassign:false} — same policy as hotkeys and Library Apply.
+  function buildVoiceCtx() {
+    return {
+      getConditions: () => agentStateRef.current.conditions.map((c) => ({ id: c.id, finish_tag: c.finish_tag })),
+      getShapeLabels: () => shapeLabels,
+      getActiveConditionId: () => activeCond || "",
+      activateCondition: (id) => activateCondition(id, { reassign: false }),
+      createCondition: (tag) => mintCondition(tag),
+      updateCondition: updateCondById,
+      addLabel,
+      activateLabel,
+      // top-center of the focused sheet: text markups render centered on `at`,
+      // and addMarkup auto-opens the Markups dock, so the note is immediately
+      // visible and draggable — the anchor is a starting point, not a commitment
+      addNote: (text) => addMarkup({ type: "text", at: [0.5, 0.06], text }, focusPanel.key),
+    };
+  }
+  const onVoiceCommand = (text) => {
+    const out = runVoiceCommand(buildVoiceCtx(), text);
+    setCommitMsg(out.message);
+    return out.ok;
+  };
+
   // ── the accept gate ─────────────────────────────────────────────────────────
   // Accept = the explicit human review one-click's Create models: the shape
   // commits through dispatchShape `add` (id/created_at minted there) with the
@@ -3913,7 +3942,11 @@ export default function TakeoffCanvas() {
   }
   // every condition-editor save lands here — a bare updated_at is the whole
   // provenance story for conditions (no origin machinery; they're all manual)
-  const updateCond = (patch) => setConditions((cs) => cs.map((c) => (c.id === activeCond ? { ...c, ...patch, updated_at: nowIso() } : c)));
+  // By-id core + active-based convenience: one save chokepoint. Voice combo
+  // intents ("cpt one waste seven") patch a condition activated in the SAME
+  // handler, before re-render — the active-based form would hit the old active.
+  const updateCondById = (id, patch) => setConditions((cs) => cs.map((c) => (c.id === id ? { ...c, ...patch, updated_at: nowIso() } : c)));
+  const updateCond = (patch) => updateCondById(activeCond, patch);
 
   // delete a condition entirely (and its takeoffs); pick a new active one
   function deleteCondition(id) {
@@ -4674,6 +4707,22 @@ export default function TakeoffCanvas() {
             <option value="">No label</option>
             {shapeLabels.map((v) => <option key={v} value={v}>{v}</option>)}
           </select>
+        )}
+        {/* Typed voice command (RFC #59 slice 2): the same grammar push-to-talk
+            will feed — a keyboard command line meanwhile, and the accessibility
+            path. Focus suppresses canvas shortcuts via the existing INPUT guards. */}
+        {cluster("Command",
+          <input
+            type="text"
+            placeholder="cpt 1 · waste 7 · label · note"
+            title={'Command line (RFC #59): a condition tag ("CPT-1", "carpet one", "tile 2 waste 5"), "waste 7", "label Phase 1", "clear label", or "note …" — Enter runs it through the same actions the buttons use. Push-to-talk dictation will feed this box.'}
+            onKeyDown={(e) => {
+              if (e.key !== "Enter") return;
+              const v = e.currentTarget.value.trim();
+              if (v && onVoiceCommand(v)) e.currentTarget.value = "";
+            }}
+            style={{ fontFamily: "var(--f-mono)", fontSize: 11.5, padding: "5px 6px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", width: 150 }}
+          />
         )}
         <div style={{ flex: 1 }} />
         {cluster(`Scale — ${labelFor(focusPanel)}`,

--- a/web/test/voiceActions.test.ts
+++ b/web/test/voiceActions.test.ts
@@ -1,0 +1,285 @@
+// Voice wiring tests (RFC #59, slice 2) — the mutation-safety bar, two ways:
+//
+// Part A (call log): every mutating capability records into ONE ordered log and
+// each case deep-equals the WHOLE log — proving an intent invokes exactly the
+// UI's call sequence, in order, and a failed precondition or rejected
+// transcript invokes NOTHING.
+//
+// Part B (state model): the RFC's bullet verbatim — "voice-produced actions
+// must be identical to their UI-produced equivalents (assert deep-equal on
+// resulting state)". makeApp() models the canvas state {conditions, activeCond,
+// shapeLabels, activeLabel, markups} with the canvas's exact verb semantics;
+// caps are bound over those SAME verbs precisely as buildVoiceCtx binds them.
+// Each case seeds two identical apps, drives one by voice and one by the
+// equivalent UI script, and asserts the final states deep-equal. The remaining
+// link — buildVoiceCtx binding these capabilities to the canvas's real
+// functions — is a 12-line by-inspection review in TakeoffCanvas.jsx.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyVoiceIntent, runVoiceCommand, REJECTION_MESSAGES,
+  type VoiceCapabilities, type VoiceOutcome,
+} from "../src/lib/voiceActions.ts";
+
+// ── Part A: ordered call-log ────────────────────────────────────────────────
+
+type LogEntry = [string, ...unknown[]];
+
+function makeCtx(overrides: Partial<VoiceCapabilities> = {}) {
+  const log: LogEntry[] = [];
+  const caps: VoiceCapabilities = {
+    getConditions: () => [
+      { id: "cnd-1", finish_tag: "CPT-1" },
+      { id: "cnd-2", finish_tag: "cpt 2" }, // non-canonical literal, like a schedule import might mint
+    ],
+    getShapeLabels: () => ["Phase 1", "Alternate"],
+    getActiveConditionId: () => "cnd-1",
+    activateCondition: (id) => { log.push(["activateCondition", id]); },
+    createCondition: (tag) => { log.push(["createCondition", tag]); return { id: `cnd-${tag}`, finish_tag: tag }; },
+    updateCondition: (id, patch) => { log.push(["updateCondition", id, patch]); },
+    addLabel: (label) => { log.push(["addLabel", label]); },
+    activateLabel: (label) => { log.push(["activateLabel", label]); },
+    addNote: (text) => { log.push(["addNote", text]); },
+    ...overrides,
+  };
+  return { caps, log };
+}
+
+test("activate known → exactly one activateCondition call", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "activate_condition", tag: "CPT-1", known: true });
+  assert.deepEqual(out, { ok: true, message: "CPT-1 active." });
+  assert.deepEqual(log, [["activateCondition", "cnd-1"]]);
+});
+
+test("activate known by non-canonical literal 'cpt 2' → exact finish_tag lookup", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "activate_condition", tag: "cpt 2", known: true });
+  assert.equal(out.ok, true);
+  assert.deepEqual(log, [["activateCondition", "cnd-2"]]);
+});
+
+test("activate known + waste → activate THEN update, by id, in order", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "activate_condition", tag: "CPT-1", known: true, waste: 7 });
+  assert.deepEqual(out, { ok: true, message: "CPT-1 active — waste 7%." });
+  assert.deepEqual(log, [
+    ["activateCondition", "cnd-1"],
+    ["updateCondition", "cnd-1", { waste_pct: 7 }],
+  ]);
+});
+
+test("activate unknown → create then activate", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "activate_condition", tag: "LVT-2", known: false });
+  assert.deepEqual(out, { ok: true, message: "Created LVT-2 — active." });
+  assert.deepEqual(log, [["createCondition", "LVT-2"], ["activateCondition", "cnd-LVT-2"]]);
+});
+
+test("activate unknown + waste → create, activate, update", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "activate_condition", tag: "LVT-2", known: false, waste: 5 });
+  assert.deepEqual(out, { ok: true, message: "Created LVT-2 — active, waste 5%." });
+  assert.deepEqual(log, [
+    ["createCondition", "LVT-2"],
+    ["activateCondition", "cnd-LVT-2"],
+    ["updateCondition", "cnd-LVT-2", { waste_pct: 5 }],
+  ]);
+});
+
+test("activate unknown that already exists (case-insensitive) → dedup, no mint", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "activate_condition", tag: "CPT 2", known: false });
+  assert.equal(out.ok, true);
+  assert.deepEqual(log, [["activateCondition", "cnd-2"]]);
+});
+
+test("defensive: known tag missing from conditions → fail, ZERO calls", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "activate_condition", tag: "GHOST-9", known: true });
+  assert.deepEqual(out, { ok: false, message: "Couldn't find condition GHOST-9." });
+  assert.deepEqual(log, []);
+});
+
+test("set_waste → one by-id update on the active condition", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "set_waste", waste: 12.5 });
+  assert.deepEqual(out, { ok: true, message: "Waste 12.5% on CPT-1." });
+  assert.deepEqual(log, [["updateCondition", "cnd-1", { waste_pct: 12.5 }]]);
+});
+
+test("set_waste guard: no active condition → exact message, ZERO calls", () => {
+  const { caps, log } = makeCtx({ getActiveConditionId: () => "" });
+  const out = applyVoiceIntent(caps, { kind: "set_waste", waste: 7 });
+  assert.deepEqual(out, { ok: false, message: "Couldn't set waste — no active condition." });
+  assert.deepEqual(log, []);
+});
+
+test("set_label known → activate only, vocabulary untouched", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "set_label", label: "Phase 1", known: true });
+  assert.deepEqual(out, { ok: true, message: "Label Phase 1 active." });
+  assert.deepEqual(log, [["activateLabel", "Phase 1"]]);
+});
+
+test("set_label unknown → addLabel THEN activate (vocabulary learns it)", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "set_label", label: "East Mezzanine", known: false });
+  assert.deepEqual(out, { ok: true, message: "Added label East Mezzanine — active." });
+  assert.deepEqual(log, [["addLabel", "East Mezzanine"], ["activateLabel", "East Mezzanine"]]);
+});
+
+test("clear_label → activateLabel(null)", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "clear_label" });
+  assert.deepEqual(out, { ok: true, message: "Label cleared." });
+  assert.deepEqual(log, [["activateLabel", null]]);
+});
+
+test("add_note → one addNote call with verbatim text", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "add_note", text: "verify seam direction with GC" });
+  assert.deepEqual(out, { ok: true, message: "Note added — see Markups." });
+  assert.deepEqual(log, [["addNote", "verify seam direction with GC"]]);
+});
+
+test("runVoiceCommand end-to-end: homophone + percent through parse and apply", () => {
+  const { caps, log } = makeCtx();
+  const out = runVoiceCommand(caps, "cpt one waist 7.5 percent");
+  assert.deepEqual(out, { ok: true, message: "CPT-1 active — waste 7.5%." });
+  assert.deepEqual(log, [
+    ["activateCondition", "cnd-1"],
+    ["updateCondition", "cnd-1", { waste_pct: 7.5 }],
+  ]);
+});
+
+test("rejected transcript → mapped message, ZERO calls", () => {
+  const { caps, log } = makeCtx();
+  const out = runVoiceCommand(caps, "carpet one seven");
+  assert.deepEqual(out, { ok: false, message: REJECTION_MESSAGES.trailing_words });
+  assert.deepEqual(log, []);
+});
+
+test("every failure message starts with \"Couldn't\" (the isDangerMsg red/sticky contract)", () => {
+  for (const msg of Object.values(REJECTION_MESSAGES))
+    assert.ok(msg.startsWith("Couldn't"), msg);
+  const { caps } = makeCtx({ getActiveConditionId: () => "" });
+  const fails: VoiceOutcome[] = [
+    applyVoiceIntent(caps, { kind: "set_waste", waste: 7 }),
+    applyVoiceIntent(caps, { kind: "activate_condition", tag: "GHOST-9", known: true }),
+  ];
+  for (const f of fails) assert.ok(!f.ok && f.message.startsWith("Couldn't"), f.message);
+});
+
+// ── Part B: state-model deep-equal (RFC bullet 7 verbatim) ─────────────────
+// makeApp() mirrors the canvas verbs' exact semantics with deterministic ids
+// and no timestamps; caps are bound over the SAME verbs, exactly as
+// buildVoiceCtx binds the real ones.
+
+type AppState = {
+  conditions: Array<{ id: string; finish_tag: string; waste_pct: number }>;
+  activeCond: string;
+  shapeLabels: string[];
+  activeLabel: string | null;
+  markups: Array<{ id: string; sheet_id: string; rfi_id: string; type: string; at: [number, number]; text: string }>;
+};
+
+function makeApp() {
+  const state: AppState = {
+    conditions: [
+      { id: "cnd-1", finish_tag: "CPT-1", waste_pct: 0 },
+      { id: "cnd-2", finish_tag: "cpt 2", waste_pct: 3 },
+    ],
+    activeCond: "cnd-1",
+    shapeLabels: ["Phase 1"],
+    activeLabel: null,
+    markups: [],
+  };
+  let seq = 0;
+
+  // UI verbs, modeled on the canvas's exact semantics
+  const mintCondition = (tag: string) => {
+    const c = { id: `cnd-m${++seq}`, finish_tag: tag, waste_pct: 0 };
+    state.conditions = [...state.conditions, c];
+    return c;
+  };
+  const activateCondition = (id: string) => { state.activeCond = id; };
+  const updateCondById = (id: string, patch: { waste_pct: number }) => {
+    state.conditions = state.conditions.map((c) => (c.id === id ? { ...c, ...patch } : c));
+  };
+  const updateCond = (patch: { waste_pct: number }) => updateCondById(state.activeCond, patch);
+  const addLabel = (v: string) => { if (!state.shapeLabels.includes(v)) state.shapeLabels = [...state.shapeLabels, v]; };
+  const activateLabel = (v: string | null) => { state.activeLabel = v; };
+  const addMarkup = (m: { type: string; at: [number, number]; text: string }, key: string) => {
+    state.markups = [...state.markups, { id: `mk-${++seq}`, sheet_id: key, rfi_id: "", ...m }];
+  };
+
+  // caps bound over the SAME verbs — the buildVoiceCtx binding, verbatim
+  const caps: VoiceCapabilities = {
+    getConditions: () => state.conditions.map((c) => ({ id: c.id, finish_tag: c.finish_tag })),
+    getShapeLabels: () => state.shapeLabels,
+    getActiveConditionId: () => state.activeCond,
+    activateCondition,
+    createCondition: (tag) => mintCondition(tag),
+    updateCondition: updateCondById,
+    addLabel,
+    activateLabel,
+    addNote: (text) => addMarkup({ type: "text", at: [0.5, 0.06], text }, "plan.pdf"),
+  };
+
+  return { state, caps, ui: { mintCondition, activateCondition, updateCond, updateCondById, addLabel, activateLabel, addMarkup } };
+}
+
+type App = ReturnType<typeof makeApp>;
+
+const EQUIV: Array<{ name: string; transcript: string; uiScript: (app: App) => void }> = [
+  { name: "activate known ≡ clicking the condition chip", transcript: "cpt one",
+    uiScript: ({ ui }) => ui.activateCondition("cnd-1") },
+  { name: "activate non-canonical literal ≡ clicking its chip", transcript: "cpt two",
+    uiScript: ({ ui }) => ui.activateCondition("cnd-2") },
+  { name: "create+activate ≡ +condition button flow", transcript: "lvt two",
+    uiScript: ({ ui }) => { const c = ui.mintCondition("LVT-2"); ui.activateCondition(c.id); } },
+  { name: "activate+waste combo ≡ chip click then editor save", transcript: "cpt one waste seven",
+    uiScript: ({ ui }) => { ui.activateCondition("cnd-1"); ui.updateCond({ waste_pct: 7 }); } },
+  { name: "create+activate+waste ≡ +condition then editor save", transcript: "tile three waste five",
+    uiScript: ({ ui }) => { const c = ui.mintCondition("CT-3"); ui.activateCondition(c.id); ui.updateCond({ waste_pct: 5 }); } },
+  { name: "waste alone ≡ editor save on the active condition", transcript: "waste twelve",
+    uiScript: ({ ui }) => ui.updateCond({ waste_pct: 12 }) },
+  { name: "homophone+decimal+percent ≡ same editor save", transcript: "cpt one waist 7.5 percent",
+    uiScript: ({ ui }) => { ui.activateCondition("cnd-1"); ui.updateCond({ waste_pct: 7.5 }); } },
+  { name: "label known ≡ picking it in the label select", transcript: "label Phase 1",
+    uiScript: ({ ui }) => ui.activateLabel("Phase 1") },
+  { name: "label unknown ≡ add-to-vocabulary then pick", transcript: "label East Mezzanine",
+    uiScript: ({ ui }) => { ui.addLabel("East Mezzanine"); ui.activateLabel("East Mezzanine"); } },
+  { name: "clear label ≡ selecting No label", transcript: "clear label",
+    uiScript: ({ ui }) => ui.activateLabel(null) },
+  { name: "note ≡ placing a text markup on the focused sheet", transcript: "note check seams at door",
+    uiScript: ({ ui }) => ui.addMarkup({ type: "text", at: [0.5, 0.06], text: "check seams at door" }, "plan.pdf") },
+];
+
+for (const c of EQUIV)
+  test(`state-equal: ${c.name}`, () => {
+    const voiceApp = makeApp();
+    const uiApp = makeApp();
+    const out = runVoiceCommand(voiceApp.caps, c.transcript);
+    assert.equal(out.ok, true, out.message);
+    c.uiScript(uiApp);
+    assert.deepEqual(voiceApp.state, uiApp.state);
+  });
+
+test("state-equal: rejected transcript mutates NOTHING", () => {
+  const app = makeApp();
+  const before = structuredClone(app.state);
+  const out = runVoiceCommand(app.caps, "carpet one seven");
+  assert.equal(out.ok, false);
+  assert.deepEqual(app.state, before);
+});
+
+test("state-equal: set_waste with no active condition mutates NOTHING", () => {
+  const app = makeApp();
+  app.state.activeCond = "";
+  const before = structuredClone(app.state);
+  const out = runVoiceCommand(app.caps, "waste 7");
+  assert.deepEqual(out, { ok: false, message: "Couldn't set waste — no active condition." });
+  assert.deepEqual(app.state, before);
+});

--- a/web/test/voiceIntent.test.ts
+++ b/web/test/voiceIntent.test.ts
@@ -8,8 +8,10 @@
 //   - homophone map is exactly waist→waste (keyword, true homophone, no
 //     literal mid-command use); no letter-name mappings;
 //   - ctx tag matching is case-insensitive EXACT after canonicalization
-//     (cpt 1 / cpt1 / cpt-1 → CPT-1), no fuzzy ever; unknown Div-9 patterns
-//     (CPT/LVT/VCT/CT/RB/TR + 1-99) come back known:false for a create-offer;
+//     (cpt 1 / cpt1 / cpt-1 → CPT-1), no fuzzy ever; live matches return the
+//     ctx LITERAL (directly actionable as finish_tag), while unknown Div-9
+//     patterns (CPT/LVT/VCT/CT/RB/TR + 1-99) come back canonical + known:false
+//     for a create-offer;
 //   - note/label free text is taken verbatim from the RAW transcript, so
 //     normalization never corrupts user prose.
 import { test } from "node:test";
@@ -53,6 +55,15 @@ const CASES: Case[] = [
   { name: "unknown pattern: tile three", input: "tile three", expect: ok({ kind: "activate_condition", tag: "CT-3", known: false }) },
   { name: "unknown pattern: transition one", input: "transition one", expect: ok({ kind: "activate_condition", tag: "TR-1", known: false }) },
   { name: "unknown pattern digits: lvt 4", input: "lvt 4", expect: ok({ kind: "activate_condition", tag: "LVT-4", known: false }) },
+
+  // 3b. live tags with non-canonical finish_tags come back as the ctx LITERAL
+  //     (maintainer note on #79: the wiring slice looks conditions up by exact
+  //     finish_tag, so the parser must hand back the tag as the project spells it)
+  { name: "non-canonical live tag, spoken: cpt one", input: "cpt one", ctx: { conditionTags: ["cpt 1"] }, expect: ok({ kind: "activate_condition", tag: "cpt 1", known: true }) },
+  { name: "non-canonical live tag, joined: cpt-1", input: "cpt-1", ctx: { conditionTags: ["cpt 1"] }, expect: ok({ kind: "activate_condition", tag: "cpt 1", known: true }) },
+  { name: "non-canonical live tag via synonym: carpet one", input: "carpet one", ctx: { conditionTags: ["cpt 1"] }, expect: ok({ kind: "activate_condition", tag: "cpt 1", known: true }) },
+  { name: "mixed-case live tag: lvt two", input: "lvt two", ctx: { conditionTags: ["Lvt-2"] }, expect: ok({ kind: "activate_condition", tag: "Lvt-2", known: true }) },
+  { name: "non-canonical live tag + waste combo", input: "cpt one waste seven", ctx: { conditionTags: ["cpt 1"] }, expect: ok({ kind: "activate_condition", tag: "cpt 1", known: true, waste: 7 }) },
 
   // 4. activate + waste combo
   { name: "combo: carpet one waste seven", input: "carpet one waste seven", expect: ok({ kind: "activate_condition", tag: "CPT-1", known: true, waste: 7 }) },


### PR DESCRIPTION
## What & why

Slice 2 of RFC #59 — the wiring: parsed voice intents now route through the exact functions the UI calls, satisfying the testing bar's mutation-safety bullet ("no voice-only code path may touch shapes/conditions directly"). Input this slice is a typed **Command** box in the toolbar; the recognizer slice will feed the same path with speech. ref #59

- `web/src/lib/voiceActions.ts` — pure dispatcher over an injected capability object (the `agentTools.js` precedent). `activate_condition` → `activateCondition(id, {reassign:false})` (same policy as hotkeys/Library Apply); unknown Div-9 tags → `mintCondition` (the one shared minting path, same as +condition and the #63 agent) then activate; waste → **by-id** condition patch; labels → `addLabel`/`activateLabel`; `note` → a text markup on the focused sheet (top-center anchor; the Markups dock auto-opens). Every failure message starts with `"Couldn't"`, so the commitMsg bar renders it red + sticky via the existing `isDangerMsg` convention.
- **Carry-forward from the #79 review**: live tags now return the ctx *literal* rather than the canonical form — a condition tagged `cpt 1` is directly actionable by exact `finish_tag` lookup. +5 parser tests with non-canonical ctx tags.
- `TakeoffCanvas.jsx` (~55 lines): `updateCond` split into a by-id core + active-based wrapper — combo intents ("cpt one waste seven") patch a condition activated in the same handler, *before* re-render, so the active-based form would have hit the old active condition. `buildVoiceCtx()` sits beside `buildAgentCtx()`; the Command input's focus suppresses canvas shortcuts through the existing INPUT guards (zero new guard code).

## How it was verified

- [x] `npm run build` green; typecheck + lint clean; full suite green (the golden-CSV failures on my machine are the known Windows-CRLF checkout issue, green in CI)
- [x] `web/test/voiceActions.test.ts` — two-part mutation-safety proof:
  - **Ordered call-log**: every intent emits exactly the UI's capability call sequence (whole-log `deepEqual`); rejected transcripts and failed preconditions emit **zero** calls.
  - **State-model deep-equal** (the testing-bar bullet verbatim): identical seeded states driven by voice vs. the equivalent UI script deep-equal at the end — 13 cases including create+activate+waste combos, the homophone path end-to-end, and two must-not-mutate cases. The remaining link (that `buildVoiceCtx` binds these capabilities to the canvas's real functions) is a 12-line by-inspection review.
- [x] Exercised in the running app against the bundled sample plan: `lvt 2 waste 7` → "Created LVT-2 — active, waste 7%." with waste showing in the condition editor; `hello world` → red sticky "Couldn't parse…"; shortcuts stay suppressed while the box has focus.
- [x] Docs: none changed — proposing to document the Command box in USER_GUIDE when the push-to-talk slice completes the feature (happy to add it here if you'd prefer).

## Notes for the reviewer

- `set_waste` with no active condition is a guarded refusal ("Couldn't set waste — no active condition."), not a silent no-op.
- Unknown labels are added to the vocabulary before activation (otherwise the toolbar select never learns them and the label wouldn't persist).
- The Command box ships always-visible — it's a legitimate keyboard command line and the accessibility path, and hiding it behind a flag would leave the wiring untested in the wild. Your call if you'd rather gate it.
- Still gated on the recognizer slice: bullets 2–6 (audio corpus, mic lifecycle, browser matrix, perf budget, privacy proof).

