### PR TITLE
Canvas: unreviewed committed shapes render as dashed pencil + Accept flow

### DIFF
--- a/web/src/lib/shapeCommands.js
+++ b/web/src/lib/shapeCommands.js
@@ -41,6 +41,13 @@
 //   replace   NO stamp, NO counted, inverse null (never recorded): the escape
 //             hatch for whole-array non-edits — hydrate, revision restore,
 //             rescale's computed re-price.
+//   review    the accept gate for machine proposals already IN the shapes
+//             array (an imported MCP takeoff, a binder run): each named shape
+//             still carrying origin.reviewed === false gets reviewed: true +
+//             accepted_ts — nothing else stamps (accepting is affirmation, not
+//             an edit; post-accept edits grade through geom/stampEdit as
+//             usual). Shapes not pending are untouched. `restore` puts the
+//             prior origin back verbatim — undo of an accept is un-accepting.
 // ─────────────────────────────────────────────────────────────────────────────
 import { mintUuid, nowIso, stampEdit } from "./provenance.js";
 import { assignShapeLabel } from "./shapeLabels.js";
@@ -52,6 +59,7 @@ export const PROVENANCE_POLICY = {
   label: "no stamp (documented non-edit)",
   delete: "no stamp; counted per origin.method unless noCount",
   replace: "no stamp, no counted, no undo entry (whole-array non-edit)",
+  review: "origin.reviewed → true + accepted_ts per still-pending shape; restore puts the prior origin back verbatim",
 };
 
 // Undo depth — one bounded gesture history, not an archive (revisions are).
@@ -242,6 +250,26 @@ export function applyShapeCommand(shapes, cmd) {
       // canvas clears both stacks alongside (a restored timeline starts fresh,
       // and a rescale invalidates every recorded `computed`).
       return { shapes: Array.isArray(cmd.shapes) ? cmd.shapes : [], inverse: null };
+    case "review": {
+      if (cmd.restore) {
+        // restore rows put the recorded origin back verbatim; the inverse is
+        // the same shape again — restore rows of the CURRENT origins, so
+        // redo-of-undo re-accepts (accepted_ts included) without re-stamping.
+        const byId = new Map(cmd.restore.map((r) => [r.id, r]));
+        const inverse = { type: "review", restore: shapes.filter((s) => byId.has(s.id)).map((s) => ({ id: s.id, origin: s.origin })) };
+        const next = shapes.map((s) => (byId.has(s.id) ? { ...s, origin: byId.get(s.id).origin } : s));
+        return { shapes: next, inverse };
+      }
+      const idSet = new Set(cmd.ids);
+      const ts = nowIso();
+      const restore = [];
+      const next = shapes.map((s) => {
+        if (!idSet.has(s.id) || s.origin?.reviewed !== false) return s;
+        restore.push({ id: s.id, origin: s.origin });
+        return { ...s, origin: { ...s.origin, reviewed: true, accepted_ts: ts } };
+      });
+      return { shapes: next, inverse: { type: "review", restore } };
+    }
   }
 }
 

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -3710,6 +3710,19 @@ export default function TakeoffCanvas() {
   // geometry never rides the contribution wire — no rejection records, no
   // counters, nothing for contribute.js to even see (the D34 cut-line).
   const rejectAgentProposal = (id) => setAgentProposals((ps) => ps.filter((p) => p.id !== id));
+
+  // ── the accept gate, for shapes already IN the data ─────────────────────────
+  // An imported MCP takeoff arrives committed but unreviewed (origin.reviewed
+  // === false) — those render dashed pencil and gate the Accept pill. Accept
+  // routes through the `review` command (ONE undo entry), which flips reviewed
+  // + stamps accepted_ts and nothing else: affirmation, not an edit. Rejecting
+  // one is just deleting it — select and Delete, like any shape.
+  const pendingCommitted = useMemo(() => visibleShapes.filter((s) => s.origin?.reviewed === false), [visibleShapes]);
+  function acceptPendingShapes() {
+    if (!pendingCommitted.length) return;
+    dispatchShape({ type: "review", ids: pendingCommitted.map((s) => s.id) });
+    setCommitMsg(`Accepted ${pendingCommitted.length} proposed shape${pendingCommitted.length === 1 ? "" : "s"} — pencil is now ink.`);
+  }
   const rejectAllAgentProposals = () => setAgentProposals([]);
 
   // ── the run ────────────────────────────────────────────────────────────────
@@ -5124,21 +5137,29 @@ export default function TakeoffCanvas() {
                       // like every other screen-relative size here.
                       const z = tf.scale;
                       const sw = (sel ? 4 : 2) / z;
+                      // Committed-but-unreviewed machine shapes (an imported MCP
+                      // takeoff) render dashed pencil — same invariant as the
+                      // ephemeral agent proposals, until Accept flips reviewed.
+                      const pending = s.origin?.reviewed === false;
+                      const pDash = `${4 / z} ${3 / z}`;
                       if (s.measure_role === "count") {
                         const [cx, cy] = pts[0], r = 7 / z;
-                        return <rect key={s.id} x={cx - r} y={cy - r} width={r * 2} height={r * 2} rx={2 / z} fill={col + "cc"} stroke={sel ? "#1f3fc7" : "#fff"} strokeWidth={(sel ? 3 : 1.5) / z} />;
+                        return <rect key={s.id} x={cx - r} y={cy - r} width={r * 2} height={r * 2} rx={2 / z} fill={col + (pending ? "55" : "cc")} stroke={sel ? "#1f3fc7" : "#fff"} strokeWidth={(sel ? 3 : 1.5) / z} strokeDasharray={pending ? `${3 / z} ${2.5 / z}` : undefined} />;
                       }
                       if (s.measure_role === "surface_area") {
-                        return <polyline key={s.id} points={pts.map((q) => q.join(",")).join(" ")} fill="none" stroke={sel ? "#1f3fc7" : col} strokeWidth={(sel ? 4.5 : 3.5) / z} strokeDasharray={`${10 / z} ${3 / z} ${2 / z} ${3 / z}`} strokeLinecap="round" strokeLinejoin="round" />;
+                        return <polyline key={s.id} points={pts.map((q) => q.join(",")).join(" ")} fill="none" stroke={sel ? "#1f3fc7" : col} strokeOpacity={pending ? 0.85 : undefined} strokeWidth={(sel ? 4.5 : 3.5) / z} strokeDasharray={pending ? pDash : `${10 / z} ${3 / z} ${2 / z} ${3 / z}`} strokeLinecap="round" strokeLinejoin="round" />;
                       }
                       if (s.measure_role === "linear") {
                         // line_style governs linear outlines (surface_area keeps its dash-dot identity above)
                         const lpts = s.curved ? flattenCurve(pts) : pts;
-                        return <polyline key={s.id} points={lpts.map((q) => q.join(",")).join(" ")} fill="none" stroke={sel ? "#1f3fc7" : col} strokeWidth={(sel ? 4 : 3) / z} strokeDasharray={dashArrayFor(cond?.line_style || "solid", z)} strokeLinecap="round" strokeLinejoin="round" />;
+                        return <polyline key={s.id} points={lpts.map((q) => q.join(",")).join(" ")} fill="none" stroke={sel ? "#1f3fc7" : col} strokeOpacity={pending ? 0.85 : undefined} strokeWidth={(sel ? 4 : 3) / z} strokeDasharray={pending ? pDash : dashArrayFor(cond?.line_style || "solid", z)} strokeLinecap="round" strokeLinejoin="round" />;
                       }
                       const ded = s.measure_role === "deduct";
                       // deduct keeps its danger-red dashing (a safety signal, wins over line_style); positive floor_area follows the condition's line_style
-                      return <polygon key={s.id} points={pts.map((q) => q.join(",")).join(" ")} fill={ded ? "rgba(176,58,38,.28)" : shapeFill(cond)} stroke={ded ? "#b03a26" : (sel ? "#1f3fc7" : col)} strokeWidth={sw} strokeDasharray={ded ? `${6 / z} ${4 / z}` : dashArrayFor(cond?.line_style || "solid", z)} />;
+                      return <polygon key={s.id} points={pts.map((q) => q.join(",")).join(" ")}
+                        fill={ded ? (pending ? "rgba(176,58,38,.10)" : "rgba(176,58,38,.28)") : pending ? col + "14" : shapeFill(cond)}
+                        stroke={ded ? "#b03a26" : (sel ? "#1f3fc7" : col)} strokeOpacity={pending ? 0.9 : undefined} strokeWidth={sw}
+                        strokeDasharray={pending ? pDash : ded ? `${6 / z} ${4 / z}` : dashArrayFor(cond?.line_style || "solid", z)} />;
                     })}
                     {/* vertex handles for the selected shape (drag to reshape) */}
                     {selectedId && (() => {
@@ -5547,6 +5568,17 @@ export default function TakeoffCanvas() {
           <div style={{ position: "absolute", left: "50%", bottom: 14, transform: "translateX(-50%)", maxWidth: "70%", zIndex: 6, pointerEvents: "none", padding: "6px 12px", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", boxShadow: "var(--shadow-1)", fontSize: 12, color: isDangerMsg(commitMsg) ? "var(--c-danger)" : "var(--c-positive)" }}>
             {commitMsg}
           </div>
+        )}
+
+        {/* accept pill — visible while committed-but-unreviewed shapes (an
+            imported MCP takeoff) are on the visible sheets; they render dashed
+            pencil until accepted. One click, one undo entry. */}
+        {pendingCommitted.length > 0 && (
+          <button onClick={acceptPendingShapes}
+            title={`${pendingCommitted.length} machine-proposed shape${pendingCommitted.length === 1 ? "" : "s"} render${pendingCommitted.length === 1 ? "s" : ""} dashed pending your review. Accept makes them ink (⌘Z undoes); to reject one, select it and press Delete.`}
+            style={{ position: "absolute", left: "50%", top: 12, transform: "translateX(-50%)", zIndex: 6, padding: "6px 14px", background: "var(--paper-bright)", border: "1.5px dashed var(--cobalt)", boxShadow: "var(--shadow-1)", fontSize: 12.5, fontWeight: 600, color: "var(--cobalt)", cursor: "pointer" }}>
+            Accept {pendingCommitted.length} proposed shape{pendingCommitted.length === 1 ? "" : "s"}
+          </button>
         )}
 
         {/* live readout — top-right. Height is capped short of the panel rail's centered

--- a/web/test/shapeCommands.test.ts
+++ b/web/test/shapeCommands.test.ts
@@ -287,3 +287,35 @@ test("vertsEqual: exact structural comparison — the zero-motion / snapped-back
   assert.ok(!vertsEqual([[0.1, 0.2]], [[0.1, 0.20000001]]));
   assert.ok(!vertsEqual(undefined as any, [[0, 0]]));
 });
+
+// ── review (the accept gate for shapes already in the data) ──────────────────
+
+test("review: accepts only still-pending shapes (reviewed → true + accepted_ts, nothing else); undo un-accepts verbatim; redo re-accepts verbatim", () => {
+  const pending = machineShape("shp-p1");
+  pending.origin = { method: "one_click_v1", actor: "agent", seed_norm: [0.4, 0.3], reviewed: false };
+  const accepted = machineShape("shp-a1");   // reviewed: true — must ride through untouched
+  const manual = manualShape("shp-m1");      // no reviewed key — not a proposal, must ride through
+  const input = [pending, accepted, manual];
+
+  const r1 = applyShapeCommand(input, { type: "review", ids: ["shp-p1", "shp-a1", "shp-m1"] });
+  const out: any = r1.shapes.find((s: any) => s.id === "shp-p1");
+  assert.equal(out.origin.reviewed, true);
+  assert.match(out.origin.accepted_ts, ISO);
+  assert.equal(out.origin.actor, "agent");                        // the rest of the origin rides through
+  assert.deepEqual(out.origin.seed_norm, [0.4, 0.3]);
+  assert.equal(out.updated_at, undefined, "accepting is affirmation, not an edit — no updated_at");
+  assert.equal(r1.shapes[1], accepted, "already-accepted shape untouched (same reference)");
+  assert.equal(r1.shapes[2], manual, "manual shape untouched (same reference)");
+
+  const undone = applyShapeCommand(r1.shapes, r1.inverse);        // un-accept: the exact input again
+  assert.deepEqual(undone.shapes, input);
+  const redone = applyShapeCommand(undone.shapes, undone.inverse); // redo restores the accepted state verbatim, accepted_ts included
+  assert.deepEqual(redone.shapes, r1.shapes);
+});
+
+test("review: an empty or all-non-pending id set is a no-op with an empty restore", () => {
+  const shapes = [machineShape("shp-a1"), manualShape("shp-m1")];
+  const r = applyShapeCommand(shapes, { type: "review", ids: ["shp-a1", "shp-m1", "shp-ghost"] });
+  assert.deepEqual(r.shapes, shapes);
+  assert.deepEqual(r.inverse, { type: "review", restore: [] });
+});


### PR DESCRIPTION
The other half of the agent trust contract. The in-canvas agent's ephemeral proposals already render dashed and gate an accept click — but a shape that arrives **already committed** with `origin.reviewed === false` (an MCP-driven takeoff imported into the app) rendered as solid ink, indistinguishable from human work, with no review gate at all. The pencil-vs-ink invariant now keys on the data, not on which proposer delivered it:

- **Render**: any committed shape with `origin.reviewed === false` draws as dashed pencil in its condition's color — low-opacity fill for areas/deducts, pencil dash for linear/surface/count — until a human accepts it. Accepted and human shapes are untouched.
- **Accept**: a new `review` command in the shape-command layer (a PROVENANCE_POLICY row like every other mutation): flips `reviewed → true` and stamps `accepted_ts` on each still-pending shape, and nothing else — accepting is affirmation, not an edit; post-accept edits grade through `stampEdit` as usual. Exact-restore inverse both directions, so ⌘Z un-accepts verbatim and redo re-accepts verbatim (accepted_ts included). One batch = one undo entry.
- **UI**: an Accept pill (top-center, dashed cobalt) appears while pending shapes are on the visible sheets — "Accept N proposed shapes"; the tooltip explains pencil/ink and that rejecting one is select + Delete. Accepting toasts "pencil is now ink."

Tests: two new `shapeCommands` cases — accept touches only still-pending shapes (already-accepted and manual shapes ride through by reference), stamps ISO `accepted_ts`, adds no `updated_at`; undo restores the prior origin deep-equal; redo restores the accepted state deep-equal; empty/non-pending id sets are a no-op with an empty restore.

Verified in the running app: seeded two `reviewed:false` shapes (an area + a linear) into a real takeoff via the store, saw both render dashed with the pill showing "Accept 2 proposed shapes", clicked Accept — both flipped to solid ink with their hatch fills, toast confirmed, pill cleared — then restored the original annotations byte-for-byte. `npm run check` green (the 4 pre-existing Node-25-only localStorage test failures reproduce identically on clean main and pass on CI's pinned Node).