### PR TITLE
feat(voice): deixis — cursor-seeded one-click ("this room") per RFC #59 design

### DIFF
--- a/web/src/lib/voiceActions.ts
+++ b/web/src/lib/voiceActions.ts
@@ -11,13 +11,35 @@
 // Outcome messages follow the commitMsg bar's convention: failures start with
 // "Couldn't" (isDangerMsg renders them red + sticky), successes are short
 // green confirmations.
+//
+// Deixis (RFC #59 deixis slice): trace_at_cursor is the one intent that
+// reaches shapes — through caps.traceAt, which the canvas binds to the SAME
+// oneClickAt flood + Create gate a physical click drives (who-aimed-it: the
+// human supplied the aim, so it commits direct as human work). The aim seed
+// is validated FIRST, so a stale/off-sheet aim rejects with zero calls.
 import { parseVoiceIntent, type Intent, type RejectReason } from "./voiceIntent.ts";
+
+/** Cursor aim for deixis: sheet-local px on sheetId. See getAimSeed. */
+export type AimSeed = { x: number; y: number; sheetId: string };
 
 export type VoiceCapabilities = {
   getConditions(): Array<{ id: string; finish_tag: string }>;
   getShapeLabels(): string[];
   /** Active condition id, "" when none — the set_waste guard. */
   getActiveConditionId(): string;
+  /** Live cursor aim for deixis. null = the aim isn't LIVE (no pointer update
+   *  since the utterance began — parked off-canvas, tab refocus, or already
+   *  consumed); sheetId "" = live aim that isn't over a sheet. Both are loud
+   *  rejects in the dispatcher, checked BEFORE any state moves. */
+  getAimSeed(): AimSeed | null;
+  /** Run the one-click trace at the seed and commit DIRECT as human work —
+   *  the who-aimed-it rule: the same flood and Create gate a physical click
+   *  drives, one_click_v1 origin, undo covers it, NEVER an agentProposals
+   *  row. conditionId/label ride BY VALUE because the same utterance armed
+   *  them pre-render (the updateCondition-by-id precedent above). May resolve
+   *  async (the raster path awaits a render); failure modes (open_boundary /
+   *  tiny) come back as ok:false with the one-click message — never silent. */
+  traceAt(seed: AimSeed, conditionId: string, label?: string): VoiceOutcome | Promise<VoiceOutcome>;
   /** Canvas binds {reassign:false} — programmatic activation never reassigns a selected shape. */
   activateCondition(id: string): void;
   /** mintCondition — the one shared minting path (UI +condition and the #63 agent use it too). */
@@ -41,14 +63,21 @@ export const REJECTION_MESSAGES: Record<RejectReason, string> = {
   unknown_tag: "Couldn't match that tag — say a live condition tag, or a Div-9 code like CPT-2 to create one.",
   bad_number: 'Couldn\'t read the waste number — say 0–100, e.g. "waste 7" or "waste 7.5".',
   trailing_words: "Couldn't parse — extra words after the command. One command at a time.",
+  deixis_no_condition: 'Couldn\'t trace — no active condition. Name one, like "CPT-1, this room".',
+  deixis_target: 'Couldn\'t aim that — "here"/"this room" places a takeoff, not a note or label clear.',
 };
 
 const fail = (message: string): VoiceOutcome => ({ ok: false, message });
 const done = (message: string): VoiceOutcome => ({ ok: true, message });
 
 /** Apply one parsed intent through the capabilities. Never throws; a failed
- *  precondition returns ok:false with a "Couldn't …" message and NO calls. */
-export function applyVoiceIntent(caps: VoiceCapabilities, intent: Intent): VoiceOutcome {
+ *  precondition returns ok:false with a "Couldn't …" message and NO calls.
+ *  Every intent resolves synchronously except trace_at_cursor, whose outcome
+ *  may ride caps.traceAt's promise (the raster flood awaits a render) — hence
+ *  the overloads: pre-deixis callers keep the plain VoiceOutcome type. */
+export function applyVoiceIntent(caps: VoiceCapabilities, intent: Exclude<Intent, { kind: "trace_at_cursor" }>): VoiceOutcome;
+export function applyVoiceIntent(caps: VoiceCapabilities, intent: Intent): VoiceOutcome | Promise<VoiceOutcome>;
+export function applyVoiceIntent(caps: VoiceCapabilities, intent: Intent): VoiceOutcome | Promise<VoiceOutcome> {
   switch (intent.kind) {
     case "activate_condition": {
       let cond: { id: string; finish_tag: string } | undefined;
@@ -91,14 +120,53 @@ export function applyVoiceIntent(caps: VoiceCapabilities, intent: Intent): Voice
     case "add_note":
       caps.addNote(intent.text);
       return done("Note added — see Markups.");
+    case "trace_at_cursor": {
+      // seed BEFORE arming: an off-sheet or stale aim rejects with ZERO calls —
+      // a bad aim must not half-arm a condition (the mutation-safety bar)
+      const seed = caps.getAimSeed();
+      if (!seed) return fail("Couldn't place that — aim went stale. Put the cursor on the room and say it again.");
+      if (!seed.sheetId) return fail("Couldn't place that — aim at a sheet.");
+      // arm the condition — the aimed click's sequence: chip click (or mint),
+      // then the waste/label riders, then the trace
+      let condId: string;
+      if (intent.tag !== undefined) {
+        const spoken = intent.tag;
+        let cond: { id: string; finish_tag: string } | undefined;
+        if (intent.known) {
+          cond = caps.getConditions().find((c) => c.finish_tag === spoken);
+          if (!cond) return fail(`Couldn't find condition ${spoken}.`);
+        } else {
+          cond =
+            caps.getConditions().find((c) => c.finish_tag.toUpperCase() === spoken.toUpperCase()) ??
+            caps.createCondition(spoken);
+        }
+        caps.activateCondition(cond.id);
+        condId = cond.id;
+      } else {
+        condId = caps.getActiveConditionId();
+        if (!condId) return fail(REJECTION_MESSAGES.deixis_no_condition); // defensive — the parser gates on ctx.hasActiveCondition
+      }
+      if (intent.waste !== undefined) caps.updateCondition(condId, { waste_pct: intent.waste });
+      if (intent.label !== undefined) {
+        if (!caps.getShapeLabels().includes(intent.label)) caps.addLabel(intent.label);
+        caps.activateLabel(intent.label);
+      }
+      // who-aimed-it: the human aimed the cursor, so the canvas commits DIRECT
+      // through the physical one-click path; the outcome (created SF, or an
+      // open_boundary/tiny reject) is the spoken result — never a silent no-op
+      return caps.traceAt(seed, condId, intent.label);
+    }
   }
 }
 
-/** Parse + apply in one call — the canvas's single entry point. */
-export function runVoiceCommand(caps: VoiceCapabilities, transcript: string): VoiceOutcome {
+/** Parse + apply in one call — the canvas's single entry point. Deixis
+ *  outcomes may resolve async (see applyVoiceIntent); everything else is a
+ *  plain VoiceOutcome, so callers Promise.resolve() or await uniformly. */
+export function runVoiceCommand(caps: VoiceCapabilities, transcript: string): VoiceOutcome | Promise<VoiceOutcome> {
   const parsed = parseVoiceIntent(transcript, {
     conditionTags: caps.getConditions().map((c) => c.finish_tag),
     shapeLabels: caps.getShapeLabels(),
+    hasActiveCondition: caps.getActiveConditionId() !== "",
   });
   if (!parsed.ok) return fail(REJECTION_MESSAGES[parsed.reason]);
   return applyVoiceIntent(caps, parsed.intent);

--- a/web/src/lib/voiceIntent.ts
+++ b/web/src/lib/voiceIntent.ts
@@ -12,6 +12,11 @@
 export type VoiceContext = {
   conditionTags: string[]; // live finish_tag values, e.g. ["CPT-1","VCT-1","P-2","C"]
   shapeLabels: string[];   // project label vocabulary (TakeoffCanvas shape_labels)
+  /** Is a condition active right now? Gates BARE deixis ("this room" alone):
+   *  with none active the parse rejects (deixis_no_condition) rather than let
+   *  the wiring guess. Optional so pre-deixis callers/tests are untouched;
+   *  absent reads as false. */
+  hasActiveCondition?: boolean;
 };
 
 export type Intent =
@@ -19,14 +24,21 @@ export type Intent =
   | { kind: "set_waste"; waste: number }
   | { kind: "set_label"; label: string; known: boolean }
   | { kind: "clear_label" }
-  | { kind: "add_note"; text: string };
+  | { kind: "add_note"; text: string }
+  // deixis (RFC #59 deixis slice): the utterance ended in "this room"/"here"/
+  // "this one"/"right here" — the speaker AIMED. The parser marks that they
+  // aimed, never where; seed resolution is the caps layer's job. No tag =
+  // bare deixis on the active condition (gated by ctx.hasActiveCondition).
+  | { kind: "trace_at_cursor"; tag?: string; known?: boolean; waste?: number; label?: string };
 
 export type RejectReason =
   | "empty"          // blank/whitespace transcript
   | "unrecognized"   // no production matched at all
   | "unknown_tag"    // tag-shaped lead but not in ctx and not a Div-9 pattern
   | "bad_number"     // waste keyword present but number missing/invalid/out of range
-  | "trailing_words"; // a production matched but tokens were left over
+  | "trailing_words" // a production matched but tokens were left over
+  | "deixis_no_condition" // bare deixis ("this room" alone) with no active condition
+  | "deixis_target"; // deixis riding note/clear-label — nothing to aim at
 
 export type VoiceParse =
   | { ok: true; intent: Intent }
@@ -58,6 +70,15 @@ const SYNONYM_PHRASES: [string[], string][] = [
   [["ceramic"], "CT"],
   [["base"], "RB"],
   [["transition"], "TR"],
+];
+
+// Deixis riders (RFC #59 deixis slice): utterance-TERMINAL only — "carpet
+// one, this room". Longest first so "right here" strips whole, not as "here".
+const DEIXIS_PHRASES: string[][] = [
+  ["this", "room"],
+  ["this", "one"],
+  ["right", "here"],
+  ["here"],
 ];
 
 const UNITS: Record<string, number> = {
@@ -283,12 +304,80 @@ function rawRemainder(transcript: string, keyword: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// deixis
+
+// Strip ONE terminal deixis phrase off the normalized tokens; null when the
+// utterance doesn't end in one (the non-deixis grammar then runs untouched).
+function takeTerminalDeixis(tokens: string[]): string[] | null {
+  for (const phrase of DEIXIS_PHRASES) {
+    const start = tokens.length - phrase.length;
+    if (start >= 0 && phrase.every((w, k) => tokens[start + k] === w))
+      return tokens.slice(0, start);
+  }
+  return null;
+}
+
+// Raw-transcript twin of takeTerminalDeixis, for label free text: drop the
+// terminal deixis phrase (and punctuation around it) from the RAW transcript
+// so "label East Wing, this room" labels "East Wing", verbatim casing intact.
+function stripTerminalDeixisRaw(transcript: string): string {
+  return transcript.replace(/[\s,.;:!–—-]*\b(?:this\s+room|this\s+one|right\s+here|here)\b[\s,.;:!?–—-]*$/i, "");
+}
+
+// [tag] [waste <n>] [label <text>] <deixis> — the aimed-trace production.
+// Riders mirror the main grammar exactly (same takeTag/takeWasteValue, same
+// raw-text label rule, keyword-first so a leading waste/label is a rider and
+// never a tag candidate). Tagless forms arm nothing themselves, so they need
+// a live active condition — absent one the parse rejects loudly, per the
+// never-a-guess bar.
+function parseDeixisUtterance(transcript: string, head: string[], ctx: VoiceContext): VoiceParse {
+  let i = 0;
+  let tag: { tag: string; known: boolean; next: number } | null = null;
+  if (head.length > 0 && head[0] !== "waste" && head[0] !== "label") {
+    tag = takeTag(head, 0, ctx);
+    if (tag) i = tag.next;
+  }
+  let waste: number | undefined;
+  if (head[i] === "waste") {
+    const w = takeWasteValue(head, i + 1);
+    if (w === null) return { ok: false, reason: "bad_number" };
+    waste = w.value;
+    i = w.next;
+  }
+  let label: string | undefined;
+  if (head[i] === "label") {
+    const m = /\blabel\b[:,]?\s*(.+)$/i.exec(stripTerminalDeixisRaw(transcript));
+    const text = m ? m[1].trim().replace(/[\s,;:–—-]+$/, "") : "";
+    if (!text) return { ok: false, reason: "unrecognized" };
+    const hit = ctx.shapeLabels.find((l) => l.toLowerCase() === text.toLowerCase());
+    label = hit ?? text;
+    i = head.length; // label free text consumes the rest of the head
+  }
+  if (i !== head.length)
+    return i === 0
+      ? { ok: false, reason: couldBeTagLead(head, ctx) ? "unknown_tag" : "unrecognized" }
+      : { ok: false, reason: "trailing_words" };
+  if (!tag && !ctx.hasActiveCondition) return { ok: false, reason: "deixis_no_condition" };
+  return {
+    ok: true,
+    intent: {
+      kind: "trace_at_cursor",
+      ...(tag ? { tag: tag.tag, known: tag.known } : {}),
+      ...(waste !== undefined ? { waste } : {}),
+      ...(label !== undefined ? { label } : {}),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // dispatch
 
 /**
  * Parse one push-to-talk transcript into one intent, or a typed rejection.
  * Grammar (keyword-first):
  *   clear label | label <text> | note <text> | waste <n> | <tag> [waste <n>]
+ *   | [tag] [waste <n>] [label <text>] <deixis>   (deixis = utterance-terminal
+ *     "this room" / "here" / "this one" / "right here" → trace_at_cursor)
  * Anything else — including a matched production with leftover tokens —
  * rejects. Never guesses.
  */
@@ -296,6 +385,18 @@ export function parseVoiceIntent(transcript: string, ctx: VoiceContext): VoicePa
   if (!transcript || !transcript.trim()) return { ok: false, reason: "empty" };
   const tokens = normalizeTokens(transcript);
   if (tokens.length === 0) return { ok: false, reason: "empty" };
+
+  // deixis production, checked BEFORE the keyword dispatch: an utterance
+  // ENDING in a deixis token is an aimed trace. On note/clear-label there is
+  // nothing to aim at, and a prose "here" is indistinguishable from an aimed
+  // one — reject loudly, never guess. Utterances without a deixis tail fall
+  // through to the existing productions unchanged.
+  const head = takeTerminalDeixis(tokens);
+  if (head !== null) {
+    if (head[0] === "note" || (head[0] === "clear" && head[1] === "label"))
+      return { ok: false, reason: "deixis_target" };
+    return parseDeixisUtterance(transcript, head, ctx);
+  }
 
   // clear label
   if (tokens[0] === "clear" && tokens[1] === "label") {

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -479,7 +479,9 @@ export default function TakeoffCanvas() {
   const editingRef = useRef(false);    // true while the inline text editor is open — read in moveCrosshair/onPointerDown/wheel (a REF, never per-mousemove state) to suppress the crosshair and freeze pan/zoom
   const editorRef = useRef(null);      // mirror of the open editor object, so finishEditor can commit without a stale-closure race
   const editorInputRef = useRef(null); // the live <input> element (uncontrolled — value read on commit)
-  const lastPtrRef = useRef(null);     // last pointer CLIENT coords — paste targets the sheet under the cursor
+  const lastPtrRef = useRef(null);     // last pointer CLIENT coords — paste targets the sheet under the cursor; ALSO the voice-deixis aim (getAimSeed) — the one pointer tracker
+  const aimSeqRef = useRef(0);         // bumps with every lastPtrRef write — the deixis freshness clock (no second tracker, just a tick on the existing one)
+  const voiceAimMarkRef = useRef(0);   // aim is LIVE for deixis only while aimSeq > this; re-marked at utterance begin (Command box focus / every run) and on canvas-leave + tab-hide, so a parked-off-canvas or refocus ghost seed can never place a trace
   const pendingClickRef = useRef(null); // deferred draw click {p,cx,cy} — drag >5px converts to a pan
   const hoverRef = useRef(null);        // hover tooltip div (DOM-direct like the crosshair)
   const hoverIdRef = useRef("");        // shape id currently described by the tooltip
@@ -1058,6 +1060,14 @@ export default function TakeoffCanvas() {
   useEffect(() => { viewRef.current = view; }, [view]);
   useEffect(() => { toolRef.current = tool; }, [tool]);
   useEffect(() => { proposalRef.current = proposal; }, [proposal]);
+  // Tab hidden ⇒ the voice-deixis aim dies: on return the tracked position
+  // predates the refocus (rAF suspended, the pointer may be anywhere), so
+  // "this room" must wait for a fresh move — the stale-aim bar (RFC #59).
+  useEffect(() => {
+    const onVis = () => { if (document.visibilityState === "hidden") voiceAimMarkRef.current = aimSeqRef.current; };
+    document.addEventListener("visibilitychange", onVis);
+    return () => document.removeEventListener("visibilitychange", onVis);
+  }, []);
 
   // one pdf.js document per file, cached for the life of the project view —
   // the canvas render AND the gallery thumbnails share this cache
@@ -2237,6 +2247,14 @@ export default function TakeoffCanvas() {
     hoverIdRef.current = "";
     angleRef.current = null;
   }
+  // Pointer left the canvas: hide the aim chrome AND kill the voice-deixis aim —
+  // a pointer parked off-canvas must not leave a ghost seed for "this room".
+  // (Other hideCrosshair callers — e.g. the inline editor — keep the aim: the
+  // pointer is still parked on the sheet there.)
+  function leaveCanvas() {
+    hideCrosshair();
+    voiceAimMarkRef.current = aimSeqRef.current;
+  }
   function describeShape(s) {
     const tag = condById[s.condition_id]?.finish_tag || "?";
     const a = s.computed?.area_sf || 0, lf = s.computed?.perimeter_lf || 0;
@@ -2273,6 +2291,7 @@ export default function TakeoffCanvas() {
   }
   function onPointerMove(e) {
     lastPtrRef.current = [e.clientX, e.clientY];   // paste targets the sheet under the cursor
+    aimSeqRef.current++;                           // deixis freshness tick — see getAimSeed
     if (hlRef.current) {
       // paint: distance-thin at capture, live preview via DOM (no React render per move)
       const st = hlRef.current;
@@ -2698,24 +2717,48 @@ export default function TakeoffCanvas() {
     }
     return pr;
   }
-  // The propose tail, shared by the vector and raster paths. Raster differences:
-  // a looser RDP eps (scan contours wobble) and NO vertex snapping — there are
-  // no true endpoints on a scan, and pulling room corners onto the title-block's
-  // vector corners would corrupt the ring. Duplicate/carve checks run inside a
-  // FUNCTIONAL setProposal so a click racing the first raster render can't
-  // clobber state.
-  function proposeRegion(f, tp, local, negative, raster) {
+  // Build one one-click region from a flood result — the trace/snap/metrics
+  // core shared VERBATIM by the stage path (proposeRegion) and the voice-deixis
+  // direct-commit path (settleRegion), so an aimed utterance and an aimed click
+  // can never trace differently. Raster differences: a looser RDP eps (scan
+  // contours wobble) and NO vertex snapping — there are no true endpoints on a
+  // scan, and pulling room corners onto the title-block's vector corners would
+  // corrupt the ring. null = no scale, or the ring collapsed (too tiny/thin).
+  function buildOneClickRegion(f, tp, local, negative, raster) {
     const upp = uppFor(tp.key);
-    if (!upp) return;
+    if (!upp) return null;
     let ring;
     if (raster) ring = traceRegion(f, RASTER_RDP_EPS);
     else {
       const grid = snapGridsRef.current.get(tp.key);
       ring = snapVertices(traceRegion(f), (x, y, d) => (grid ? nearestSnap(grid, x, y, d) : null), 7);
     }
-    if (ring.length < 3) { setCommitMsg("Couldn't trace that space — trace it with Area (A)."); return; }
-    const area_sf = +(ringArea(ring) * upp * upp).toFixed(2);
-    const perim_lf = +(closedMetrics(ring).perim * upp).toFixed(2);
+    if (ring.length < 3) return null;
+    // poly0 freezes the MACHINE trace (post-snap, pre-handle-edit) so a
+    // corrected region can still report what the fill proposed; sens rides
+    // only when the estimator moved the knob off Balanced (vector path
+    // only — the raster mask is single-tier, sensitivity is inert there).
+    return {
+      kind: negative ? "neg" : "pos",
+      seed: local,
+      poly: ring,
+      poly0: ring.map(([x, y]) => [x, y]),
+      ...(!raster && fillSens !== SENS_BALANCED ? { sens: fillSens } : {}),
+      area_sf: +(ringArea(ring) * upp * upp).toFixed(2),
+      perim_lf: +(closedMetrics(ring).perim * upp).toFixed(2),
+      hf: !!f.hatchFiltered,
+      rt: !!raster,
+    };
+  }
+  // The propose tail (physical clicks): stage the region for the Create (⏎)
+  // gate. Duplicate/carve checks run inside a FUNCTIONAL setProposal so a
+  // click racing the first raster render can't clobber state.
+  function proposeRegion(f, tp, local, negative, raster) {
+    const region = buildOneClickRegion(f, tp, local, negative, raster);
+    if (!region) {
+      if (uppFor(tp.key)) setCommitMsg("Couldn't trace that space — trace it with Area (A).");
+      return;
+    }
     // Decide accept/dup/carve-reject INSIDE the functional updater, against
     // its own authoritative `prev` — not proposalRef, which only catches up
     // on the next render's passive-effect flush (a macrotask). proposeRegion
@@ -2752,8 +2795,7 @@ export default function TakeoffCanvas() {
     flushSync(() => {
       setProposal((prev) => {
         const rs = prev && prev.key === tp.key ? prev.regions : [];
-        const kind = negative ? "neg" : "pos";
-        if (rs.some((r) => r.kind === kind && pointInPoly(local[0], local[1], r.poly))) {
+        if (rs.some((r) => r.kind === region.kind && pointInPoly(local[0], local[1], r.poly))) {
           outcome = "dup";
           return prev;
         }
@@ -2762,23 +2804,35 @@ export default function TakeoffCanvas() {
           return prev;
         }
         outcome = "added";
-        // poly0 freezes the MACHINE trace (post-snap, pre-handle-edit) so a
-        // corrected region can still report what the fill proposed; sens rides
-        // only when the estimator moved the knob off Balanced (vector path
-        // only — the raster mask is single-tier, sensitivity is inert there).
-        return { key: tp.key, regions: [...rs, { kind, seed: local, poly: ring, poly0: ring.map(([x, y]) => [x, y]), ...(!raster && fillSens !== SENS_BALANCED ? { sens: fillSens } : {}), area_sf, perim_lf, hf: !!f.hatchFiltered, rt: !!raster }] };
+        return { key: tp.key, regions: [...rs, region] };
       });
     });
     if (outcome === "dup") setCommitMsg(negative ? "That cutout is already carved." : "Already selected — ⌥-click carves an enclosed cutout; ⏎ creates.");
     else if (outcome === "needsPos") setCommitMsg("⌥-click carves an enclosed area INSIDE the selection (a column or shaft) — click its room first.");
     else setCommitMsg("");
   }
-  async function oneClickAt(p, negative) {
+  // `direct` (voice deixis, RFC #59): { conditionId, label } — the human aimed
+  // the crosshair, so the flood COMMITS in one step through settleRegion →
+  // commitOneClickRegions (the same gate ⏎ drives) instead of staging a
+  // proposal, and every exit returns { ok, message } so the voice outcome can
+  // speak it — a deixis trace never no-ops silently. The condition rides BY
+  // VALUE because the utterance armed it in this same handler (the activeCond
+  // closure is a render behind). Click callers ignore the return value; their
+  // message surface stays setCommitMsg, unchanged.
+  async function oneClickAt(p, negative, direct) {
+    const say = (message) => { setCommitMsg(message); return { ok: false, message }; };
     const tp = panelAt(p[0]);
     const upp = uppFor(tp.key);
-    if (!upp) { setCommitMsg(`Set the scale for ${labelFor(tp)} first.`); return; }
-    if (!activeCond) { setCommitMsg("Pick or add a condition first."); return; }
-    if (proposal && proposal.key !== tp.key) { setCommitMsg(`Finish the selection on ${labelFor(panelByKey(proposal.key))} first — ⏎ creates it, Esc discards.`); return; }
+    if (!upp) return say(`Set the scale for ${labelFor(tp)} first.`);
+    if (!(direct ? direct.conditionId : activeCond)) return say("Pick or add a condition first.");
+    // a click may EXTEND a same-sheet proposal; voice deixis commits whole and
+    // must never swallow a selection the human is still reviewing — ANY pending
+    // proposal rejects the utterance
+    if (proposal && (direct || proposal.key !== tp.key)) {
+      return say(direct
+        ? "Finish the pending one-click selection first — ⏎ creates it, Esc discards."
+        : `Finish the selection on ${labelFor(panelByKey(proposal.key))} first — ⏎ creates it, Esc discards.`);
+    }
     const local = [p[0] - tp.xOffset, p[1]];
     // Trigger policy: vector is exact and always wins where it works — including
     // the fork's hatch escalation (fillSens), which runs untouched here. The
@@ -2791,22 +2845,26 @@ export default function TakeoffCanvas() {
     const vectorViable = !!stats && stats.segCount >= RASTER_MIN_SEGS;
     if (!rasterEligible || vectorViable) {
       const mo = ensureMask(tp.key);
-      if (!mo && !rasterEligible) { setCommitMsg("Still reading this sheet's linework — try again in a second."); return; }
+      if (!mo && !rasterEligible) return say("Still reading this sheet's linework — try again in a second.");
       if (mo) {
         const f = floodRegion(mo, local[0], local[1], fillSens);
-        if (f.status === "ok") { proposeRegion(f, tp, local, negative, false); return; }
+        if (f.status === "ok") return settleRegion(f, tp, local, negative, false, direct);
         if (!rasterEligible) {
-          setCommitMsg(f.status === "leak"
+          return say(f.status === "leak"
             ? "That space isn't enclosed on the plan linework — the fill spilled. Click a more enclosed spot, or trace it with Area (A)."
             : "Landed in dense linework (hatching/text). Zoom in and click an open spot, or trace it with Area (A).");
-          return;
         }
       }
     }
     setCommitMsg("Reading the scan…");
     const seq = renderSeqRef.current;
     const rmo = await ensureRasterMask(tp.key);
-    if (seq !== renderSeqRef.current) { setCommitMsg(""); return; }   // sheet group changed mid-render — the new sheet must not be left showing a stale "Reading the scan…" ("…" messages never auto-expire, see commitMsg's 6s-timer effect
+    if (seq !== renderSeqRef.current) {   // sheet group changed mid-render — the new sheet must not be left showing a stale "Reading the scan…" ("…" messages never auto-expire, see commitMsg's 6s-timer effect
+      setCommitMsg("");
+      return direct
+        ? say("Couldn't place that — the sheet changed while reading the scan. Say it again.")
+        : { ok: false, message: "" };
+    }
     // The raster render can take real time on a large scan; the user may have
     // switched tools or started a DIFFERENT panel's proposal while it was in
     // flight. renderSeq alone only catches a sheet-GROUP change — re-validate
@@ -2814,40 +2872,74 @@ export default function TakeoffCanvas() {
     // `proposal` — this is an async continuation resuming after other renders)
     // so a late raster result can never silently replace another panel's
     // in-progress proposal or paint a ghost selection in the wrong tool.
-    if (toolRef.current !== "oneclick" || (proposalRef.current && proposalRef.current.key !== tp.key)) { setCommitMsg(""); return; }
-    if (!rmo) { setCommitMsg("Couldn't read this scan — trace it with Area (A)."); return; }
+    // Voice (direct) is modeless — no tool check — but a proposal appearing
+    // mid-await means the human started clicking; the utterance yields loudly
+    // rather than race the hand.
+    if (direct ? proposalRef.current : (toolRef.current !== "oneclick" || (proposalRef.current && proposalRef.current.key !== tp.key))) {
+      setCommitMsg("");
+      return direct
+        ? say("Couldn't place that — a one-click selection started while reading the scan. Finish it (⏎/Esc), then say it again.")
+        : { ok: false, message: "" };
+    }
+    if (!rmo) return say("Couldn't read this scan — trace it with Area (A).");
     // The raster mask is single-tier (softCount 0), so floodRegion's hatch
     // escalation — and with it the Fill sensitivity knob — is structurally
     // inert on scans; no sensitivity is passed.
     const f = floodRegion(rmo, local[0], local[1]);
     if (f.status !== "ok") {
-      setCommitMsg(f.status === "leak"
+      return say(f.status === "leak"
         ? "That space isn't enclosed on the scan — the fill escaped through a gap (faded line or open doorway). Click a more enclosed spot, or trace it with Area (A)."
         : "Landed on dense scan ink (text or hatching). Zoom in and click an open spot, or trace it with Area (A).");
-      return;
     }
-    proposeRegion(f, tp, local, negative, true);
+    return settleRegion(f, tp, local, negative, true, direct);
   }
-  function createProposal() {
-    if (!proposal || !proposal.regions.length) return;
-    const tp = panelByKey(proposal.key);
-    const made = proposal.regions.map((r) => ({
-      sheet_id: tp.key, condition_id: activeCond,
+  // After a successful flood: a physical click STAGES the region for the
+  // ⏎/dblclick Create gate; a voice-deixis trace (direct) COMMITS it now —
+  // same builder, same commit gate, no preview-then-Enter. The spoken
+  // imperative IS the confirmation (RFC #59 who-aimed-it rule).
+  function settleRegion(f, tp, local, negative, raster, direct) {
+    if (!direct) { proposeRegion(f, tp, local, negative, raster); return { ok: true, message: "" }; }
+    const region = buildOneClickRegion(f, tp, local, negative, raster);
+    if (!region) return { ok: false, message: "Couldn't trace that space — trace it with Area (A)." };
+    return commitOneClickRegions({ key: tp.key, regions: [region] }, direct);
+  }
+  // The ONE commit gate for one-click regions — the ⏎/dblclick Create AND a
+  // voice-deixis trace both land here, so human-aimed work gets exactly one
+  // origin shape (one_click_v1, reviewed) and one undo path. `direct` (voice)
+  // pins { conditionId, label } from the utterance BY VALUE — the arming
+  // setState hasn't rendered, so the activeCond/activeLabel closures are one
+  // render behind (the updateCondition-by-id precedent in voiceActions).
+  function commitOneClickRegions(prop, direct) {
+    const tp = panelByKey(prop.key);
+    const condId = direct ? direct.conditionId : activeCond;
+    const label = direct && direct.label !== undefined ? direct.label : (activeLabel || undefined);
+    const made = prop.regions.map((r) => ({
+      sheet_id: tp.key, condition_id: condId,
       measure_role: r.kind === "neg" ? "deduct" : "floor_area",
       verts_norm: r.poly.map(([x, y]) => [x / tp.img.w, y / tp.img.h]),
       computed: { area_sf: r.area_sf, perimeter_lf: r.perim_lf },
-      ...(activeLabel ? { label: activeLabel } : {}),
+      ...(label ? { label } : {}),
       // the provenance receipt: machine-proposed, human-reviewed at the Create
-      // gate. A handle-corrected region (touched) records the machine's frozen
-      // trace (poly0) as proposed_verts_norm — the one-click correction pair;
-      // an untouched region's verts ARE the proposal, so nothing extra rides.
-      // Post-Create edits are stamped by stampEdit, which freezes the same
-      // field from the pre-edit ring only when Create didn't already.
+      // gate (voice deixis: the spoken imperative is the review). A handle-
+      // corrected region (touched) records the machine's frozen trace (poly0)
+      // as proposed_verts_norm — the one-click correction pair; an untouched
+      // region's verts ARE the proposal, so nothing extra rides. Post-Create
+      // edits are stamped by stampEdit, which freezes the same field from the
+      // pre-edit ring only when Create didn't already.
       origin: { method: "one_click_v1", seed_norm: [r.seed[0] / tp.img.w, r.seed[1] / tp.img.h], reviewed: true, ...(r.hf ? { hatch_filtered: true } : {}), ...(r.rt ? { raster_traced: true } : {}), ...(r.sens != null ? { fill_sensitivity: r.sens } : {}), ...(r.touched ? { edited_before_create: true, proposed_verts_norm: r.poly0.map(([x, y]) => [x / tp.img.w, y / tp.img.h]) } : {}) },
     }));
-    dispatchShape({ type: "add", shapes: made });   // Create is the creation gate — id/created_at minted by the command
-    const sf = proposal.regions.reduce((n, r) => n + (r.kind === "neg" ? -r.area_sf : r.area_sf), 0);
-    setCommitMsg(`Created ${made.length} takeoff${made.length === 1 ? "" : "s"} — ${fa(sf)} ${condById[activeCond]?.finish_tag || ""}. Click the next room.`);
+    dispatchShape({ type: "add", shapes: made });   // the creation gate — id/created_at minted by the command
+    const sf = prop.regions.reduce((n, r) => n + (r.kind === "neg" ? -r.area_sf : r.area_sf), 0);
+    // condById is a render closure — a condition minted THIS utterance is only
+    // in the live mirror, so fall through to it for the tag
+    const tag = (condById[condId] || agentStateRef.current.conditions.find((c) => c.id === condId))?.finish_tag || "";
+    const message = `Created ${made.length} takeoff${made.length === 1 ? "" : "s"} — ${fa(sf)} ${tag}. Click the next room.`;
+    setCommitMsg(message);
+    return { ok: true, message };
+  }
+  function createProposal() {
+    if (!proposal || !proposal.regions.length) return;
+    commitOneClickRegions(proposal);
     setProposal(null);
   }
 
@@ -3639,12 +3731,49 @@ export default function TakeoffCanvas() {
     };
   }
 
+  // Voice deixis (RFC #59 deixis slice): "carpet one, this room" — the
+  // utterance carries WHAT, the crosshair carries WHERE. getAimSeed resolves
+  // the existing pointer tracker (lastPtrRef — the same positions the
+  // moveCrosshair aim renders from; no second tracker) into a sheet-local
+  // seed. null = the aim isn't LIVE: nothing tracked since the utterance
+  // began — Command box focus / the previous run — or since the pointer left
+  // the canvas or the tab hid (voiceAimMarkRef). sheetId "" = live aim that
+  // isn't over a sheet. Both become loud rejects in the dispatcher, checked
+  // before any state moves. The seed is the RAW cursor, not the snap/angle-
+  // adjusted point: a flood seed targets a room's interior, where snap pull
+  // toward a wall endpoint could only hurt — and matches a mid-room click,
+  // which never snaps either.
+  function getAimSeed() {
+    if (status !== "ready" || !lastPtrRef.current) return null;
+    if (aimSeqRef.current <= voiceAimMarkRef.current) return null;   // stale — no pointer update since the utterance began / last invalidation
+    const p = toImage(lastPtrRef.current[0], lastPtrRef.current[1]);
+    const tp = panelAt(p[0]);
+    const x = p[0] - tp.xOffset, y = p[1];
+    if (!tp.img.w || x < 0 || y < 0 || x >= tp.img.w || y >= tp.img.h) return { x, y, sheetId: "" };
+    return { x, y, sheetId: tp.key };
+  }
+  // The who-aimed-it rule: the human put the crosshair there, so the trace
+  // runs the SAME oneClickAt flood a physical click runs and commits DIRECT
+  // as human work (one_click_v1 origin, same undo) — one utterance, no
+  // preview-then-⏎, and NEVER an agentProposals row (that gate is for agent-
+  // INFERRED placement; the line is aim). conditionId/label ride explicitly:
+  // the utterance armed them in this same handler, so the render closures are
+  // stale. Failures wrap into the commitMsg bar's "Couldn't" convention.
+  async function voiceTraceAt(seed, conditionId, label) {
+    const tp = panelByKey(seed.sheetId);
+    if (!tp || tp.key !== seed.sheetId || !tp.img.w) return { ok: false, message: "Couldn't place that — aim at a sheet." };
+    const out = await oneClickAt([seed.x + tp.xOffset, seed.y], false, { conditionId, label });
+    if (out.ok) return out;
+    const m = out.message || "Couldn't place that — the view changed mid-trace. Say it again.";
+    return { ok: false, message: /^couldn'?t/i.test(m) ? m : `Couldn't place that — ${m.charAt(0).toLowerCase()}${m.slice(1)}` };
+  }
   // Voice-command capabilities (RFC #59 slice 2) — every entry binds an action
   // the UI already exposes; the dispatcher (voiceActions.ts) never touches
   // state directly. getConditions reads the live mirror (mintCondition updates
   // it mid-handler); the rest are safe render closures because the voice path
-  // is fully synchronous, unlike the agent loop. Programmatic activation
-  // passes {reassign:false} — same policy as hotkeys and Library Apply.
+  // is synchronous up to traceAt, whose async continuation carries its state
+  // by value/ref instead. Programmatic activation passes {reassign:false} —
+  // same policy as hotkeys and Library Apply.
   function buildVoiceCtx() {
     return {
       getConditions: () => agentStateRef.current.conditions.map((c) => ({ id: c.id, finish_tag: c.finish_tag })),
@@ -3659,12 +3788,20 @@ export default function TakeoffCanvas() {
       // and addMarkup auto-opens the Markups dock, so the note is immediately
       // visible and draggable — the anchor is a starting point, not a commitment
       addNote: (text) => addMarkup({ type: "text", at: [0.5, 0.06], text }, focusPanel.key),
+      getAimSeed,
+      traceAt: (seed, conditionId, label) => voiceTraceAt(seed, conditionId, label),
     };
   }
   const onVoiceCommand = (text) => {
     const out = runVoiceCommand(buildVoiceCtx(), text);
-    setCommitMsg(out.message);
-    return out.ok;
+    // every run consumes the aim (the seed was already read synchronously):
+    // repeating "this room" without a fresh pointer move is a stale-aim
+    // reject, never a silent double-commit of the same room
+    voiceAimMarkRef.current = aimSeqRef.current;
+    const finish = (o) => { setCommitMsg(o.message); return o.ok; };
+    // deixis traces can resolve async (raster flood awaits a render) — the
+    // outcome message lands when it lands; everything else stays synchronous
+    return typeof out?.then === "function" ? out.then(finish) : finish(out);
   };
 
   // ── the accept gate ─────────────────────────────────────────────────────────
@@ -4723,16 +4860,21 @@ export default function TakeoffCanvas() {
         )}
         {/* Typed voice command (RFC #59 slice 2): the same grammar push-to-talk
             will feed — a keyboard command line meanwhile, and the accessibility
-            path. Focus suppresses canvas shortcuts via the existing INPUT guards. */}
+            path. Focus suppresses canvas shortcuts via the existing INPUT guards.
+            Deixis: focus marks the utterance's start — "this room" then needs an
+            aim placed AFTER it (park the pointer on the room, type, Enter). */}
         {cluster("Command",
           <input
             type="text"
-            placeholder="cpt 1 · waste 7 · label · note"
-            title={'Command line (RFC #59): a condition tag ("CPT-1", "carpet one", "tile 2 waste 5"), "waste 7", "label Phase 1", "clear label", or "note …" — Enter runs it through the same actions the buttons use. Push-to-talk dictation will feed this box.'}
+            placeholder="cpt 1 · waste 7 · this room"
+            title={'Command line (RFC #59): a condition tag ("CPT-1", "carpet one", "tile 2 waste 5"), "waste 7", "label Phase 1", "clear label", or "note …" — Enter runs it through the same actions the buttons use. End with "this room" / "here" while the pointer rests on a room to trace and commit it there ("carpet one, this room"). Push-to-talk dictation will feed this box.'}
+            onFocus={() => { voiceAimMarkRef.current = aimSeqRef.current; }}
             onKeyDown={(e) => {
               if (e.key !== "Enter") return;
               const v = e.currentTarget.value.trim();
-              if (v && onVoiceCommand(v)) e.currentTarget.value = "";
+              if (!v) return;
+              const el = e.currentTarget;   // capture: currentTarget nulls after dispatch, and deixis outcomes can resolve async (raster)
+              Promise.resolve(onVoiceCommand(v)).then((ok) => { if (ok) el.value = ""; });
             }}
             style={{ fontFamily: "var(--f-mono)", fontSize: 11.5, padding: "5px 6px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", width: 150 }}
           />
@@ -5073,7 +5215,7 @@ export default function TakeoffCanvas() {
        )}
        <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
         <div ref={containerRef} onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp}
-          onPointerCancel={onPointerUp} onPointerLeave={hideCrosshair} onContextMenu={(e) => e.preventDefault()}
+          onPointerCancel={onPointerUp} onPointerLeave={leaveCanvas} onContextMenu={(e) => e.preventDefault()}
           onDoubleClick={(e) => { if (tool === "oneclick") { if (proposal?.regions.length) createProposal(); } else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "curve" || tool === "surface" || tool === "zone") finishShape(); else if (tool === "select") editMarkupAt(e); }}
           style={{ position: "absolute", inset: 0, background: darkMode ? "#0b0e14" : "var(--paper-cream)", cursor: tool === "pan" ? "grab" : tool === "select" ? "default" : "none", touchAction: "none" }}>
           {/* aim crosshair (draw modes): the OS cursor is hidden on the canvas — the

--- a/web/test/voiceActions.test.ts
+++ b/web/test/voiceActions.test.ts
@@ -40,6 +40,11 @@ function makeCtx(overrides: Partial<VoiceCapabilities> = {}) {
     addLabel: (label) => { log.push(["addLabel", label]); },
     activateLabel: (label) => { log.push(["activateLabel", label]); },
     addNote: (text) => { log.push(["addNote", text]); },
+    getAimSeed: () => ({ x: 320, y: 240, sheetId: "plan.pdf" }),
+    traceAt: (seed, conditionId, label) => {
+      log.push(["traceAt", seed, conditionId, label]);
+      return { ok: true, message: "Created 1 takeoff — 234.5 SF CPT-1. Click the next room." };
+    },
     ...overrides,
   };
   return { caps, log };
@@ -160,6 +165,123 @@ test("rejected transcript → mapped message, ZERO calls", () => {
   assert.deepEqual(log, []);
 });
 
+// ── deixis (RFC #59 deixis slice): seed handoff, ordered like the aimed click ──
+
+const SEED = { x: 320, y: 240, sheetId: "plan.pdf" };
+
+test("deixis known tag: activate THEN traceAt with the seed — the aimed click's order", () => {
+  const { caps, log } = makeCtx();
+  const out = runVoiceCommand(caps, "carpet one, this room");
+  assert.deepEqual(out, { ok: true, message: "Created 1 takeoff — 234.5 SF CPT-1. Click the next room." });
+  assert.deepEqual(log, [
+    ["activateCondition", "cnd-1"],
+    ["traceAt", SEED, "cnd-1", undefined],
+  ]);
+});
+
+test("deixis + waste: activate, update by id, THEN traceAt — chip click, editor save, aimed click", () => {
+  const { caps, log } = makeCtx();
+  const out = runVoiceCommand(caps, "cpt one waste seven this room");
+  assert.deepEqual(out, { ok: true, message: "Created 1 takeoff — 234.5 SF CPT-1. Click the next room." });
+  assert.deepEqual(log, [
+    ["activateCondition", "cnd-1"],
+    ["updateCondition", "cnd-1", { waste_pct: 7 }],
+    ["traceAt", SEED, "cnd-1", undefined],
+  ]);
+});
+
+test("deixis unknown tag: create, activate, traceAt", () => {
+  const { caps, log } = makeCtx();
+  const out = runVoiceCommand(caps, "lvt two here");
+  assert.deepEqual(out, { ok: true, message: "Created 1 takeoff — 234.5 SF CPT-1. Click the next room." });
+  assert.deepEqual(log, [
+    ["createCondition", "LVT-2"],
+    ["activateCondition", "cnd-LVT-2"],
+    ["traceAt", SEED, "cnd-LVT-2", undefined],
+  ]);
+});
+
+test("deixis + unknown label: activate, addLabel, activateLabel, traceAt carrying the label", () => {
+  const { caps, log } = makeCtx();
+  const out = runVoiceCommand(caps, "cpt one label East Mezzanine this one");
+  assert.deepEqual(out, { ok: true, message: "Created 1 takeoff — 234.5 SF CPT-1. Click the next room." });
+  assert.deepEqual(log, [
+    ["activateCondition", "cnd-1"],
+    ["addLabel", "East Mezzanine"],
+    ["activateLabel", "East Mezzanine"],
+    ["traceAt", SEED, "cnd-1", "East Mezzanine"],
+  ]);
+});
+
+test("deixis + known label: no addLabel — vocabulary untouched", () => {
+  const { caps, log } = makeCtx();
+  const out = runVoiceCommand(caps, "cpt one label Phase 1 right here");
+  assert.deepEqual(out, { ok: true, message: "Created 1 takeoff — 234.5 SF CPT-1. Click the next room." });
+  assert.deepEqual(log, [
+    ["activateCondition", "cnd-1"],
+    ["activateLabel", "Phase 1"],
+    ["traceAt", SEED, "cnd-1", "Phase 1"],
+  ]);
+});
+
+test("bare deixis: traceAt on the ACTIVE condition, nothing re-armed", () => {
+  const { caps, log } = makeCtx();
+  const out = runVoiceCommand(caps, "this room");
+  assert.deepEqual(out, { ok: true, message: "Created 1 takeoff — 234.5 SF CPT-1. Click the next room." });
+  assert.deepEqual(log, [["traceAt", SEED, "cnd-1", undefined]]);
+});
+
+test("deixis stale aim (getAimSeed null) → exact message, ZERO calls — nothing half-arms", () => {
+  const { caps, log } = makeCtx({ getAimSeed: () => null });
+  const out = runVoiceCommand(caps, "carpet one, this room");
+  assert.deepEqual(out, { ok: false, message: "Couldn't place that — aim went stale. Put the cursor on the room and say it again." });
+  assert.deepEqual(log, []);
+});
+
+test("deixis off-sheet aim (sheetId \"\") → exact message, ZERO calls", () => {
+  const { caps, log } = makeCtx({ getAimSeed: () => ({ x: -40, y: 9999, sheetId: "" }) });
+  const out = runVoiceCommand(caps, "carpet one, this room");
+  assert.deepEqual(out, { ok: false, message: "Couldn't place that — aim at a sheet." });
+  assert.deepEqual(log, []);
+});
+
+test("bare deixis with no active condition → parse-level reject, ZERO calls", () => {
+  const { caps, log } = makeCtx({ getActiveConditionId: () => "" });
+  const out = runVoiceCommand(caps, "this room");
+  assert.deepEqual(out, { ok: false, message: REJECTION_MESSAGES.deixis_no_condition });
+  assert.deepEqual(log, []);
+});
+
+test("deixis one-click failure (open boundary) speaks through the outcome — armed, but no commit", () => {
+  const { caps, log } = makeCtx({
+    traceAt: (seed, conditionId, label) => {
+      log.push(["traceAt", seed, conditionId, label]);
+      return { ok: false, message: "Couldn't place that — that space isn't enclosed on the plan linework. Click a more enclosed spot, or trace it with Area (A)." };
+    },
+  });
+  const out = runVoiceCommand(caps, "carpet one, this room");
+  assert.deepEqual(out, { ok: false, message: "Couldn't place that — that space isn't enclosed on the plan linework. Click a more enclosed spot, or trace it with Area (A)." });
+  assert.deepEqual(log, [
+    ["activateCondition", "cnd-1"],
+    ["traceAt", SEED, "cnd-1", undefined],
+  ]);
+});
+
+test("deixis async traceAt: the promise outcome rides through runVoiceCommand", async () => {
+  const { caps, log } = makeCtx({
+    traceAt: (seed, conditionId, label) => {
+      log.push(["traceAt", seed, conditionId, label]);
+      return Promise.resolve({ ok: true, message: "Created 1 takeoff — 120 SF CPT-1. Click the next room." });
+    },
+  });
+  const out = await runVoiceCommand(caps, "carpet one, this room");
+  assert.deepEqual(out, { ok: true, message: "Created 1 takeoff — 120 SF CPT-1. Click the next room." });
+  assert.deepEqual(log, [
+    ["activateCondition", "cnd-1"],
+    ["traceAt", SEED, "cnd-1", undefined],
+  ]);
+});
+
 test("every failure message starts with \"Couldn't\" (the isDangerMsg red/sticky contract)", () => {
   for (const msg of Object.values(REJECTION_MESSAGES))
     assert.ok(msg.startsWith("Couldn't"), msg);
@@ -182,6 +304,10 @@ type AppState = {
   shapeLabels: string[];
   activeLabel: string | null;
   markups: Array<{ id: string; sheet_id: string; rfi_id: string; type: string; at: [number, number]; text: string }>;
+  // deixis: committed takeoffs land in shapes with the CLICK path's origin;
+  // agentProposals stays EMPTY under voice — the who-aimed-it line
+  shapes: Array<{ id: string; sheet_id: string; condition_id: string; label?: string; origin: { method: string; seed: [number, number]; reviewed: true } }>;
+  agentProposals: unknown[];
 };
 
 function makeApp() {
@@ -194,6 +320,12 @@ function makeApp() {
     shapeLabels: ["Phase 1"],
     activeLabel: null,
     markups: [],
+    shapes: [],
+    agentProposals: [],
+  };
+  // the aim is INPUT, not asserted state — mutable so reject cases can park it
+  const box: { aim: { x: number; y: number; sheetId: string } | null } = {
+    aim: { x: 320, y: 240, sheetId: "plan.pdf" },
   };
   let seq = 0;
 
@@ -213,6 +345,18 @@ function makeApp() {
   const addMarkup = (m: { type: string; at: [number, number]; text: string }, key: string) => {
     state.markups = [...state.markups, { id: `mk-${++seq}`, sheet_id: key, rfi_id: "", ...m }];
   };
+  // the aimed one-click COMMIT, modeled on commitOneClickRegions' semantics:
+  // deterministic flood stand-in, click-path origin, label stamped from the
+  // explicit override when the utterance carried one, else the active label —
+  // exactly the canvas fallback. Never touches agentProposals.
+  const oneClickCommitAt = (seed: { x: number; y: number; sheetId: string }, condId: string, label?: string) => {
+    const eff = label !== undefined ? label : (state.activeLabel || undefined);
+    state.shapes = [...state.shapes, {
+      id: `sh-${++seq}`, sheet_id: seed.sheetId, condition_id: condId,
+      ...(eff ? { label: eff } : {}),
+      origin: { method: "one_click_v1", seed: [seed.x, seed.y], reviewed: true },
+    }];
+  };
 
   // caps bound over the SAME verbs — the buildVoiceCtx binding, verbatim
   const caps: VoiceCapabilities = {
@@ -225,9 +369,11 @@ function makeApp() {
     addLabel,
     activateLabel,
     addNote: (text) => addMarkup({ type: "text", at: [0.5, 0.06], text }, "plan.pdf"),
+    getAimSeed: () => box.aim,
+    traceAt: (seed, conditionId, label) => { oneClickCommitAt(seed, conditionId, label); return { ok: true, message: "Created 1 takeoff." }; },
   };
 
-  return { state, caps, ui: { mintCondition, activateCondition, updateCond, updateCondById, addLabel, activateLabel, addMarkup } };
+  return { state, caps, box, ui: { mintCondition, activateCondition, updateCond, updateCondById, addLabel, activateLabel, addMarkup, oneClickCommitAt } };
 }
 
 type App = ReturnType<typeof makeApp>;
@@ -255,31 +401,74 @@ const EQUIV: Array<{ name: string; transcript: string; uiScript: (app: App) => v
     uiScript: ({ ui }) => ui.activateLabel(null) },
   { name: "note ≡ placing a text markup on the focused sheet", transcript: "note check seams at door",
     uiScript: ({ ui }) => ui.addMarkup({ type: "text", at: [0.5, 0.06], text: "check seams at door" }, "plan.pdf") },
+  // deixis ≡ the aimed click: arm by hand, then physically one-click the same
+  // seed and Create — the whole point of the who-aimed-it rule
+  { name: "deixis known tag ≡ chip click then aimed one-click Create", transcript: "carpet one, this room",
+    uiScript: ({ ui, box }) => { ui.activateCondition("cnd-1"); ui.oneClickCommitAt(box.aim!, "cnd-1"); } },
+  { name: "deixis + waste ≡ chip click, editor save, aimed one-click", transcript: "cpt one waste seven this room",
+    uiScript: ({ ui, box }) => { ui.activateCondition("cnd-1"); ui.updateCond({ waste_pct: 7 }); ui.oneClickCommitAt(box.aim!, "cnd-1"); } },
+  { name: "deixis create ≡ +condition then aimed one-click", transcript: "lvt two here",
+    uiScript: ({ ui, box }) => { const c = ui.mintCondition("LVT-2"); ui.activateCondition(c.id); ui.oneClickCommitAt(box.aim!, c.id); } },
+  { name: "deixis + label ≡ add+pick label then aimed one-click", transcript: "cpt one label East Mezzanine this one",
+    uiScript: ({ ui, box }) => { ui.activateCondition("cnd-1"); ui.addLabel("East Mezzanine"); ui.activateLabel("East Mezzanine"); ui.oneClickCommitAt(box.aim!, "cnd-1", "East Mezzanine"); } },
+  { name: "bare deixis ≡ aimed one-click on the active condition", transcript: "right here",
+    uiScript: ({ ui, box }) => ui.oneClickCommitAt(box.aim!, "cnd-1") },
 ];
 
 for (const c of EQUIV)
-  test(`state-equal: ${c.name}`, () => {
+  test(`state-equal: ${c.name}`, async () => {
     const voiceApp = makeApp();
     const uiApp = makeApp();
-    const out = runVoiceCommand(voiceApp.caps, c.transcript);
+    const out = await runVoiceCommand(voiceApp.caps, c.transcript);
     assert.equal(out.ok, true, out.message);
     c.uiScript(uiApp);
     assert.deepEqual(voiceApp.state, uiApp.state);
   });
 
-test("state-equal: rejected transcript mutates NOTHING", () => {
+test("state-equal: rejected transcript mutates NOTHING", async () => {
   const app = makeApp();
   const before = structuredClone(app.state);
-  const out = runVoiceCommand(app.caps, "carpet one seven");
+  const out = await runVoiceCommand(app.caps, "carpet one seven");
   assert.equal(out.ok, false);
   assert.deepEqual(app.state, before);
 });
 
-test("state-equal: set_waste with no active condition mutates NOTHING", () => {
+test("state-equal: set_waste with no active condition mutates NOTHING", async () => {
   const app = makeApp();
   app.state.activeCond = "";
   const before = structuredClone(app.state);
-  const out = runVoiceCommand(app.caps, "waste 7");
+  const out = await runVoiceCommand(app.caps, "waste 7");
   assert.deepEqual(out, { ok: false, message: "Couldn't set waste — no active condition." });
+  assert.deepEqual(app.state, before);
+});
+
+// ── deixis provenance + zero-mutation (the who-aimed-it line, both sides) ──
+
+test("deixis commits ONE shape as human one-click work — agentProposals stays empty", async () => {
+  const app = makeApp();
+  const out = await runVoiceCommand(app.caps, "carpet one, this room");
+  assert.equal(out.ok, true, out.message);
+  assert.deepEqual(app.state.shapes, [{
+    id: "sh-1", sheet_id: "plan.pdf", condition_id: "cnd-1",
+    origin: { method: "one_click_v1", seed: [320, 240], reviewed: true },
+  }]);
+  assert.deepEqual(app.state.agentProposals, []);   // NEVER a proposal row for human aim
+});
+
+test("deixis stale aim mutates NOTHING — not even the condition arms", async () => {
+  const app = makeApp();
+  app.box.aim = null;
+  const before = structuredClone(app.state);
+  const out = await runVoiceCommand(app.caps, "carpet one, this room");
+  assert.deepEqual(out, { ok: false, message: "Couldn't place that — aim went stale. Put the cursor on the room and say it again." });
+  assert.deepEqual(app.state, before);
+});
+
+test("deixis off-sheet aim mutates NOTHING", async () => {
+  const app = makeApp();
+  app.box.aim = { x: -12, y: 400, sheetId: "" };
+  const before = structuredClone(app.state);
+  const out = await runVoiceCommand(app.caps, "carpet one, this room");
+  assert.deepEqual(out, { ok: false, message: "Couldn't place that — aim at a sheet." });
   assert.deepEqual(app.state, before);
 });

--- a/web/test/voiceIntent.test.ts
+++ b/web/test/voiceIntent.test.ts
@@ -132,6 +132,44 @@ const CASES: Case[] = [
   { name: "near-prefix rejects: cptx one", input: "cptx one", expect: no("unrecognized") },
   { name: "unmapped material rejects: granite one", input: "granite one", expect: no("unrecognized") },
   { name: "ambiguous bare vinyl rejects: vinyl one", input: "vinyl one", expect: no("unknown_tag") },
+
+  // 16. deixis (RFC #59 deixis slice) — utterance-terminal riders. Matrix:
+  // every token × (tag | bare | +waste | +label). Bare/tagless forms need
+  // ctx.hasActiveCondition; the parser marks THAT the speaker aimed, never where.
+  // tag × every token
+  { name: "deixis tag: cpt one this room", input: "cpt one this room", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true }) },
+  { name: "deixis tag: carpet one here", input: "carpet one here", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true }) },
+  { name: "deixis tag with comma: CPT-1, this one", input: "CPT-1, this one", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true }) },
+  { name: "deixis tag create-offer: tile three right here", input: "tile three right here", expect: ok({ kind: "trace_at_cursor", tag: "CT-3", known: false }) },
+  // bare × every token (active condition present)
+  { name: "bare deixis: this room", input: "this room", ctx: { hasActiveCondition: true }, expect: ok({ kind: "trace_at_cursor" }) },
+  { name: "bare deixis: here", input: "here", ctx: { hasActiveCondition: true }, expect: ok({ kind: "trace_at_cursor" }) },
+  { name: "bare deixis: this one", input: "this one", ctx: { hasActiveCondition: true }, expect: ok({ kind: "trace_at_cursor" }) },
+  { name: "bare deixis: right here", input: "right here", ctx: { hasActiveCondition: true }, expect: ok({ kind: "trace_at_cursor" }) },
+  // +waste × every token
+  { name: "deixis+waste: carpet one waste seven this room", input: "carpet one waste seven this room", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true, waste: 7 }) },
+  { name: "deixis+waste decimal: cpt one waste 7.5 here", input: "cpt one waste 7.5 here", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true, waste: 7.5 }) },
+  { name: "deixis+waste rider, tagless: waste ten this one", input: "waste ten this one", ctx: { hasActiveCondition: true }, expect: ok({ kind: "trace_at_cursor", waste: 10 }) },
+  { name: "deixis+waste homophone+percent: cpt one waist twelve percent right here", input: "cpt one waist twelve percent right here", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true, waste: 12 }) },
+  // +label × every token (known labels come back in vocabulary casing; unknown verbatim)
+  { name: "deixis+label known: carpet one label phase 1 this room", input: "carpet one label phase 1 this room", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true, label: "Phase 1" }) },
+  { name: "deixis+label unknown: cpt one label East Mezzanine here", input: "cpt one label East Mezzanine here", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true, label: "East Mezzanine" }) },
+  { name: "deixis+label rider, tagless: label Alternate this one", input: "label Alternate this one", ctx: { hasActiveCondition: true }, expect: ok({ kind: "trace_at_cursor", label: "Alternate" }) },
+  { name: "deixis full combo: carpet one waste seven label phase 1 right here", input: "carpet one waste seven label phase 1 right here", expect: ok({ kind: "trace_at_cursor", tag: "CPT-1", known: true, waste: 7, label: "Phase 1" }) },
+
+  // 17. deixis rejects — never a guess
+  { name: "bare deixis, no active condition: this room", input: "this room", expect: no("deixis_no_condition") },
+  { name: "bare deixis, no active condition: here", input: "here", expect: no("deixis_no_condition") },
+  { name: "tagless waste rider, no active condition: waste seven here", input: "waste seven here", expect: no("deixis_no_condition") },
+  { name: "deixis on note rejects: note check this one", input: "note check this one", expect: no("deixis_target") },
+  { name: "deixis on note rejects: note verify base here", input: "note verify base here", expect: no("deixis_target") },
+  { name: "deixis on clear label rejects: clear label here", input: "clear label here", expect: no("deixis_target") },
+  { name: "deixis on clear label rejects: clear label this room", input: "clear label this room", expect: no("deixis_target") },
+  { name: "deixis with numberless tag rejects: carpet this room", input: "carpet this room", expect: no("unknown_tag") },
+  { name: "deixis with prose head rejects: hello this room", input: "hello this room", expect: no("unrecognized") },
+  { name: "deixis keeps the ambiguity bar: carpet one seven this room", input: "carpet one seven this room", expect: no("trailing_words") },
+  { name: "deixis with numberless waste rejects: cpt one waste here", input: "cpt one waste here", expect: no("bad_number") },
+  { name: "deixis with empty label rejects: label here", input: "label here", expect: no("unrecognized") },
 ];
 
 for (const c of CASES)


### PR DESCRIPTION
Implements the deixis slice per the design comment on #59 (https://github.com/Kentucky-ai/opentakeoff/issues/59#issuecomment-5040727788) — voice/Command-box grammar borrows the human's aim: while the pointer is on the canvas, a terminal deixis token resolves the cursor position into a one-click seed, and the utterance supplies everything else.

## Live demo (dev :5174, VA sample plan, scale 1/8"=1'-0", CPT-1 armed)

> **`carpet one, this room`** → "Created 1 takeoff — **44.8 SF** CPT-1. Click the next room." — solid ink, no proposal row, ⌘Z removes it.

Rejects, both spoken: pointer on canvas background → "Couldn't place that — aim at a sheet."; repeat-Enter without moving the pointer → "aim went stale. Put the cursor on the room and say it again."

## What's in it

- **Grammar** (`voiceIntent.ts`): terminal deixis tokens (`this room` / `here` / `this one` / `right here`) → new `trace_at_cursor` intent carrying optional tag/waste/label riders. Parser stays pure — it marks *that* the speaker aimed, never *where*. Bare deixis is active-condition-gated; deixis on `note`/`clear label` rejects. New reject reasons `deixis_no_condition`, `deixis_target`.
- **Caps** (`voiceActions.ts`): `getAimSeed(): {x,y,sheetId}|null` + `traceAt(seed, conditionId, label?)`. `null` = aim not live; `sheetId:""` = live but off-sheet (mirrors the `getActiveConditionId()→""` precedent).
- **Canvas** (`TakeoffCanvas.jsx`): seed reads the existing crosshair tracker — no second pointer tracker. Stale-aim rule: the pointer must have moved since the latest of {box focus, previous run, canvas pointerleave, tab-hide}, and each run consumes the aim — kills ghost seeds (parked pointer, tab refocus) and repeat-utterance double-commits.
- **Who-aimed-it**: human-deixis commits DIRECT through the same one-click path a physical click takes — extracted shared cores `buildOneClickRegion` + `commitOneClickRegions` so ⏎ / double-click / button / voice all route through the one Create gate and can never diverge. Lands as human work (undo covers it, same capture origin). `agentProposals` accept gate untouched; a pending interactive proposal makes deixis reject loudly rather than swallow staged regions. `open_boundary`/`tiny` flood failures speak instead of committing garbage.

## Tests

+47 (voiceIntent 204, voiceActions 474 lines): full deixis token × (tag | bare | +waste | +label) matrix, bare-deixis-no-condition + deixis-on-note rejects, seed handoff via ordered call-log matching the click path's sequence, direct-commit (never a proposal row), off-sheet + stale-aim rejects with zero mutation, deep-equal state vs the equivalent aimed click. Typecheck, lint, build green; suite 908/912 locally — the 4 fails are the known Node-25 localStorage false-fails (CI's pinned Node 24 is arbiter).

One deliberate grammar consequence, per the terminal-rider rule: `label X here` / `waste 7 here` now parse as deixis productions (previously label-verbatim / trailing-reject).

Non-goals honored: no recognizer work (that slice stays claimed in #59), no two-tier router — the seam is left for grammar-fastpath → #63 fallback.
