### PR TITLE
Adopt npm trusted publishing for opentakeoff-mcp releases

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,8 +1,12 @@
 name: Publish to MCP Registry
 
-# Registry-only release automation. The npm artifact is published manually
-# (hardware-key 2FA) BEFORE the tag is pushed — this workflow refuses to run
-# ahead of it. workflow_dispatch exercises OIDC login without publishing.
+# Full release automation via trusted publishing (adopted 2026-07-21, decision
+# doc in the maintainer binder): pushing an mcp-v* tag publishes the npm
+# artifact (OIDC, provenance attested — no token exists anywhere), then the
+# MCP registry entry, the GitHub release, and the MCPB bundle. The `release`
+# environment pauses every run for the maintainer's approval, so a human
+# decision still gates each publish. workflow_dispatch exercises OIDC login
+# without publishing.
 #
 # MCP releases live in the mcp-v* tag namespace: bare v* tags are app
 # releases (v0.2.0, v0.3.0 already exist), so the server versions its tags
@@ -14,12 +18,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write # OIDC token for mcp-publisher login github-oidc
+  id-token: write # OIDC token for npm trusted publishing + mcp-publisher login github-oidc
   contents: write # tag checkout + GitHub release creation
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release # required reviewer holds the run until approved
     defaults:
       run:
         working-directory: mcp
@@ -44,14 +49,31 @@ jobs:
             fi
           fi
 
-      - name: Require the npm artifact to exist
+      - uses: actions/setup-node@v4
+        if: github.ref_type == 'tag'
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: |
+            web/package-lock.json
+            mcp/package-lock.json
+
+      - name: Install the engine's dependencies (mcp imports web/src/lib)
+        if: github.ref_type == 'tag'
+        working-directory: web
+        run: npm ci --no-audit --no-fund
+
+      - name: Publish to npm (trusted publishing, provenance attested)
         if: github.ref_type == 'tag'
         run: |
           VERSION=$(jq -r .version package.json)
-          if ! npm view "opentakeoff-mcp@${VERSION}" version; then
-            echo "::error::opentakeoff-mcp@${VERSION} is not on npm — npm publish (hardware key) comes before the tag push"
-            exit 1
+          if npm view "opentakeoff-mcp@${VERSION}" version 2>/dev/null; then
+            echo "opentakeoff-mcp@${VERSION} is already on npm — skipping publish (idempotent re-run)"
+            exit 0
           fi
+          npm ci --no-audit --no-fund
+          # prepublishOnly runs the full gate (typecheck + tests + build) before anything ships
+          npm publish --provenance --access public
 
       - name: Install mcp-publisher
         run: |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -212,19 +212,25 @@ npm test        # session + tool-layer + e2e, against demo/sample-plan.pdf
 ## Releasing (maintainers)
 
 MCP releases live in the **`mcp-v*`** tag namespace — bare `v*` tags belong to
-the app (v0.2.0, v0.3.0 are app releases). The npm artifact publishes manually
-(hardware-key 2FA) **before** the tag is pushed; the workflow refuses to run
-ahead of it.
+the app (v0.2.0, v0.3.0 are app releases). Releases publish via **npm trusted
+publishing**: the tag push fires `.github/workflows/publish-mcp.yml`, which
+pauses at the `release` environment for maintainer approval, then publishes
+the npm artifact over OIDC with a **provenance attestation** (no npm token
+exists anywhere — the npm package designates that exact repo + workflow as
+its trusted publisher), followed by the MCP registry entry, the GitHub
+release, and the MCPB bundle.
 
 ```bash
 # 1. bump the version — all three fields together:
 #    package.json .version, server.json .version, server.json .packages[0].version
-# 2. from mcp/, publish with the hardware key:
-npm publish
-# 3. tag and push — this fires .github/workflows/publish-mcp.yml:
+# 2. tag and push — this fires the whole release:
 git tag mcp-v<version> && git push origin mcp-v<version>
+# 3. approve the run (GitHub → Actions → the paused "Publish to MCP Registry" run)
 ```
 
-The workflow checks version consistency, requires the npm artifact to exist,
-publishes to the official MCP registry via GitHub OIDC, verifies the listing,
-and creates the GitHub release (titled `opentakeoff-mcp <version>`).
+The workflow checks version consistency, runs the full publish gate
+(`prepublishOnly` = typecheck + tests + build), publishes to npm and the
+official MCP registry, verifies the registry listing, and creates the GitHub
+release (titled `opentakeoff-mcp <version>`). A re-run skips the npm publish
+if that version already shipped, so a transient failure downstream is safe to
+retry.


### PR DESCRIPTION
Retires the manual hardware-key npm ceremony (decision doc: adopt with gate). Pushing an `mcp-v*` tag now runs the **whole** release in one workflow, paused at the new `release` environment until the maintainer approves the run:

1. version-consistency check (unchanged);
2. **npm publish over OIDC trusted publishing with `--provenance`** — no token stored anywhere, nothing to expire; the npm page gets a verified built-from-this-repo attestation. `prepublishOnly` (typecheck + full test suite + build) runs in CI before anything ships, with web/ deps installed since the engine imports `web/src/lib`. If the version is already on npm the step skips cleanly, so re-running after a transient downstream failure never double-publishes;
3. MCP registry publish + listing verification, GitHub release, MCPB attach (all unchanged).

The old "require the npm artifact to exist" gate is replaced by the idempotent skip — the workflow now *creates* the artifact. The `release` environment (required reviewer) was created ahead of this PR; the npm-side trusted publisher (repo `Kentucky-ai/opentakeoff`, workflow `publish-mcp.yml`, environment `release`) is configured on npmjs.com by the maintainer. mcp/README's Releasing section documents the new ceremony: bump → merge → tag → approve.