### PR TITLE
fix(mcp): detect_rooms withholds what it can't stand behind

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.6.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -69,6 +69,7 @@ export const oneClickOutput = {
 const detectedRoom = z.object({
   label: z.string().describe("The room-number text the seed was read from (e.g. \"104\", \"139A\")"),
   nverts: z.number().int().describe("Vertex count of the traced polygon"),
+  merged_labels: z.array(z.string()).optional().describe("Other labels that flooded to this same region — the area is counted once, under `label`"),
   hatch_filtered: z.literal(true).optional().describe("Present when hatch/pattern linework was classified out of the boundary"),
   verts: z.array(point).optional().describe("Traced polygon vertices (image px), when return_verts was set"),
   area_sf: z.number().optional().describe("Scaled mode: traced area in SF"),
@@ -86,6 +87,14 @@ const detectedRoom = z.object({
 export const detectRoomsOutput = {
   detected: z.number().int().describe("Count of cleanly-detected rooms — may be fewer than the labels found on the sheet"),
   rooms: z.array(detectedRoom),
+  withheld: z.object({
+    total: z.number().int().describe("Seeds found on the sheet but not reported as rooms"),
+    degenerate: z.number().int().describe("Traced to fewer than 3 vertices"),
+    duplicate: z.number().int().describe("Flooded to a region another label already claimed — counted once, never twice"),
+    implausible: z.number().int().describe("Enclosed and clean, but smaller than min_area_sf — a label bubble, door swing, or wall cavity rather than a room"),
+    min_area_sf: z.number().optional().describe("The plausibility floor applied (scaled mode only)"),
+  }).describe("What detection skipped and why — a withheld room is a question the caller can ask; a silently dropped one is a hole in a bid"),
+  note: z.string().optional().describe("Human-readable summary of what was withheld, when anything was"),
   warning: z.string().optional().describe("Preview mode (no scale): why quantities are unavailable and what to do"),
 };
 

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -426,50 +426,96 @@ export class Session {
    *  exactly like oneClick — just N of them from one call instead of N
    *  reasoning-heavy round-trips. Same contract as oneClick: no scale → a
    *  px-only preview per room; no condition → nothing commits (a review
-   *  pass, not a proposal-acceptance gate — this server has none). A region
-   *  that traces to a degenerate ring (<3 verts) is dropped from the batch
-   *  rather than failing the whole call — one bad label must not sink every
-   *  other clean detection on the sheet. */
-  async detectRooms(name: string, opts: { condition?: string; role: "floor_area" | "deduct"; returnVerts: boolean }) {
+   *  pass, not a proposal-acceptance gate — this server has none).
+   *
+   *  Withholding — nothing is committed until it survives all three, and the
+   *  batch NEVER silently drops work: every withheld seed is counted and
+   *  reasoned in `withheld`, because a room the tool knows it skipped is a
+   *  question the caller can ask, while a room it skipped silently is a hole
+   *  in a bid.
+   *    1. degenerate — traced to fewer than 3 vertices.
+   *    2. duplicate — two labels flooding one region (a room tagged twice, or
+   *       a legend number landing in the same space) trace to an identical
+   *       ring. Committing both double-counts the area with no signal, which
+   *       is the worst failure mode an estimating tool has. One region commits
+   *       once; the collapsed labels ride along on `merged_labels`.
+   *    3. implausible — a flood trapped inside a room-number bubble, a door
+   *       swing, or a wall cavity is fully enclosed, so it traces clean and
+   *       `detectRegions` passes it. Area is the only thing that separates it
+   *       from a room. Withheld below `minAreaSf` (default 5 SF — smaller than
+   *       any real finished space; a broom closet is ~10 SF). Only applied
+   *       once a scale exists, since without one there is no real area to
+   *       judge and nothing commits anyway. */
+  async detectRooms(name: string, opts: { condition?: string; role: "floor_area" | "deduct"; returnVerts: boolean; minAreaSf?: number }) {
     const s = this.sheet(name);
     const mask = await this.ensureMask(name);
     if (!mask) throw new UserError("This sheet has no vector linework (likely a scan); raster fallback not yet available in the MCP server.");
+    const minAreaSf = opts.minAreaSf ?? 5;
     const seeds = roomLabelSeeds(s.text);
     const regions = detectRegions(mask, seeds);
-    const rooms = regions
-      .map((r) => {
-        const ring = snapVertices(traceRegion(r.flood), (px, py, d) => (s.snap ? nearestSnap(s.snap, px, py, d) : null), SNAP_TOL);
-        if (ring.length < 3) return null; // couldn't trace into a polygon — drop, don't sink the batch
-        const areaPx2 = ringArea(ring);
-        const perimPx = closedMetrics(ring).perim;
+
+    // Trace every region first. Nothing commits in this pass — withholding has
+    // to be decided across the whole batch (dedupe needs to see every ring).
+    const withheld = { degenerate: 0, duplicate: 0, implausible: 0 };
+    type Cand = { label: string; ring: Point[]; areaPx2: number; perimPx: number; seed: readonly [number, number] | number[]; hatch: boolean; merged: string[] };
+    const byRing = new Map<string, Cand>();
+    const order: Cand[] = [];
+    for (const r of regions) {
+      const ring = snapVertices(traceRegion(r.flood), (px, py, d) => (s.snap ? nearestSnap(s.snap, px, py, d) : null), SNAP_TOL);
+      if (ring.length < 3) { withheld.degenerate++; continue; }
+      const key = ring.map(([x, y]) => `${Math.round(x)},${Math.round(y)}`).join(";");
+      const seen = byRing.get(key);
+      if (seen) { seen.merged.push(r.str); withheld.duplicate++; continue; }
+      const cand: Cand = {
+        label: r.str, ring, areaPx2: ringArea(ring), perimPx: closedMetrics(ring).perim,
+        seed: r.seed, hatch: !!r.flood.hatchFiltered, merged: [],
+      };
+      byRing.set(key, cand);
+      order.push(cand);
+    }
+
+    const upp = s.upp;
+    const rooms = order
+      .map((c) => {
         const common = {
-          label: r.str,
-          nverts: ring.length,
-          ...(r.flood.hatchFiltered ? { hatch_filtered: true as const } : {}),
-          ...(opts.returnVerts ? { verts: ring.map(([vx, vy]) => [round1(vx), round1(vy)]) } : {}),
+          label: c.label,
+          nverts: c.ring.length,
+          ...(c.merged.length ? { merged_labels: c.merged } : {}),
+          ...(c.hatch ? { hatch_filtered: true as const } : {}),
+          ...(opts.returnVerts ? { verts: c.ring.map(([vx, vy]) => [round1(vx), round1(vy)]) } : {}),
         };
-        if (s.upp == null) {
-          return { ...common, area_px2: round1(areaPx2), perimeter_px: round1(perimPx) };
+        if (upp == null) {
+          return { ...common, area_px2: round1(c.areaPx2), perimeter_px: round1(c.perimPx) };
         }
-        const upp = s.upp;
-        const area_sf = round2(areaPx2 * upp * upp);
-        const perimeter_lf = round2(perimPx * upp);
+        const area_sf = round2(c.areaPx2 * upp * upp);
+        if (area_sf < minAreaSf) { withheld.implausible++; return null; }
+        const perimeter_lf = round2(c.perimPx * upp);
         let shape_id: string | undefined;
         if (opts.condition) {
-          shape_id = this.commit(s, opts.condition, opts.role, ring, { area_sf, perimeter_lf }, {
+          shape_id = this.commit(s, opts.condition, opts.role, c.ring, { area_sf, perimeter_lf }, {
             method: "one_click_v1",
             actor: "agent",
-            seed_norm: [r.seed[0] / s.widthPx, r.seed[1] / s.heightPx],
+            seed_norm: [c.seed[0] / s.widthPx, c.seed[1] / s.heightPx],
             reviewed: false,
-            ...(r.flood.hatchFiltered ? { hatch_filtered: true as const } : {}),
+            ...(c.hatch ? { hatch_filtered: true as const } : {}),
           }).id;
         }
         return { ...common, area_sf, perimeter_lf, ...(shape_id ? { shape_id } : {}) };
       })
       .filter((r): r is NonNullable<typeof r> => r !== null);
+
+    const withheldTotal = withheld.degenerate + withheld.duplicate + withheld.implausible;
     return {
       detected: rooms.length,
       rooms,
+      withheld: {
+        total: withheldTotal,
+        ...withheld,
+        ...(upp != null ? { min_area_sf: minAreaSf } : {}),
+      },
+      ...(withheldTotal
+        ? { note: `${withheldTotal} seed(s) withheld — ${withheld.duplicate} duplicate region(s), ${withheld.implausible} under ${minAreaSf} SF, ${withheld.degenerate} untraceable. Raise or lower min_area_sf to see more.` }
+        : {}),
       ...(s.upp == null ? { warning: `No scale set for ${s.key} — quantities unavailable. Call set_scale${s.detected ? ` (detected: ${s.detected.label})` : ""}.` } : {}),
     };
   }

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -81,15 +81,16 @@ export function registerTools(server: McpServer, session: Session): void {
   }, run("one_click", (a) => session.oneClick(a.sheet, a.x, a.y, { condition: a.condition, role: a.role, returnVerts: a.return_verts })));
 
   server.registerTool("detect_rooms", {
-    description: `Batch room detection: reads every room-number label off the sheet's text layer (e.g. "134", "OFFICE 101") and runs One-Click at each — one call instead of read_sheet_text + reasoning + N one_click calls. Only cleanly-traced rooms are returned; a label that leaked or landed in dense linework is silently withheld, never reported as a bad room. With the sheet's scale set, returns area_sf/perimeter_lf per room; pass condition to commit every detected room under that finish tag (role "deduct" makes them subtract). Without a scale, returns px-only quantities per room and commits nothing. ${COORDS}`,
+    description: `Batch room detection: reads every room-number label off the sheet's text layer (e.g. "134", "OFFICE 101") and runs One-Click at each — one call instead of read_sheet_text + reasoning + N one_click calls. A seed is only reported as a room once it survives three gates, and everything skipped is counted and reasoned in \`withheld\` — never dropped silently, because a room the tool tells you it skipped is a question you can ask, while one it hides is a hole in a bid. The gates: a flood that leaked or landed in dense linework never becomes a region; two labels flooding the SAME region commit once (the extra labels ride on \`merged_labels\` — double-counting an area is the worst failure an estimating tool has); and a flood that is enclosed and clean but smaller than min_area_sf is a room-number bubble, a door swing, or a wall cavity rather than a room. With the sheet's scale set, returns area_sf/perimeter_lf per room; pass condition to commit every detected room under that finish tag (role "deduct" makes them subtract). Without a scale, returns px-only quantities per room and commits nothing — the plausibility floor needs real units, so it only applies once a scale is set. ${COORDS}`,
     inputSchema: {
       sheet: z.string(),
       condition: z.string().optional().describe("Finish tag to commit every detected room under (minted on first use)"),
       role: roleSchema,
       return_verts: z.boolean().default(false).describe("Include each traced polygon's vertices (image px)"),
+      min_area_sf: z.number().positive().default(5).describe("Plausibility floor: enclosed regions smaller than this are withheld as label bubbles/cavities, not rooms. Default 5 SF — below any real finished space (a broom closet is ~10 SF). Lower it to inspect what was skipped."),
     },
     outputSchema: detectRoomsOutput,
-  }, run("detect_rooms", (a) => session.detectRooms(a.sheet, { condition: a.condition, role: a.role, returnVerts: a.return_verts })));
+  }, run("detect_rooms", (a) => session.detectRooms(a.sheet, { condition: a.condition, role: a.role, returnVerts: a.return_verts, minAreaSf: a.min_area_sf })));
 
   server.registerTool("measure_polygon", {
     description: `Measure a closed polygon you supply (min 3 vertices, image px): area_sf and perimeter_lf at the sheet's scale. Requires the scale to be set. Pass condition to commit it; role "deduct" subtracts. ${COORDS}`,

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -93,6 +93,50 @@ test("detect_rooms: batch-finds all 4 rooms via the wire, commits under one cond
   assert.equal(summary.data.conditions[0].shape_count, 4);
 });
 
+// Regression for FINDING-2026-07-22: on a real sheet, detect_rooms reported 48
+// "rooms" — 37 of them label-bubble floods under 5 SF, plus one region claimed by
+// two labels and committed twice (589 SF double-counted). Every one traced
+// cleanly, so the <3-vertex guard passed them and the schema tests passed too.
+// What was missing was a contract on WITHHOLDING, so that is what these assert.
+test("detect_rooms withholding: floor is enforced, reported, and never silent", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  await call(client, "set_scale", { sheet: KEY, use_detected: true });
+
+  const normal = await call(client, "detect_rooms", { sheet: KEY, return_verts: true });
+  assert.equal(normal.isError, false);
+  assert.ok(normal.data.withheld, "withheld is always reported, even when nothing was withheld");
+  assert.equal(typeof normal.data.withheld.total, "number");
+  assert.equal(normal.data.withheld.min_area_sf, 5, "default plausibility floor");
+
+  // No two reported rooms may share a ring — that is the double-count. Keyed on
+  // real geometry: the fixture's rooms are congruent, so area would collide.
+  const rings = normal.data.rooms.map((r: any) => JSON.stringify(r.verts));
+  assert.ok(rings.every((v: string) => v !== undefined));
+  assert.equal(new Set(rings).size, rings.length, "one region commits once");
+
+  // Raise the floor above every room: all withheld, counted as implausible,
+  // and — the part that actually matters — nothing committed.
+  const strict = await call(client, "detect_rooms", { sheet: KEY, condition: "CPT-1", min_area_sf: 1e6 });
+  assert.equal(strict.isError, false);
+  assert.equal(strict.data.detected, 0);
+  assert.equal(strict.data.rooms.length, 0);
+  assert.equal(strict.data.withheld.implausible, normal.data.detected);
+  assert.match(strict.data.note, /withheld/);
+  const summary = await call(client, "takeoff_summary");
+  assert.equal(summary.data.conditions.length, 0, "withheld rooms must not commit");
+});
+
+test("detect_rooms preview: the plausibility floor needs real units, so it waits for a scale", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  const preview = await call(client, "detect_rooms", { sheet: KEY, min_area_sf: 1e6 });
+  assert.equal(preview.isError, false);
+  assert.equal(preview.data.withheld.implausible, 0, "no scale — no SF to judge, so the floor cannot apply");
+  assert.equal(preview.data.withheld.min_area_sf, undefined);
+  assert.ok(preview.data.detected > 0);
+});
+
 test("measure_polygon scale gate: exact refusal text with the detected hint", async () => {
   const client = await pair();
   await call(client, "load_plan", { path: PLAN });


### PR DESCRIPTION
`detect_rooms` on the bundled sample plan reported **48 rooms**. Ten of them were rooms.

- 37 were floods trapped inside room-number bubbles, door swings, and wall cavities — median **4.7 SF**, most of them 4-vertex squares the size of the label tag itself.
- Labels `557` and `706` flooded to a **byte-identical 184-vertex ring** and both committed: **589.18 SF counted twice**, 17.5% of the reported total, with nothing in the output to indicate it.

Every one of those traced cleanly, so the `<3 vertex` guard passed them, and the schema tests passed too.

## Why the existing guards didn't catch it

The floods aren't malformed. `detectRegions` already rejects leaks and dense linework (`f.status !== "ok"`), and that gate works. But a fill trapped inside a label bubble is *fully enclosed* — status `ok`, clean ring, valid polygon. **Area was the only thing separating it from a room, and nothing was checking area.**

The measured distribution shows how clean the separation actually is:

```
0.35 … 4.72 SF   ← 37 rings (label bubbles, cavities)
      ↓
7.33 · 12.53 · 51.13 · 90.97 · 153.32 · 183.35 · 285.64 · 374.21 · 589.18 · 862.54 SF   ← the rooms
```

## Three gates, nothing silent

1. **Dedupe by traced ring** — one region commits once. Labels that collapsed onto it ride along on `merged_labels` rather than disappearing. Double-counting an area is the worst failure mode an estimating tool has.
2. **`min_area_sf` plausibility floor, default 5 SF** — below any real finished space (a broom closet is ~10 SF) and below the gap above. Applied **only once a scale is set**: without real units there is nothing to judge, and nothing commits anyway.
3. **`withheld` is always returned** — `{ total, degenerate, duplicate, implausible, min_area_sf }` plus a readable `note`. A room the tool tells you it skipped is a question you can ask; one it hides is a hole in a bid. `min_area_sf` doubles as the escape hatch to inspect what was skipped.

The docstring promised silent withholding the code never performed. It now describes what is actually enforced — the gap between doc and behaviour costs more trust than the defect did.

## Result on the sample plan

| | before | after |
|---|---|---|
| Rooms reported | 48 | **10** |
| Median area | 4.71 SF | **183.35 SF** |
| Double-counted | 589.2 SF | **0** |
| Committed total | 3,359.9 SF | **2,610.2 SF** |
| Withheld reporting | none | `38 withheld — 1 duplicate, 37 under 5 SF, 0 untraceable` |

Preview mode (no scale) correctly ignores the floor: 47 detected, dedupe only.

## Tests

Conformance covered the tool's *schema* and its semantic-misuse errors — not measurement plausibility, which is why CI never saw this. Two tests added on the **withholding contract**: the floor is enforced, reported, and commits nothing when it fires; reported rings are unique; and the floor waits for a scale.

`npm run typecheck` clean · `npm test` **43/43** · `npm run build` + `npm run smoke:dist` green · verified against the built `dist/` bundle, not just source.
