### PR TITLE
Stage the voice model at deploy time so the hosted demo has push-to-talk (RFC #59)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,12 @@
 # GEMINI_API_KEY is set, so a default deploy is still fully static.
 [build]
   base    = "web"
-  command = "npm run build"
+  # Stage the on-device voice model (RFC #59) same-origin before the build, so
+  # push-to-talk dictation is live on the hosted demo (~44 MB, gitignored, not
+  # fetched by the app at runtime). Tolerant by design: a HuggingFace hiccup at
+  # deploy time logs and deploys WITHOUT voice rather than failing the whole
+  # static site — feature-absence, never breakage, exactly as the app degrades.
+  command = "node scripts/fetch-voice-model.mjs || echo 'voice model fetch failed — deploying without voice'; npm run build"
   publish = "dist"
 
 # Serverless functions live under the build base (web/netlify/functions).


### PR DESCRIPTION
Slice-4 follow-up to #90 (RFC #59 voice recognizer). The recognizer ships the model as a gitignored, staged artifact — the running app never fetches it from a third party. This wires the Netlify build to stage it same-origin before `vite build`, so push-to-talk dictation is live on the hosted demo.

**Tolerant by design:** the fetch is guarded (`node scripts/fetch-voice-model.mjs || echo …; npm run build`) — a HuggingFace hiccup at deploy time logs and deploys the demo *without* voice rather than failing the whole static site. Feature-absence, never breakage — the same way the app degrades when the model isn't present.

~44 MB, cached between builds. No app code changes; `netlify.toml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
