### PR TITLE
feat(voice): the two-tier router - consent-gated bridge to the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased — the two-tier router (RFC #59, slice 5)
+
+### Added
+- **"ask the agent" — the consent-gated bridge from voice to the agent.** The deterministic grammar stays the entire fast path; when a spoken/typed command is *fully* unrecognized and the bring-your-own agent is configured, the red rejection now adds an offer: press `⏎` (or say the fixed literal **"ask the agent"**) to hand that exact transcript to the in-canvas agent as a task. The offer names both costs — the text leaves the browser, on *your* endpoint with *your* key — expires after 20 s, and never appears for near-miss rejects (a garbled number or trailing words is almost-valid grammar; routing it would launder a mishear into a mutation — pinned by a table test across every rejection reason). Confirmation runs the exact same `runAgent` the Agent panel runs — same tools, same dashed-proposals → Accept gate — so the router changes who *reads* the words, never who owns the work, and the zero-wrong-actions invariant never sees the agent path. Design record and green-light on [#59](https://github.com/Kentucky-ai/opentakeoff/issues/59). Contributed by @karthikyeluripati.
+
 ## Unreleased — voice dictation: the recognizer (RFC #59, slice 4)
 
 ### Added

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -662,6 +662,15 @@ Anything ambiguous is refused with a red explanation, never guessed —
 "carpet one seven" could be CPT-1 + waste 7 or a mis-heard CPT-17, so it
 asks you to say it again.
 
+**When it isn't a command.** If what you said (or typed) isn't in the grammar
+at all and you've configured the bring-your-own agent (§14), the red
+rejection adds an offer: press `⏎` — or say **"ask the agent"** — to hand
+that exact text to the agent as a task. It runs on *your* endpoint with
+*your* key, its proposals land as dashed outlines for your review, and
+nothing is ever sent without that explicit confirm (`Esc` or 20 seconds
+dismisses the offer). Near-miss commands — a garbled number, extra words —
+never get the offer; they just ask you to say it again.
+
 **Push-to-talk.** Hold **M** (or hold the **Voice** toolbar button), speak,
 release to run — the transcript flashes in a chip so you can see what was
 heard, then the outcome lands in the message bar. `Esc` mid-hold discards.

--- a/docs/VOICE.md
+++ b/docs/VOICE.md
@@ -97,6 +97,34 @@ stress floor, not a forecast), but the safety property held absolutely:
 a mishear costs a re-say, never corrupted takeoff data. The committed
 corpus of real recorded speech is what the CI floor applies to.
 
+## The two-tier router (slice 5)
+
+The grammar is the entire fast path — deterministic, zero AI. When a
+transcript is **fully unrecognized** (and only then), and the bring-your-own
+agent is configured, the red rejection gains one *offered* escape hatch:
+
+> not a command — ⏎ or say "ask the agent" to run it on YOUR agent
+> (your endpoint, your key) · proposals land for review · Esc dismisses
+
+The hard lines, all pinned by tests:
+- **Never silent, never auto.** The rejection stays; the offer only acts on
+  explicit confirmation, names both costs (the transcript leaves the browser;
+  it runs on your configured endpoint), and expires after 20 s so a stale ⏎
+  can't become a surprise agent run. Unconfigured deployments never see it.
+- **Near-misses never route.** `bad_number`, `trailing_words`, `unknown_tag`
+  and the deixis rejects are almost-valid grammar — routing them would
+  launder a mishear into a mutation. They keep asking for a re-say
+  (table-tested across every rejection reason).
+- **"ask the agent" is a fixed literal**, matched whole-utterance after
+  punctuation strip — not a grammar production; "no second grammar" stays
+  honest. Spoken with nothing pending it says so and sends nothing.
+- **The bridge grows nothing.** Confirmation calls the same `runAgent` the
+  Agent panel runs — same config, same tool registry, and agent-inferred work
+  stays on the dashed-proposals → Accept gate. The router changes who reads
+  the words, never who owns the work; the zero-wrong-actions invariant never
+  sees the agent path because the router only exists where the dispatcher
+  refused.
+
 ## Privacy proof
 
 - `web/test/voicePrivacy.test.ts` replaces `fetch`/`XMLHttpRequest`/`WebSocket`

--- a/web/src/lib/voiceActions.ts
+++ b/web/src/lib/voiceActions.ts
@@ -53,7 +53,13 @@ export type VoiceCapabilities = {
   addNote(text: string): void;
 };
 
-export type VoiceOutcome = { ok: boolean; message: string };
+/** reason rides ONLY on parse rejections (runVoiceCommand) — it is what lets
+ *  the two-tier router (slice 5) tell `unrecognized` (offerable to the agent)
+ *  from every other reject, which are near-misses of valid grammar: routing
+ *  those would launder a mishear into a mutation, so they keep asking for a
+ *  re-say. Dispatcher failures (ok:false from applyVoiceIntent) carry no
+ *  reason and are never offerable. */
+export type VoiceOutcome = { ok: boolean; message: string; reason?: RejectReason };
 
 /** Every value MUST start with "Couldn't" — that prefix is what the commitMsg
  *  bar's isDangerMsg keys on to render red + sticky. */
@@ -168,6 +174,33 @@ export function runVoiceCommand(caps: VoiceCapabilities, transcript: string): Vo
     shapeLabels: caps.getShapeLabels(),
     hasActiveCondition: caps.getActiveConditionId() !== "",
   });
-  if (!parsed.ok) return fail(REJECTION_MESSAGES[parsed.reason]);
+  if (!parsed.ok) return { ...fail(REJECTION_MESSAGES[parsed.reason]), reason: parsed.reason };
   return applyVoiceIntent(caps, parsed.intent);
+}
+
+// ── the two-tier router seam (RFC #59 slice 5) ─────────────────────────────
+// The router is a thin, consent-gated bridge from a REFUSED transcript into
+// the existing agent loop (runAgentLoop + tool registry + Accept gate). It
+// never runs where the dispatcher acted — the zero-wrong-actions invariant
+// never sees the agent path — and it grows no tools and no interpretation of
+// its own. The canvas renders the offer; these pure pieces decide it.
+
+/** The spoken confirmation is a FIXED LITERAL (review ask on the design
+ *  record), not a grammar production — "no second grammar" stays honest. */
+export const AGENT_HANDOFF_TRIGGER = "ask the agent";
+
+/** Whole-utterance equality after trim/lowercase/terminal-punctuation strip
+ *  (whisper writes "Ask the agent."). "please ask the agent" or the phrase
+ *  inside prose does NOT match — a trigger is said alone or not at all. */
+export function isAgentHandoffTrigger(text: string): boolean {
+  return text.trim().toLowerCase().replace(/[.!?,;:…]+$/u, "").trim() === AGENT_HANDOFF_TRIGGER;
+}
+
+/** The offer gate, in one pure predicate (the pinned near-miss test bites
+ *  here): ONLY a fully-unrecognized transcript with the agent actually
+ *  configured is offerable. Near-misses (bad_number, trailing_words,
+ *  unknown_tag, deixis_*) are almost-valid grammar — routing them would
+ *  launder a mishear into a mutation — and `empty` has nothing to send. */
+export function shouldOfferAgentHandoff(outcome: VoiceOutcome, aiConfigured: boolean): boolean {
+  return !outcome.ok && outcome.reason === "unrecognized" && aiConfigured;
 }

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -62,7 +62,7 @@ import AgentPanel from "../components/AgentPanel.jsx";
 import AiSettings from "../components/AiSettings.jsx";
 import { AGENT_TOOL_DEFS, executeAgentTool, agentScaleGate } from "../lib/agentTools.js";
 import { runAgentLoop } from "../lib/agentLoop.js";
-import { runVoiceCommand } from "../lib/voiceActions";
+import { runVoiceCommand, isAgentHandoffTrigger, shouldOfferAgentHandoff } from "../lib/voiceActions";
 import { createVoiceRecognizerClient } from "../lib/voiceRecognizerClient";
 import { startCapture, captureSupported } from "../lib/voiceCapture";
 import { aiConfig, isAiConfigured } from "../lib/ai.js";
@@ -1677,6 +1677,11 @@ export default function TakeoffCanvas() {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (menuDepthRef.current > 0) return;
       if (e.key === "Enter") {
+        // router offer confirm takes the key FIRST (RFC #59 slice 5): the
+        // offer is the most recent thing the user was told ⏎ does, and it
+        // auto-expires — so it can never contest ⏎ for long, and a pending
+        // agent-proposal accept resumes the key the moment the offer clears
+        if (agentOfferFnsRef.current?.pending()) { e.preventDefault(); agentOfferFnsRef.current.confirm(); return; }
         if (tool === "oneclick" && proposal?.regions.length) { e.preventDefault(); createProposal(); return; }
         const ok = ((tool === "area" || tool === "deduct") && poly.length >= 3) || (tool === "zone" && poly.length >= 3 && !zoneTraceCross) || ((tool === "linear" || tool === "surface" || tool === "curve") && poly.length >= 2);
         if (ok) { e.preventDefault(); finishShape(); return; }
@@ -1748,7 +1753,7 @@ export default function TakeoffCanvas() {
         // tool's points, on-screen or hidden
         else if (tool === "calibrate") { setCalib((c) => c.slice(0, -1)); }
         else if (tool === "check") { setCheck((c) => c.slice(0, -1)); }
-      } else if (e.key === "Escape") { if (ocSel) { setOcSel(null); } else if (selVert != null) { setSelVert(null); } else { setPoly([]); setCalib([]); setCheck([]); setCheckStated(""); setScaleGuide(null); selectShape(null); setMarkupDraft(null); setProposal(null); setArmedStamp(null); setScheduleAnchor(null); resetZone(); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; } }
+      } else if (e.key === "Escape") { if (agentOfferFnsRef.current?.pending()) { agentOfferFnsRef.current.dismiss(); } else if (ocSel) { setOcSel(null); } else if (selVert != null) { setSelVert(null); } else { setPoly([]); setCalib([]); setCheck([]); setCheckStated(""); setScaleGuide(null); selectShape(null); setMarkupDraft(null); setProposal(null); setArmedStamp(null); setScheduleAnchor(null); resetZone(); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; } }
       // ⌘Z: the drawing context wins — mid-trace it still pops the last placed
       // point (with or without ⇧, matching the old behavior byte-for-byte);
       // only with no trace in progress does the command stack engage
@@ -3800,7 +3805,16 @@ export default function TakeoffCanvas() {
     // repeating "this room" without a fresh pointer move is a stale-aim
     // reject, never a silent double-commit of the same room
     voiceAimMarkRef.current = aimSeqRef.current;
-    const finish = (o) => { setCommitMsg(o.message); return o.ok; };
+    const finish = (o) => {
+      setCommitMsg(o.message);
+      // two-tier router (RFC #59 slice 5): a FULLY-unrecognized transcript,
+      // with the agent configured, earns an OFFER — never an auto-run. Any
+      // other outcome (success, near-miss reject, dispatcher refusal) clears
+      // a stale offer so ⏎ can never become a surprise agent run.
+      if (shouldOfferAgentHandoff(o, isAiConfigured())) offerAgentHandoff(text);
+      else clearAgentOffer();
+      return o.ok;
+    };
     // deixis traces can resolve async (raster flood awaits a render) — the
     // outcome message lands when it lands; everything else stays synchronous
     return typeof out?.then === "function" ? out.then(finish) : finish(out);
@@ -3817,12 +3831,43 @@ export default function TakeoffCanvas() {
   // pointer tick mid-hold would stale-reject every still-handed "this room".
   // The standing invalidations (canvas-leave, tab-hide, previous run) still
   // guard every ghost-seed path the #83 design named.
-  const [voiceChip, setVoiceChip] = useState(null); // { text, tone: "live"|"busy"|"info" } | null
+  const [voiceChip, setVoiceChip] = useState(null); // { text, tone: "live"|"busy"|"info"|"offer" } | null
   const voiceClientRef = useRef(null);
   const voiceCaptureRef = useRef(null);              // live CaptureSession during a hold
   const voiceModelRef = useRef({ phase: "unprobed" });
   const voiceHoldRef = useRef(false);                // physical key/button state
   const voiceFlashRef = useRef(0);                   // transcript-flash timer
+  // ── two-tier router offer (RFC #59 slice 5) ───────────────────────────────
+  // A thin consent-gated bridge into the EXISTING agent loop: confirm hands
+  // the refused transcript to runAgent() — same cfg, tools, Accept gate as the
+  // panel; no new tools, no second interpretation. The offer expires (consent
+  // hygiene), and the spoken confirm is a fixed literal, never grammar.
+  const AGENT_OFFER_TTL_MS = 20000;
+  const pendingAgentOfferRef = useRef(null);         // { transcript } | null — the chip is the render, the ref is the logic
+  const agentOfferTimerRef = useRef(0);
+  function offerAgentHandoff(transcript) {
+    clearTimeout(agentOfferTimerRef.current);
+    pendingAgentOfferRef.current = { transcript };
+    setVoiceChip({ text: 'not a command — ⏎ or say "ask the agent" to run it on YOUR agent (your endpoint, your key) · proposals land for review · Esc dismisses', tone: "offer" });
+    agentOfferTimerRef.current = setTimeout(() => clearAgentOffer(), AGENT_OFFER_TTL_MS);
+  }
+  function clearAgentOffer() {
+    if (!pendingAgentOfferRef.current) return;
+    clearTimeout(agentOfferTimerRef.current);
+    pendingAgentOfferRef.current = null;
+    setVoiceChip((c) => (c && c.tone === "offer" ? null : c));
+  }
+  function confirmAgentHandoff() {
+    const t = pendingAgentOfferRef.current?.transcript;
+    clearAgentOffer();
+    if (!t) return;
+    // runAgent self-guards (agentRunning, isAiConfigured, sheet ready); the
+    // panel opens so the run — and its Accept gate — happen in plain sight
+    setAgentOpen(true);
+    void runAgent(t);
+  }
+  const agentOfferFnsRef = useRef(null);
+  agentOfferFnsRef.current = { confirm: confirmAgentHandoff, dismiss: clearAgentOffer, pending: () => !!pendingAgentOfferRef.current };
   function ensureVoiceClient() {
     if (!voiceClientRef.current) {
       voiceClientRef.current = createVoiceRecognizerClient((s) => {
@@ -3875,6 +3920,16 @@ export default function TakeoffCanvas() {
     setVoiceChip({ text: "decoding…", tone: "busy" });
     voiceClientRef.current.transcribe(pcm).then((text) => {
       const t = text.trim();
+      // the spoken router confirm is a FIXED LITERAL (never grammar): said
+      // alone with an offer pending it confirms; without one it says so —
+      // and the trigger itself never becomes an offer
+      if (isAgentHandoffTrigger(t)) {
+        if (pendingAgentOfferRef.current) { setVoiceChip(null); agentOfferFnsRef.current.confirm(); return true; }
+        setVoiceChip({ text: "nothing to hand off — say the command first", tone: "info" });
+        clearTimeout(voiceFlashRef.current);
+        voiceFlashRef.current = setTimeout(() => setVoiceChip((c) => (c && c.tone === "info" ? null : c)), 2400);
+        return false;
+      }
       // flash what was heard — the transcript is the receipt — then the
       // outcome lands in the commitMsg bar like every other command
       setVoiceChip(t ? { text: `“${t}”`, tone: "info" } : null);
@@ -3920,11 +3975,13 @@ export default function TakeoffCanvas() {
       window.removeEventListener("keydown", down);
       window.removeEventListener("keyup", up);
       document.removeEventListener("visibilitychange", onVis);
-      // unmount cleanup — no orphaned audio contexts or workers
+      // unmount cleanup — no orphaned audio contexts, workers, or offer timers
       voiceCaptureRef.current?.cancel();
       voiceCaptureRef.current = null;
       voiceClientRef.current?.dispose();
       voiceClientRef.current = null;
+      clearTimeout(agentOfferTimerRef.current);
+      pendingAgentOfferRef.current = null;
     };
   }, []);
 
@@ -4998,6 +5055,14 @@ export default function TakeoffCanvas() {
               const v = e.currentTarget.value.trim();
               if (!v) return;
               const el = e.currentTarget;   // capture: currentTarget nulls after dispatch, and deixis outcomes can resolve async (raster)
+              // router confirm (RFC #59 slice 5): the rejected text is still in
+              // the box (only success clears it) — a second ⏎ on the SAME text
+              // confirms the pending offer instead of re-rejecting in a loop
+              if (pendingAgentOfferRef.current && v === pendingAgentOfferRef.current.transcript) {
+                agentOfferFnsRef.current.confirm();
+                el.value = "";
+                return;
+              }
               Promise.resolve(onVoiceCommand(v)).then((ok) => { if (ok) el.value = ""; });
             }}
             style={{ fontFamily: "var(--f-mono)", fontSize: 11.5, padding: "5px 6px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", width: 150 }}
@@ -5853,7 +5918,7 @@ export default function TakeoffCanvas() {
             hold state, decode state, and a brief flash of the heard transcript
             (the receipt); outcomes land in the commitMsg bar like every command. */}
         {voiceChip && (
-          <div style={{ position: "absolute", left: "50%", top: 14, transform: "translateX(-50%)", zIndex: 6, pointerEvents: "none", padding: "5px 12px", background: "var(--surface-pop)", border: `1px solid ${voiceChip.tone === "live" ? "var(--cobalt)" : "var(--ink-faint)"}`, boxShadow: "var(--shadow-1)", fontFamily: "var(--f-mono)", fontSize: 11.5, color: "var(--ink)", display: "flex", alignItems: "center", gap: 7, whiteSpace: "nowrap" }}>
+          <div style={{ position: "absolute", left: "50%", top: 14, transform: "translateX(-50%)", zIndex: 6, pointerEvents: "none", padding: "5px 12px", background: "var(--surface-pop)", border: `1px solid ${voiceChip.tone === "live" || voiceChip.tone === "offer" ? "var(--cobalt)" : "var(--ink-faint)"}`, boxShadow: "var(--shadow-1)", fontFamily: "var(--f-mono)", fontSize: 11.5, color: "var(--ink)", display: "flex", alignItems: "center", gap: 7, whiteSpace: "nowrap" }}>
             {voiceChip.tone === "live" && <span className="pip" />}
             {voiceChip.text}
           </div>

--- a/web/test/voiceActions.test.ts
+++ b/web/test/voiceActions.test.ts
@@ -18,8 +18,10 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   applyVoiceIntent, runVoiceCommand, REJECTION_MESSAGES,
+  AGENT_HANDOFF_TRIGGER, isAgentHandoffTrigger, shouldOfferAgentHandoff,
   type VoiceCapabilities, type VoiceOutcome,
 } from "../src/lib/voiceActions.ts";
+import type { RejectReason } from "../src/lib/voiceIntent.ts";
 
 // ── Part A: ordered call-log ────────────────────────────────────────────────
 
@@ -161,7 +163,7 @@ test("runVoiceCommand end-to-end: homophone + percent through parse and apply", 
 test("rejected transcript → mapped message, ZERO calls", () => {
   const { caps, log } = makeCtx();
   const out = runVoiceCommand(caps, "carpet one seven");
-  assert.deepEqual(out, { ok: false, message: REJECTION_MESSAGES.trailing_words });
+  assert.deepEqual(out, { ok: false, message: REJECTION_MESSAGES.trailing_words, reason: "trailing_words" });
   assert.deepEqual(log, []);
 });
 
@@ -248,7 +250,7 @@ test("deixis off-sheet aim (sheetId \"\") → exact message, ZERO calls", () => 
 test("bare deixis with no active condition → parse-level reject, ZERO calls", () => {
   const { caps, log } = makeCtx({ getActiveConditionId: () => "" });
   const out = runVoiceCommand(caps, "this room");
-  assert.deepEqual(out, { ok: false, message: REJECTION_MESSAGES.deixis_no_condition });
+  assert.deepEqual(out, { ok: false, message: REJECTION_MESSAGES.deixis_no_condition, reason: "deixis_no_condition" });
   assert.deepEqual(log, []);
 });
 
@@ -471,4 +473,50 @@ test("deixis off-sheet aim mutates NOTHING", async () => {
   const out = await runVoiceCommand(app.caps, "carpet one, this room");
   assert.deepEqual(out, { ok: false, message: "Couldn't place that — aim at a sheet." });
   assert.deepEqual(app.state, before);
+});
+
+// ── Part C: the two-tier router seam (RFC #59 slice 5) ─────────────────────
+// The router is decided by pure pieces so the gate is table-testable: ONLY a
+// fully-unrecognized transcript, with the agent configured, is offerable.
+// Near-misses are almost-valid grammar — routing them would launder a mishear
+// into a mutation — and the spoken confirm is a FIXED LITERAL, not grammar.
+
+const ALL_REASONS: RejectReason[] = [
+  "empty", "unrecognized", "unknown_tag", "bad_number", "trailing_words",
+  "deixis_no_condition", "deixis_target",
+];
+
+test("PINNED: only unrecognized × configured offers — every near-miss reason never reaches the offer", () => {
+  for (const reason of ALL_REASONS) {
+    for (const configured of [true, false]) {
+      const offer = shouldOfferAgentHandoff({ ok: false, message: REJECTION_MESSAGES[reason], reason }, configured);
+      assert.equal(offer, reason === "unrecognized" && configured, `${reason} × configured=${configured}`);
+    }
+  }
+});
+
+test("router: ok outcomes and reasonless dispatcher failures never offer", () => {
+  assert.equal(shouldOfferAgentHandoff({ ok: true, message: "CPT-1 active." }, true), false);
+  assert.equal(shouldOfferAgentHandoff({ ok: false, message: "Couldn't set waste — no active condition." }, true), false);
+});
+
+test("router: runVoiceCommand surfaces the reason on parse rejections only", () => {
+  const { caps } = makeCtx();
+  const rej = runVoiceCommand(caps, "the quick brown fox") as VoiceOutcome;
+  assert.deepEqual(rej, { ok: false, message: REJECTION_MESSAGES.unrecognized, reason: "unrecognized" });
+  const nearMiss = runVoiceCommand(caps, "waste banana") as VoiceOutcome;
+  assert.equal(nearMiss.reason, "bad_number");
+  const okOut = runVoiceCommand(caps, "cpt one") as VoiceOutcome;
+  assert.equal(okOut.ok, true);
+  assert.equal("reason" in okOut, false);
+  const dispatcherFail = applyVoiceIntent(makeCtx({ getActiveConditionId: () => "" }).caps, { kind: "set_waste", waste: 7 });
+  assert.equal("reason" in dispatcherFail, false);
+});
+
+test("router trigger: fixed literal, whole-utterance only", () => {
+  assert.equal(AGENT_HANDOFF_TRIGGER, "ask the agent");
+  for (const yes of ["ask the agent", "Ask the agent.", "  ASK THE AGENT!  ", "ask the agent…?!"])
+    assert.equal(isAgentHandoffTrigger(yes), true, yes);
+  for (const no of ["please ask the agent", "ask the agent to trace the wing", "I would ask the agent", "ask agent", ""])
+    assert.equal(isAgentHandoffTrigger(no), false, no);
 });


### PR DESCRIPTION
## What & why

Slice 5 of RFC #59 — the two-tier router, built on the green-lit design record in the issue thread. The deterministic grammar remains the entire fast path; a **fully-unrecognized** transcript (and only that), with the bring-your-own agent configured, earns an *offer* — never an auto-run — to hand the exact text to the in-canvas agent as a task. This closes the RFC's slice list. ref #59

## The design record's lines, held (your three asks, pinned)

1. **Fixed literal trigger** — `AGENT_HANDOFF_TRIGGER = "ask the agent"`, whole-utterance equality after punctuation strip; not a grammar production. Test pins that "please ask the agent" / the phrase-in-prose never match, and speaking it with nothing pending says so and sends nothing.
2. **Consent names both costs** — the offer reads: *not a command — ⏎ or say "ask the agent" to run it on YOUR agent (your endpoint, your key) · proposals land for review · Esc dismisses*. It auto-expires after 20 s so a stale ⏎ can never become a surprise agent run.
3. **The pinned near-miss test** — `shouldOfferAgentHandoff` is one pure predicate, table-tested across **every** `RejectReason` × {configured, unconfigured}: exactly `unrecognized × configured` offers; `bad_number`, `trailing_words`, `unknown_tag`, `empty`, and both deixis rejects never do. Dispatcher failures carry no reason and are never offerable.

The bridge grows nothing: confirmation calls the same `runAgent` the panel runs — same cfg, same tool registry — and agent-inferred work stays on the dashed-proposals → Accept gate. The router changes who *reads* the words, never who owns the work; the zero-wrong-actions invariant never sees the agent path because the router only exists where the dispatcher refused.

## Mechanics

- `voiceActions.ts`: `VoiceOutcome` gains `reason?` (parse rejections only) + the two pure router predicates (~30 lines).
- `TakeoffCanvas.jsx` (~60 lines): offer state (ref-driven, chip-rendered), three confirm paths — global ⏎ inserted *ahead* of the one-click/finish-shape/accept-proposals chain (and auto-yielding the key the moment the offer clears), Command-box ⏎ on the same rejected text, and the spoken literal. Esc dismisses at the head of the existing back-out chain.
- Tests: +7 router cases; two existing rejection envelopes updated to carry their reason. Full suite 924/931 (7 = the known Windows-CRLF golden-CSV checkout issue, green in CI); corpus gate live-green.

## Verified in the running app

Unrecognized text → red rejection *stays* + offer chip → ⏎ → Agent panel opens with `Goal: <transcript>` through the real loop (visible transport error against a dummy endpoint — the handoff is honest); near-miss ("waste banana") never offers; unconfigured deployments never see the offer. Docs: router sections in `docs/VOICE.md` + USER_GUIDE §17, CHANGELOG entry.

