### PR TITLE
feat(mcp): the agent command algebra — edit_shape + undo_last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased — the agent command algebra: `edit_shape` + `undo_last`
+
+### Added
+- **`edit_shape` and `undo_last` — the agent stops being an appender and becomes an editor.** Until now an MCP agent had exactly one mutation move (commit) and one recovery move (delete and re-derive from scratch): a ring that overshot into the corridor by two vertices cost the whole room, and a `detect_rooms` sweep committed under the wrong condition cost N deletes. `edit_shape` revises a committed shape in place — new `verts`, a different `condition`, a different `role`, or any combination — and always recomputes quantities from the result, so a role flip alone re-measures (closed area vs open length). That closes the loop the description teaches and a human estimator already runs: commit → `view_sheet overlay:true` → *see* what landed → fix the two vertices that missed → look again. `undo_last` steps back over the session's own last *n* mutations with exact inverses (a commit is removed, an edit restored verbatim, a delete re-inserted at its old index), and a whole `detect_rooms` sweep undoes as **one** gesture rather than four, because the sweep is what the agent actually did. Reads are never journaled, so *n* counts changes, not tool calls; `load_plan` clears the history along with the shapes its entries refer to, because undoing across a document swap would be a lie.
+- Two rules keep the new write surface honest, both pinned by tests. **Ink is not pencil**: a shape carrying `origin.reviewed === true` is work a human affirmed and `edit_shape` refuses it — this server sets that flag on nothing, so the guard is inert here by design and exists so the surface ports safely to a host that has a real review gate. **Self-revision is not correction**: agent edits tally on a new `origin.agent_edits` and touch nothing in the human-correction vocabulary (`edited`, `edits`, `proposed_verts_norm`), which mean *a human corrected the machine* — merging a machine's own fix into them would corrupt the one signal that measures whether the machine is improving. Freezing `proposed_verts_norm` stays correct on a human's first edit, because the geometry a reviewer saw is the agent's final revision, not its first draft.
+
 ## Unreleased — the two-tier router (RFC #59, slice 5)
 
 ### Added

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -108,14 +108,37 @@ includes document text, shape vertices, or result payload content.
 | `sheet_info` | One sheet's dims, vector segment count, scale status, detected suggestion, committed shape count. |
 | `set_scale` | Set a sheet's scale — exactly one of `label`, `upp`, `calibrate {p1, p2, feet}`, `use_detected`. |
 | `one_click` | One-Click Area at (x, y): flood fill bounded by the plan linework, traced, vertices snapped. Pass `condition` to commit; `role: "deduct"` subtracts. |
-| `detect_rooms` | Batch One-Click: reads every room-number label off the sheet's text layer and floods each — one call instead of `read_sheet_text` + reasoning + N `one_click` calls. Only cleanly-traced rooms come back; a leaked/dense-linework label is silently withheld. Pass `condition` to commit every detected room. |
+| `detect_rooms` | Batch One-Click: reads every room-number label off the sheet's text layer and floods each — one call instead of `read_sheet_text` + reasoning + N `one_click` calls. Only cleanly-traced rooms come back; everything skipped is counted and reasoned in `withheld` (degenerate / duplicate / implausible), never dropped silently. Pass `condition` to commit every detected room. |
 | `measure_polygon` | Area + perimeter of a polygon you supply (min 3 verts). Requires scale. |
 | `measure_line` | Length of an open polyline (min 2 points). Requires scale. |
 | `takeoff_summary` | Per-condition totals + grand totals, computed by the Report's rules. |
 | `export_takeoff` | The full `opentakeoff.takeoff_canvas.v1` payload — exactly what the app autosaves. Inline, and to disk with `path`. |
 | `delete_shape` | Remove a committed shape by id. |
+| `edit_shape` | **Revise** a committed shape instead of redoing it: new `verts`, a different `condition`, a different `role`, or any combination — quantities recomputed from the result. Refuses shapes a human affirmed. |
+| `undo_last` | Step back over your own last `n` mutations, newest first. Exact inverses: a commit is removed, an edit restored verbatim, a delete re-inserted where it was. A whole `detect_rooms` sweep is **one** step. |
 | `read_sheet_text` | Positioned page text (image px), optionally restricted to a region — title blocks, room labels, finish schedules. |
 | `view_sheet` | The agent's eyes: render the sheet (or an image-px crop) to PNG. `overlay` burns committed shapes in (solid = human-affirmed, dashed = unreviewed) to verify geometry landed; `grid` burns in a calibrated 1-ft/5-ft measuring grid with foot labels (`"auto"` from the set scale, or the drawing scale like `"1/4"`) so dimensions are counted off cells, not guessed. |
+
+### The agent revises its own work
+
+`edit_shape` and `undo_last` exist because an agent that can only *append* has
+one recovery move: delete and re-derive. The loop they enable instead —
+**commit → `view_sheet overlay:true` → see the ring overshot into the corridor
+→ move those two vertices → look again** — is the loop a human estimator
+already runs, and it is the difference between an agent that drafts and one
+that works.
+
+Two rules hold the surface honest:
+
+- **Ink is not pencil.** A shape carrying `origin.reviewed === true` is work a
+  human affirmed, and no agent verb touches it. This server has no review gate
+  of its own, so the guard is inert here — it is the contract that makes the
+  surface safe to port to a host that *does* have one.
+- **Self-revision is not correction.** `edit_shape` bumps `origin.agent_edits`
+  and touches nothing in the human-correction vocabulary (`edited`, `edits`,
+  `proposed_verts_norm`). Those fields mean *a human corrected the machine*;
+  merging a machine's own fix into them would corrupt the one signal that
+  measures whether the machine is getting better.
 
 Every JSON tool declares an **`outputSchema`**, and every reply carries the
 payload as **`structuredContent`** — typed, machine-validated on every call —

--- a/mcp/scripts/smoke-dist.mjs
+++ b/mcp/scripts/smoke-dist.mjs
@@ -95,6 +95,7 @@ const names = listed.tools.map((tool) => tool.name).sort();
 assert.deepEqual(names, [
   "delete_shape",
   "detect_rooms",
+  "edit_shape",
   "export_takeoff",
   "load_plan",
   "measure_line",
@@ -104,6 +105,7 @@ assert.deepEqual(names, [
   "set_scale",
   "sheet_info",
   "takeoff_summary",
+  "undo_last",
   "view_sheet",
 ]);
 

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -182,6 +182,34 @@ export const deleteShapeOutput = {
   shape_count: z.number().int().describe("Committed shapes remaining"),
 };
 
+/** edit_shape: the revised shape's re-measured quantities. Quantities are
+ * always recomputed from the resulting geometry and role, so a role flip alone
+ * re-measures (closed area vs open length). */
+export const editShapeOutput = {
+  shape_id: z.string(),
+  changed: z.array(z.enum(["verts", "condition", "role"])).describe("Which fields this call actually changed"),
+  measure_role: z.enum(["floor_area", "deduct", "linear"]),
+  nverts: z.number().int(),
+  area_sf: z.number().describe("0 for linear shapes"),
+  perimeter_lf: z.number().describe("Length for linear shapes, perimeter for closed ones"),
+  agent_edits: z.number().int().describe("How many times the agent has revised this shape — separate from the human-correction tally"),
+};
+
+/** undo_last: what was actually stepped back. `undone` may be fewer than
+ * requested when the journal ran out; the note says so rather than pretending. */
+export const undoLastOutput = {
+  undone: z.number().int().describe("Steps actually reversed"),
+  steps: z.array(z.object({
+    seq: z.number().int(),
+    op: z.enum(["commit", "edit", "delete"]),
+    tool: z.string().describe("The tool call this step came from"),
+    shapes: z.number().int().describe("Shapes affected by reversing this step"),
+  })).describe("Newest first"),
+  shape_count: z.number().int().describe("Committed shapes after the undo"),
+  remaining: z.number().int().describe("Steps still available to undo"),
+  note: z.string().optional(),
+};
+
 export const readSheetTextOutput = {
   sheet: z.string(),
   items: z.array(z.object({ str: z.string(), x: z.number(), y: z.number() })).describe("Positioned text items (image px)"),

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -71,6 +71,11 @@ export interface ShapeOrigin {
   copied?: boolean;
   /** Per-kind tally of human corrections (provenance.js). */
   edits?: Record<string, number>;
+  /** How many times the AGENT revised its own shape (edit_shape). Deliberately
+   * separate from `edited`/`edits`, which mean "a human corrected the machine"
+   * — a machine correcting itself is a different event, and merging the two
+   * would corrupt the correction signal the capture layer grades on. */
+  agent_edits?: number;
 }
 
 export interface Shape {
@@ -127,6 +132,30 @@ export interface SheetSummary {
   detected_scale?: string;
 }
 
+/** Bounded gesture history, not an archive — mirrors the canvas's UNDO_CAP. */
+export const UNDO_CAP = 100;
+
+/** The agent-scoped command journal. Every mutation this server performs
+ * records one entry carrying enough state to invert it exactly: a commit
+ * removes by id, an edit restores the pre-edit shape verbatim, a delete
+ * re-inserts at the recorded index. Undo is a true inverse, never an
+ * approximation, so an agent that overshot can step back instead of
+ * re-deriving a whole sheet.
+ *
+ * Scope, stated precisely: this is the MCP session's OWN history. It is not
+ * the browser canvas's undo stack, nothing is shared between them, and
+ * load_plan clears it along with the shapes its entries refer to.
+ *
+ * One entry per TOOL CALL, not per shape — undoing a detect_rooms sweep that
+ * committed 18 rooms takes back the sweep, which is the gesture the agent
+ * actually made. */
+export type JournalPayload =
+  | { op: "commit"; tool: string; ids: string[] }
+  | { op: "edit"; tool: string; before: Shape }
+  | { op: "delete"; tool: string; removed: { shape: Shape; index: number }[] };
+
+export type JournalEntry = JournalPayload & { seq: number };
+
 const sheetSummary = (s: SheetState): SheetSummary => ({
   sheet: s.key,
   page: s.pageNum,
@@ -145,6 +174,26 @@ export class Session {
   conditions: Condition[] = [];
   shapes: Shape[] = [];
 
+  /** Newest-last. Capped at UNDO_CAP; the oldest entry falls off the front. */
+  private journal: JournalEntry[] = [];
+  private seq = 0;
+  /** Ids minted by commit() since the last flush — one tool call may commit
+   * many shapes (detect_rooms), and they journal as a single reversible step. */
+  private pendingCommits: string[] = [];
+
+  private record(entry: JournalPayload): void {
+    this.journal.push({ ...entry, seq: ++this.seq });
+    if (this.journal.length > UNDO_CAP) this.journal.shift();
+  }
+
+  /** Journal whatever commit() minted during this tool call, as one entry.
+   * A call that committed nothing records nothing — undo steps over reads. */
+  private flushCommits(tool: string): void {
+    if (!this.pendingCommits.length) return;
+    this.record({ op: "commit", tool, ids: this.pendingCommits });
+    this.pendingCommits = [];
+  }
+
   /** load_plan replaces the session's document: the old doc is destroyed and
    * ALL state — scales, caches, conditions, shapes — is cleared. */
   async loadPlan(filePath: string) {
@@ -154,6 +203,10 @@ export class Session {
     this.conditions = [];
     this.shapes = [];
     this.file = null;
+    // the journal's entries reference shapes that no longer exist — undoing
+    // across a document swap would be a lie, so the history goes with them
+    this.journal = [];
+    this.pendingCommits = [];
 
     const doc = await openPdf(filePath);
     this.doc = doc;
@@ -374,6 +427,7 @@ export class Session {
       ...(origin ? { origin } : {}),
     };
     this.shapes.push(shape);
+    this.pendingCommits.push(shape.id);
     return shape;
   }
 
@@ -418,6 +472,7 @@ export class Session {
         ...(f.hatchFiltered ? { hatch_filtered: true as const } : {}),
       }).id;
     }
+    this.flushCommits("one_click");
     return { ...common, area_sf, perimeter_lf, ...(shape_id ? { shape_id } : {}) };
   }
 
@@ -504,6 +559,7 @@ export class Session {
       })
       .filter((r): r is NonNullable<typeof r> => r !== null);
 
+    this.flushCommits("detect_rooms"); // the whole sweep is one reversible step
     const withheldTotal = withheld.degenerate + withheld.duplicate + withheld.implausible;
     return {
       detected: rooms.length,
@@ -530,6 +586,7 @@ export class Session {
     // agent-supplied coordinates are a hand trace by a machine hand: manual
     // method, agent actor — and never reviewed (no human affirmed anything).
     if (opts.condition) shape_id = this.commit(s, opts.condition, opts.role, verts, { area_sf, perimeter_lf }, { method: "manual", actor: "agent" }).id;
+    this.flushCommits("measure_polygon");
     return { area_sf, perimeter_lf, nverts: verts.length, ...(shape_id ? { shape_id } : {}) };
   }
 
@@ -540,6 +597,7 @@ export class Session {
     let shape_id: string | undefined;
     // area_sf stays 0 — the canvas only mints border SF when the condition has a thickness
     if (opts.condition) shape_id = this.commit(s, opts.condition, "linear", pts, { area_sf: 0, perimeter_lf: length_lf }, { method: "manual", actor: "agent" }).id;
+    this.flushCommits("measure_line");
     return { length_lf, npts: pts.length, ...(shape_id ? { shape_id } : {}) };
   }
 
@@ -553,8 +611,123 @@ export class Session {
   deleteShape(id: string) {
     const i = this.shapes.findIndex((x) => x.id === id);
     if (i < 0) throw new UserError(`No shape with id ${JSON.stringify(id)}.`);
-    this.shapes.splice(i, 1);
+    const [shape] = this.shapes.splice(i, 1);
+    this.record({ op: "delete", tool: "delete_shape", removed: [{ shape, index: i }] });
     return { deleted: id, shape_count: this.shapes.length };
+  }
+
+  /** Revise a committed shape in place: new geometry, a different condition, a
+   * different role, or any combination. This is the verb that turns the agent
+   * from an appender into an editor — it can propose a ring, look at the
+   * overlay, see it overshot into the corridor, and move the two offending
+   * vertices, instead of deleting and re-deriving the whole room.
+   *
+   * The review gate is absolute: a shape a human affirmed (origin.reviewed ===
+   * true) is ink, and no agent verb touches ink. This server never sets that
+   * flag itself, so the guard is inert here today — it is the contract that
+   * makes this surface portable to a host that DOES have a review gate, and it
+   * belongs in the code rather than in a host's good intentions.
+   *
+   * Provenance: agent self-revision bumps origin.agent_edits and touches
+   * NOTHING in the human-correction vocabulary (edited / edits /
+   * proposed_verts_norm — see web/src/lib/provenance.js). Those fields grade a
+   * human's correction of a machine proposal; an agent fixing its own work is
+   * not that, and conflating the two would poison the exact signal the capture
+   * layer exists to collect. Freezing proposed_verts_norm stays correct on the
+   * human's first edit, because the geometry a reviewer saw IS the agent's
+   * final revision, not its first draft. */
+  editShape(id: string, patch: { verts?: Point[]; condition?: string; role?: MeasureRole }) {
+    const i = this.shapes.findIndex((x) => x.id === id);
+    if (i < 0) throw new UserError(`No shape with id ${JSON.stringify(id)}.`);
+    const cur = this.shapes[i];
+    if (cur.origin?.reviewed === true) {
+      throw new UserError(`Shape ${JSON.stringify(id)} was affirmed by a human — reviewed work is ink, not pencil, and cannot be edited by an agent.`);
+    }
+    if (patch.verts === undefined && patch.condition === undefined && patch.role === undefined) {
+      throw new UserError("Nothing to change — pass at least one of verts, condition, role.");
+    }
+    const s = this.sheet(cur.sheet_id);
+    if (s.upp == null) throw new UserError(this.scaleGate(s));
+    const upp = s.upp;
+    const role = patch.role ?? cur.measure_role;
+
+    // Geometry: either the supplied verts or the shape's own, back in image px.
+    const vertsPx: Point[] = patch.verts
+      ?? cur.verts_norm.map(([x, y]) => [x * s.widthPx, y * s.heightPx] as Point);
+    const minPts = role === "linear" ? 2 : 3;
+    if (vertsPx.length < minPts) {
+      throw new UserError(`A ${role === "linear" ? "linear shape needs at least 2 points" : "closed shape needs at least 3 vertices"} — got ${vertsPx.length}.`);
+    }
+
+    // Quantities are always recomputed from the resulting geometry AND role, so
+    // a role flip alone re-measures correctly (open length vs closed area).
+    const computed = role === "linear"
+      ? { area_sf: 0, perimeter_lf: round2(openLen(vertsPx) * upp) }
+      : (() => {
+          const met = closedMetrics(vertsPx);
+          return { area_sf: round2(met.area * upp * upp), perimeter_lf: round2(met.perim * upp) };
+        })();
+
+    const before: Shape = structuredClone(cur);
+    const condition_id = patch.condition !== undefined ? this.conditionFor(patch.condition).id : cur.condition_id;
+    this.shapes[i] = {
+      ...cur,
+      condition_id,
+      measure_role: role,
+      verts_norm: vertsPx.map(([x, y]) => [x / s.widthPx, y / s.heightPx]),
+      computed,
+      ...(cur.origin ? { origin: { ...cur.origin, agent_edits: (cur.origin.agent_edits ?? 0) + 1 } } : {}),
+    };
+    this.record({ op: "edit", tool: "edit_shape", before });
+
+    const changed = [
+      ...(patch.verts !== undefined ? ["verts"] : []),
+      ...(patch.condition !== undefined ? ["condition"] : []),
+      ...(patch.role !== undefined ? ["role"] : []),
+    ];
+    return {
+      shape_id: id,
+      changed,
+      measure_role: role,
+      nverts: vertsPx.length,
+      ...computed,
+      agent_edits: this.shapes[i].origin?.agent_edits ?? 0,
+    };
+  }
+
+  /** Step back over this session's own last n mutations, newest first. Each
+   * entry's inverse is exact (see JournalEntry), so this restores state rather
+   * than approximating it. Reads are not journaled, so undo never has to step
+   * over a look — n counts gestures that changed something. */
+  undoLast(n: number) {
+    const undone: { seq: number; op: JournalEntry["op"]; tool: string; shapes: number }[] = [];
+    for (let k = 0; k < n; k++) {
+      const e = this.journal.pop();
+      if (!e) break;
+      if (e.op === "commit") {
+        const dead = new Set(e.ids);
+        this.shapes = this.shapes.filter((x) => !dead.has(x.id));
+        undone.push({ seq: e.seq, op: e.op, tool: e.tool, shapes: e.ids.length });
+      } else if (e.op === "edit") {
+        const i = this.shapes.findIndex((x) => x.id === e.before.id);
+        // the shape may have been deleted after the edit; undoing the edit of a
+        // shape that is gone is a no-op on geometry, not an error
+        if (i >= 0) this.shapes[i] = e.before;
+        undone.push({ seq: e.seq, op: e.op, tool: e.tool, shapes: i >= 0 ? 1 : 0 });
+      } else {
+        for (const { shape, index } of e.removed) {
+          this.shapes.splice(Math.min(index, this.shapes.length), 0, shape);
+        }
+        undone.push({ seq: e.seq, op: e.op, tool: e.tool, shapes: e.removed.length });
+      }
+    }
+    return {
+      undone: undone.length,
+      steps: undone,
+      shape_count: this.shapes.length,
+      remaining: this.journal.length,
+      ...(undone.length < n ? { note: `Only ${undone.length} step(s) were available to undo.` } : {}),
+    };
   }
 
   /** The exact browser save payload (TakeoffCanvas.jsx autosave + the schema key

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -1,16 +1,17 @@
-// The twelve tools — thin zod-validated handlers over the Session. Replies are
+// The fourteen tools — thin zod-validated handlers over the Session. Replies are
 // compact JSON (format.ts); view_sheet alone replies with an image content
 // item plus a JSON meta text item. Failures are isError results, never thrown
 // protocol errors.
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ok, okImage, fail, UserError, type ToolReply } from "./format.ts";
-import type { Session } from "./session.ts";
+import { UNDO_CAP, type Session } from "./session.ts";
 import { traceToolCall } from "./trace.ts";
 import {
   loadPlanOutput, sheetInfoOutput, setScaleOutput, oneClickOutput, detectRoomsOutput,
   measurePolygonOutput, measureLineOutput, takeoffSummaryOutput,
   exportTakeoffOutput, deleteShapeOutput, readSheetTextOutput,
+  editShapeOutput, undoLastOutput,
 } from "./outputs.ts";
 
 // The coordinate contract, stated on every tool so any agent reading any one
@@ -137,6 +138,25 @@ export function registerTools(server: McpServer, session: Session): void {
     inputSchema: { shape_id: z.string() },
     outputSchema: deleteShapeOutput,
   }, run("delete_shape", ({ shape_id }) => session.deleteShape(shape_id)));
+
+  server.registerTool("edit_shape", {
+    description: `REVISE a shape you already committed, instead of deleting it and starting over: pass new verts to move the geometry, condition to reassign it to a different finish tag, role to switch between floor_area / deduct / linear, or any combination. Quantities are recomputed from the result — a role flip alone re-measures (closed area vs open length). The loop this is for: one_click or measure_polygon to commit, view_sheet with overlay:true to LOOK at what landed, then edit_shape to fix the two vertices that overshot into the corridor. Shapes a human affirmed (origin.reviewed) are ink and are refused — an agent revises its own pencil and nothing else. Agent self-revision is tallied on origin.agent_edits, kept deliberately separate from the human-correction fields. ${COORDS}`,
+    inputSchema: {
+      shape_id: z.string().describe("Id returned when the shape was committed"),
+      verts: z.array(pointSchema).optional().describe("Replacement geometry (image px): ≥3 vertices for an area shape, ≥2 points for a linear one"),
+      condition: z.string().optional().describe("Reassign to this finish tag (minted on first use)"),
+      role: z.enum(["floor_area", "deduct", "linear"]).optional().describe("Switch what the shape measures"),
+    },
+    outputSchema: editShapeOutput,
+  }, run("edit_shape", (a) => session.editShape(a.shape_id, { verts: a.verts, condition: a.condition, role: a.role })));
+
+  server.registerTool("undo_last", {
+    description: `Step back over your OWN last n mutations, newest first — a committed one_click, a whole detect_rooms sweep, an edit_shape, or a delete_shape. Each step is reversed exactly (a commit is removed, an edit is restored verbatim, a delete is re-inserted where it was), so this restores state rather than approximating it. Reads are never journaled, so n counts gestures that changed something, not tool calls you made. Use it when a sweep committed against the wrong condition or a batch went in on the wrong sheet — one call instead of N deletes. Scope: this session's own history only. It is not the browser canvas's undo stack, and load_plan clears it along with the shapes it refers to.`,
+    inputSchema: {
+      n: z.number().int().min(1).max(UNDO_CAP).default(1).describe(`How many steps to reverse (1–${UNDO_CAP})`),
+    },
+    outputSchema: undoLastOutput,
+  }, run("undo_last", ({ n }) => session.undoLast(n)));
 
   server.registerTool("read_sheet_text", {
     description: `The sheet's text with positions — items [{str, x, y}] in image px plus the joined text. Optionally restrict to a region {x0, y0, x1, y1}. Use it to read title blocks, room labels, finish schedules, and scale notes. ${COORDS}`,

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -43,14 +43,23 @@ async function captureStderr(fn: () => Promise<void>): Promise<string> {
   return output;
 }
 
-test("tools/list: all twelve tools, each described with the coordinate contract", async () => {
+// undo_last is the one tool that takes no coordinates — it addresses this
+// session's own command history, not the sheet — so the coordinate contract
+// would be noise in its description rather than orientation. Every other tool
+// speaks image px and says so.
+const NO_COORDS = new Set(["undo_last"]);
+
+test("tools/list: all fourteen tools, each described with the coordinate contract", async () => {
   const client = await pair();
   const { tools } = await client.listTools();
   assert.deepEqual(tools.map((t) => t.name).sort(), [
-    "delete_shape", "detect_rooms", "export_takeoff", "load_plan", "measure_line", "measure_polygon",
-    "one_click", "read_sheet_text", "set_scale", "sheet_info", "takeoff_summary", "view_sheet",
+    "delete_shape", "detect_rooms", "edit_shape", "export_takeoff", "load_plan", "measure_line", "measure_polygon",
+    "one_click", "read_sheet_text", "set_scale", "sheet_info", "takeoff_summary", "undo_last", "view_sheet",
   ]);
-  for (const t of tools) assert.match(t.description || "", /image px at render scale 2\.0/, `${t.name} carries the coordinate contract`);
+  for (const t of tools) {
+    if (NO_COORDS.has(t.name)) continue;
+    assert.match(t.description || "", /image px at render scale 2\.0/, `${t.name} carries the coordinate contract`);
+  }
 });
 
 test("load_plan: happy path returns sheets; a missing file is isError, not a crash", async () => {
@@ -240,4 +249,154 @@ test("output contract: every JSON tool declares outputSchema; structuredContent 
   const bad: any = await client.callTool({ name: "sheet_info", arguments: { sheet: "no-such-sheet" } });
   assert.equal(!!bad.isError, true);
   assert.equal(bad.structuredContent, undefined);
+});
+
+// ── The command algebra: the agent revises and retracts its OWN work ──────────
+// Before this, the agent could only append. A proposal that overshot had to be
+// deleted and re-derived from scratch; a sweep committed under the wrong
+// condition meant N deletes. These are the two verbs that close that gap.
+
+test("edit_shape: moves geometry, reassigns, flips role — and re-measures every time", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  await call(client, "set_scale", { sheet: KEY, use_detected: true });
+
+  const square = [[100, 100], [300, 100], [300, 300], [100, 300]];
+  const made = await call(client, "measure_polygon", { sheet: KEY, verts: square, condition: "CPT-1" });
+  assert.equal(made.isError, false);
+  const id = made.data.shape_id;
+  const area0 = made.data.area_sf;
+  assert.ok(area0 > 0);
+
+  // Geometry: half the width => half the area, recomputed server-side.
+  const moved = await call(client, "edit_shape", { shape_id: id, verts: [[100, 100], [200, 100], [200, 300], [100, 300]] });
+  assert.equal(moved.isError, false);
+  assert.deepEqual(moved.data.changed, ["verts"]);
+  assert.ok(Math.abs(moved.data.area_sf - area0 / 2) < 0.01, `half area: ${moved.data.area_sf} vs ${area0 / 2}`);
+  assert.equal(moved.data.agent_edits, 1);
+
+  // Reassign: the shape moves to a second condition, and the totals follow.
+  const reassigned = await call(client, "edit_shape", { shape_id: id, condition: "VCT-2" });
+  assert.equal(reassigned.isError, false);
+  assert.deepEqual(reassigned.data.changed, ["condition"]);
+  assert.equal(reassigned.data.agent_edits, 2);
+  const summary = await call(client, "takeoff_summary");
+  const byTag = Object.fromEntries(summary.data.conditions.map((c: any) => [c.finish_tag, c.shape_count]));
+  assert.equal(byTag["CPT-1"], 0, "left the old condition");
+  assert.equal(byTag["VCT-2"], 1, "landed on the new one");
+
+  // Role flip alone re-measures: a closed ring read as an open polyline.
+  const linear = await call(client, "edit_shape", { shape_id: id, role: "linear" });
+  assert.equal(linear.isError, false);
+  assert.equal(linear.data.measure_role, "linear");
+  assert.equal(linear.data.area_sf, 0, "a linear shape carries no area");
+  assert.ok(linear.data.perimeter_lf > 0);
+
+  // Provenance: agent self-revision never touches the human-correction fields.
+  const payload = await call(client, "export_takeoff");
+  const shape = payload.data.shapes.find((s: any) => s.id === id);
+  assert.equal(shape.origin.agent_edits, 3);
+  assert.equal(shape.origin.edited, undefined, "agent self-revision is not a human correction");
+  assert.equal(shape.origin.edits, undefined);
+  assert.equal(shape.origin.proposed_verts_norm, undefined, "nothing froze — no human has reviewed this");
+});
+
+test("edit_shape refusals: unknown id, empty patch, too few verts, and human ink", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  await call(client, "set_scale", { sheet: KEY, use_detected: true });
+  const made = await call(client, "measure_polygon", {
+    sheet: KEY, verts: [[100, 100], [300, 100], [300, 300]], condition: "CPT-1",
+  });
+  const id = made.data.shape_id;
+
+  const unknown = await call(client, "edit_shape", { shape_id: "shp-nope", verts: [[0, 0], [1, 0], [1, 1]] });
+  assert.equal(unknown.isError, true);
+  assert.match(unknown.data.error, /No shape with id/);
+
+  const empty = await call(client, "edit_shape", { shape_id: id });
+  assert.equal(empty.isError, true);
+  assert.match(empty.data.error, /at least one of verts, condition, role/);
+
+  const thin = await call(client, "edit_shape", { shape_id: id, verts: [[0, 0], [10, 10]] });
+  assert.equal(thin.isError, true);
+  assert.match(thin.data.error, /at least 3 vertices/);
+
+  // The review gate is absolute: reviewed work is ink and no agent verb touches
+  // it. This server never sets the flag, so it is set directly here — the guard
+  // is the contract that makes this surface safe to port to a host that has a
+  // real review gate.
+  const session = new Session();
+  await session.loadPlan(PLAN);
+  session.setScale(KEY, { use_detected: true });
+  const inkId = session.measurePolygon(KEY, [[100, 100], [300, 100], [300, 300]], { role: "floor_area", condition: "CPT-1" }).shape_id!;
+  session.shapes.find((s) => s.id === inkId)!.origin!.reviewed = true;
+  assert.throws(() => session.editShape(inkId, { condition: "VCT-2" }), /affirmed by a human/);
+});
+
+test("undo_last: a sweep is one step, an edit restores verbatim, a delete comes back", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  await call(client, "set_scale", { sheet: KEY, use_detected: true });
+
+  // A whole detect_rooms sweep undoes as ONE gesture, not four.
+  const sweep = await call(client, "detect_rooms", { sheet: KEY, condition: "CPT-1" });
+  assert.equal(sweep.data.detected, 4);
+  const back = await call(client, "undo_last", { n: 1 });
+  assert.equal(back.isError, false);
+  assert.equal(back.data.undone, 1);
+  assert.equal(back.data.steps[0].op, "commit");
+  assert.equal(back.data.steps[0].tool, "detect_rooms");
+  assert.equal(back.data.steps[0].shapes, 4, "the sweep's four rooms, one step");
+  assert.equal(back.data.shape_count, 0);
+
+  // An edit restores the pre-edit shape verbatim.
+  const made = await call(client, "measure_polygon", {
+    sheet: KEY, verts: [[100, 100], [300, 100], [300, 300], [100, 300]], condition: "CPT-1",
+  });
+  const id = made.data.shape_id;
+  const area0 = made.data.area_sf;
+  await call(client, "edit_shape", { shape_id: id, verts: [[100, 100], [200, 100], [200, 300], [100, 300]] });
+  const undoEdit = await call(client, "undo_last", { n: 1 });
+  assert.equal(undoEdit.data.steps[0].op, "edit");
+  const restored = (await call(client, "export_takeoff")).data.shapes.find((s: any) => s.id === id);
+  assert.ok(Math.abs(restored.computed.area_sf - area0) < 0.01, "geometry is back to the original");
+
+  // A delete comes back where it was.
+  await call(client, "delete_shape", { shape_id: id });
+  assert.equal((await call(client, "takeoff_summary")).data.conditions[0].shape_count, 0);
+  const undoDelete = await call(client, "undo_last", { n: 1 });
+  assert.equal(undoDelete.data.steps[0].op, "delete");
+  assert.equal(undoDelete.data.shape_count, 1);
+
+  // Running past the end is honest, not an error.
+  const past = await call(client, "undo_last", { n: 50 });
+  assert.equal(past.isError, false);
+  assert.ok(past.data.undone < 50);
+  assert.match(past.data.note, /Only \d+ step/);
+  assert.equal(past.data.remaining, 0);
+});
+
+test("undo_last: reads are never journaled, and load_plan clears the history", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  await call(client, "set_scale", { sheet: KEY, use_detected: true });
+  await call(client, "measure_polygon", { sheet: KEY, verts: [[100, 100], [300, 100], [300, 300]], condition: "CPT-1" });
+
+  // Look at the sheet, measure without committing, read text — none of it is a
+  // gesture, so undo still steps over the one thing that actually changed state.
+  await call(client, "read_sheet_text", { sheet: KEY });
+  await call(client, "measure_polygon", { sheet: KEY, verts: [[10, 10], [20, 10], [20, 20]] });
+  await call(client, "sheet_info", { sheet: KEY });
+  const back = await call(client, "undo_last", { n: 1 });
+  assert.equal(back.data.undone, 1);
+  assert.equal(back.data.shape_count, 0, "the committed shape, not a read");
+  assert.equal(back.data.remaining, 0, "the reads left no steps behind");
+
+  // A new document invalidates every id the journal refers to.
+  await call(client, "measure_polygon", { sheet: KEY, verts: [[100, 100], [300, 100], [300, 300]], condition: "CPT-1" });
+  await call(client, "load_plan", { path: PLAN });
+  const afterLoad = await call(client, "undo_last", { n: 1 });
+  assert.equal(afterLoad.data.undone, 0, "history goes with the document it described");
+  assert.equal(afterLoad.data.remaining, 0);
 });


### PR DESCRIPTION
## What

Two tools that turn an MCP agent from an **appender** into an **editor**.

Until now the agent had exactly one mutation move (commit) and one recovery move (delete and re-derive from scratch). A ring that overshot into the corridor by two vertices cost the whole room. A `detect_rooms` sweep committed under the wrong condition cost N deletes.

- **`edit_shape`** — revise a committed shape in place: new `verts`, a different `condition`, a different `role`, or any combination. Quantities are always recomputed from the result, so a role flip alone re-measures (closed area vs open length).
- **`undo_last`** — step back over the session's own last *n* mutations, newest first, with exact inverses: a commit is removed, an edit restored verbatim, a delete re-inserted at its old index.

Together they close the loop a human estimator already runs, and the one `view_sheet`'s overlay was built for but the write surface couldn't finish:

> commit → `view_sheet overlay:true` → **see** the ring overshot → move those two vertices → look again

## Design decisions worth reviewing

**A sweep is one gesture.** `undo_last` journals per *tool call*, not per shape, so undoing a `detect_rooms` that committed 18 rooms takes back the sweep. That's what the agent actually did. Reads are never journaled, so `n` counts changes rather than tool calls.

**`load_plan` clears the journal.** Its entries reference shapes that no longer exist; undoing across a document swap would be a lie.

**Ink is not pencil.** `edit_shape` refuses any shape carrying `origin.reviewed === true`. This server sets that flag on nothing, so the guard is *inert here by design* — it is the contract that makes the surface safe to port to a host that does have a review gate, and it belongs in code rather than in a host's good intentions.

**Self-revision is not correction.** Agent edits tally on a new `origin.agent_edits` and touch nothing in the human-correction vocabulary (`edited`, `edits`, `proposed_verts_norm`). Those fields mean *a human corrected the machine*; merging a machine's own fix into them would corrupt the one signal that measures whether the machine is improving. Freezing `proposed_verts_norm` stays correct on a human's first edit, because the geometry a reviewer saw is the agent's final revision, not its first draft.

## Verification

There is no UI surface here — this is the MCP server, so the running-app check is a real client driving a real plan. The new tests do exactly that over `InMemoryTransport` against `demo/sample-plan.pdf`:

- `edit_shape` halves a square and asserts the server-recomputed area halves; reassign moves the shape between conditions and `takeoff_summary` follows; a role flip to `linear` zeroes area and keeps length.
- Provenance asserted on the exported payload: `agent_edits: 3`, and `edited` / `edits` / `proposed_verts_norm` all still absent.
- Refusals: unknown id, empty patch, too few verts, and human ink (set directly on a `Session`, since the server never sets `reviewed`).
- `undo_last`: a 4-room sweep undoes as one step; an edit restores the original area; a delete comes back; running past the end returns an honest `note` rather than an error; reads leave no steps behind; `load_plan` clears the history.

Full `mcp` CI gate green locally — `npm run typecheck`, `npm test` (47 pass), `npm run build`, `npm run smoke:dist`. `web/` is untouched.

Also fixed one stale line in `mcp/README.md`: `detect_rooms` no longer withholds "silently" — the `withheld` channel shipped, and the table now says so.

## Not in this PR

The `reviewed` guard is the seam for the Spline port, where the review gate is real and the pencil/ink distinction has teeth. That lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)