### PR TITLE
feat(mcp): sheet_context — vector, text, and hatch families in one coordinate frame (RFC #29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased — `sheet_context`: vector, raster, and text in one coordinate frame (RFC #29)
+
+### Added
+- **`sheet_context` — the fifteenth tool, and the reasoning half of the agent's eyes.** `view_sheet` lets an agent look; this lets it *know*: for one region, in one call, the classified vector segments the engine itself floods against (endpoints exactly as drawn, one meta byte each — curve/clip/poché bits + device pen width), every text span with its bbox, and the sheet's **hatch-family instances**, each carrying a content-derived id built from its quantized (angle, pitch, pen-width) signature. Same pattern spec ⇒ same id anywhere on the sheet — so matching a plan region to a legend swatch stops being a vision guess and becomes `id === id`, deterministic and citable (both instances arrive with their bboxes as evidence pointers). The frame contract is deliberately trivial: everything is already in image px, the method clips and never transforms, and the reply echoes the post-clamp region — hand that same rect to `view_sheet` and the render matches by construction, with no second renderer to drift.
+- **Decimation that confesses.** Declared, ordered, and counted on every reply: segments shorter than `min_len_px` drop first (default 2.0 px — one PDF point at render scale, invisible ink), then `max_segments` applies **longest-first** (walls are long, hatch strokes are short — truncation degrades toward structure). Whole segments drop with their meta intact; nothing is simplified or merged, because a merge would silently rewrite the classification. `kept + dropped.short + dropped.cap === total_in_region` always, pinned by test. Measured on a real 140k-segment E-size unit plan: full sheet at defaults is a 205 KB reply in ~100 ms (71k segments were sub-2px ink, 65k capped), a quarter-sheet window is 132 KB in ~8 ms with no cap hit — and the classifier found 17 hatch-family instances.
+- **`hatchFamilies` in the engine (`web/src/lib/oneclick.ts`)** — the hatch sweep now has two views of one algorithm: the classifier's (`classifyHatchSegs`, soft bits for the flood, bit-compatible with the historical behavior) and the context view, which keeps the (angle, pitch, pen-width) signature the sweep always computed and previously threw away. Pure, DOM-free, deterministic; the legend-match property (same spec, different place, same id) is pinned in `web/test/hatchFamilies.test.ts`.
+
 ## Unreleased — the agent command algebra: `edit_shape` + `undo_last`
 
 ### Added

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -117,6 +117,7 @@ includes document text, shape vertices, or result payload content.
 | `edit_shape` | **Revise** a committed shape instead of redoing it: new `verts`, a different `condition`, a different `role`, or any combination — quantities recomputed from the result. Refuses shapes a human affirmed. |
 | `undo_last` | Step back over your own last `n` mutations, newest first. Exact inverses: a commit is removed, an edit restored verbatim, a delete re-inserted where it was. A whole `detect_rooms` sweep is **one** step. |
 | `read_sheet_text` | Positioned page text (image px), optionally restricted to a region — title blocks, room labels, finish schedules. |
+| `sheet_context` | The region's STRUCTURE in one frame: classified vector segments (endpoints as drawn, meta byte per segment), text spans with bboxes, and hatch-family instances with content-derived ids — same pattern spec ⇒ same id anywhere on the sheet, so plan↔legend matching is `id === id`. Decimation is declared and counted on every reply: `kept + dropped === total_in_region`, cap applies longest-first so walls survive. |
 | `view_sheet` | The agent's eyes: render the sheet (or an image-px crop) to PNG. `overlay` burns committed shapes in (solid = human-affirmed, dashed = unreviewed) to verify geometry landed; `grid` burns in a calibrated 1-ft/5-ft measuring grid with foot labels (`"auto"` from the set scale, or the drawing scale like `"1/4"`) so dimensions are counted off cells, not guessed. |
 
 ### The agent revises its own work

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -16,7 +16,7 @@
     "mcpb": "npm run build && node scripts/build-mcpb.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test test/conformance.test.ts test/e2e.test.ts test/resources.test.ts test/session.test.ts test/tools.test.ts test/view.test.ts"
+    "test": "node --import tsx --test test/conformance.test.ts test/context.test.ts test/e2e.test.ts test/resources.test.ts test/session.test.ts test/tools.test.ts test/view.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/scripts/smoke-dist.mjs
+++ b/mcp/scripts/smoke-dist.mjs
@@ -103,6 +103,7 @@ assert.deepEqual(names, [
   "one_click",
   "read_sheet_text",
   "set_scale",
+  "sheet_context",
   "sheet_info",
   "takeoff_summary",
   "undo_last",

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -215,3 +215,44 @@ export const readSheetTextOutput = {
   items: z.array(z.object({ str: z.string(), x: z.number(), y: z.number() })).describe("Positioned text items (image px)"),
   text: z.string().describe("The items joined with spaces"),
 };
+
+/** sheet_context (issue #29): vectors + text + hatch families of one region,
+ * in one frame. Structured-only by design — the raster stays view_sheet's
+ * job, and frame agreement is a contract on the echoed region rect rather
+ * than on a second renderer. */
+const hatchFamilyRow = z.object({
+  id: z.string().describe("Content hash of the quantized (angle, pitch, pen-width) signature — the SAME id for the same pattern spec anywhere on the sheet, so legend↔plan matching is id === id. Identifies a pattern, not a material; the legend maps pattern → material."),
+  angle_deg: z.number().describe("Raw mean angle [0, 180) — rides beside the id for tolerance matching at bucket boundaries"),
+  pitch_px: z.number().describe("Raw median row pitch, image px"),
+  pen_w_px: z.number().int().describe("Modal device pen width of the members"),
+  rows: z.number().int(),
+  segments: z.number().int().describe("Member segments in the whole instance"),
+  segments_in_region: z.number().int().describe("…of which this many were returned in vectors (post-decimation)"),
+  bbox: z.array(z.number()).length(4).describe("The instance's tight bbox [x0, y0, x1, y1], image px"),
+});
+
+export const sheetContextOutput = {
+  sheet: z.string(),
+  page: z.number().int(),
+  sheet_px: z.array(z.number()).length(2),
+  region: z.array(z.number()).length(4).describe("The region actually resolved, post-clamp — pass this same rect to view_sheet and the render is in the same frame by construction"),
+  has_vector_linework: z.boolean().describe("false = a scan: vectors and hatch are empty because there are none, not because the region is blank"),
+  vectors: z.object({
+    segments: z.array(z.array(z.number()).length(4)).describe("[x0, y0, x1, y1] per segment, image px, endpoints exactly as drawn — clipped by KEEPING whole intersecting segments, never by rewriting them"),
+    meta: z.array(z.number().int()).describe("One byte per segment, aligned with segments: bit 1 = curve chord, bit 2 = clip-only, bit 4 = filled-not-stroked; high nibble = device pen width"),
+    family: z.array(z.string().nullable()).describe("Aligned with segments: the hatch-family id this segment belongs to, or null for structural linework"),
+    kept: z.number().int(),
+    total_in_region: z.number().int().describe("Segments intersecting the region before any decimation — kept + dropped always reconciles to this"),
+    truncated: z.boolean(),
+    dropped: z.object({
+      short: z.number().int().describe("Below min_len_px (invisible ink)"),
+      cap: z.number().int().describe("Over max_segments — the SHORTEST went first, so walls survive"),
+    }),
+    note: z.string().optional(),
+  }),
+  text: z.object({
+    spans: z.array(z.object({ str: z.string(), x0: z.number(), y0: z.number(), x1: z.number(), y1: z.number() })).describe("Text with bboxes, image px, same frame as the vectors"),
+    count: z.number().int(),
+  }),
+  hatch: z.object({ families: z.array(hatchFamilyRow), count: z.number().int() }),
+};

--- a/mcp/src/pdf.ts
+++ b/mcp/src/pdf.ts
@@ -15,7 +15,7 @@ const PDFJS_ROOT = path.dirname(requireHere.resolve("pdfjs-dist/package.json"));
 export const OPS = pdfjs.OPS as unknown as OpsTable;
 
 export interface ViewportLike { width: number; height: number; transform: number[] }
-interface TextItemLike { str?: string; transform: number[]; height?: number }
+interface TextItemLike { str?: string; transform: number[]; width?: number; height?: number }
 export interface TextContentLike { items: TextItemLike[] }
 
 export interface PageHandle {
@@ -151,6 +151,31 @@ export function positionedText(ph: PageHandle): { str: string; x: number; y: num
     if (!str.trim()) continue;
     const t = pdfjs.Util.transform(ph.viewport.transform, it.transform);
     out.push({ str, x: +t[4].toFixed(1), y: +t[5].toFixed(1) });
+  }
+  return out;
+}
+
+export interface TextSpan { str: string; x0: number; y0: number; x1: number; y1: number }
+
+/** Positioned page text as BBOX SPANS in image px (issue #29's sheet_context
+ * needs boxes, not points, to answer "which text is inside this region").
+ * Same composed transform as positionedText: t[4], t[5] is the baseline's
+ * bottom-left in device space. item.width/height are user-space units; this
+ * server's viewports are unrotated at RENDER_SCALE (openPdf), so device
+ * extent is a straight scale — glyphs rise from the baseline, y is down, so
+ * the box spans [y − h, y]. */
+export function textSpans(ph: PageHandle): TextSpan[] {
+  const out: TextSpan[] = [];
+  for (const it of ph.textContent.items || []) {
+    const str = it.str || "";
+    if (!str.trim()) continue;
+    const t = pdfjs.Util.transform(ph.viewport.transform, it.transform);
+    const x = t[4], y = t[5];
+    const w = (it.width || 0) * RENDER_SCALE;
+    // pdf.js gives height on most items; the composed transform's column
+    // norm is the font's device height when it doesn't
+    const h = (it.height || 0) * RENDER_SCALE || Math.hypot(t[2], t[3]);
+    out.push({ str, x0: +x.toFixed(1), y0: +(y - h).toFixed(1), x1: +(x + w).toFixed(1), y1: +y.toFixed(1) });
   }
   return out;
 }

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -5,12 +5,12 @@
 // what the canvas commits (web/src/pages/TakeoffCanvas.jsx), so an exported
 // takeoff round-trips into the app.
 import path from "node:path";
-import { openPdf, positionedText, OPS, type DocHandle, type PageHandle } from "./pdf.ts";
+import { openPdf, positionedText, textSpans, OPS, type DocHandle, type PageHandle, type TextSpan } from "./pdf.ts";
 import { UserError, round1, round2 } from "./format.ts";
 import { STANDARD_SCALES, RENDER_SCALE, detectScale, extractSheetNumber, type DetectedScale } from "../../web/src/lib/sheets.ts";
 import {
   extractVectorGeometry, buildMask, floodRegion, traceRegion, snapVertices, ringArea,
-  MASK_MAX_DIM, type MaskObj, type VectorGeometry, type Point,
+  hatchFamilies, MASK_MAX_DIM, type MaskObj, type VectorGeometry, type Point, type HatchFamily,
 } from "../../web/src/lib/oneclick.ts";
 import { roomLabelSeeds, detectRegions } from "../../web/src/lib/detectRooms.ts";
 import { buildSnapGrid, nearestSnap, closedMetrics, openLen } from "../../web/src/lib/geometry.js";
@@ -108,7 +108,36 @@ interface SheetState {
   mask?: MaskObj | null;
   /** rendered-page PNG at IMAGE_MAX_EDGE, built on first resource read */
   png?: Uint8Array;
+  /** hatch-family instances (image px), built with geo on first sheet_context */
+  hatch?: HatchFamily[];
+  /** text as bbox spans (image px), built on first sheet_context */
+  spans?: TextSpan[];
 }
+
+/** sheet_context decimation defaults (issue #29) — declared and stable, never
+ * adaptive: an agent that receives a silently-truncated geometry set measures
+ * confidently and is wrong, so every reply carries the counts. */
+export const CONTEXT_MIN_LEN_PX = 2.0;   // one PDF point at render scale 2.0 — below any pen width
+export const CONTEXT_MAX_SEGMENTS = 4000; // cap, applied longest-first (walls survive, hatch strokes go)
+export const CONTEXT_MAX_SEGMENTS_CEIL = 20000;
+
+/** Does the segment intersect the axis-aligned rect? Liang–Barsky boolean —
+ * endpoints untouched, this is a KEEP test, never a clip-and-rewrite. */
+function segIntersectsRect(x1: number, y1: number, x2: number, y2: number, r: { x0: number; y0: number; x1: number; y1: number }): boolean {
+  if (Math.max(x1, x2) < r.x0 || Math.min(x1, x2) > r.x1 || Math.max(y1, y2) < r.y0 || Math.min(y1, y2) > r.y1) return false;
+  const dx = x2 - x1, dy = y2 - y1;
+  let t0 = 0, t1 = 1;
+  for (const [p, q] of [[-dx, x1 - r.x0], [dx, r.x1 - x1], [-dy, y1 - r.y0], [dy, r.y1 - y1]] as [number, number][]) {
+    if (p === 0) { if (q < 0) return false; continue; }
+    const t = q / p;
+    if (p < 0) { if (t > t1) return false; if (t > t0) t0 = t; }
+    else { if (t < t0) return false; if (t < t1) t1 = t; }
+  }
+  return true;
+}
+
+const rectsOverlap = (a: [number, number, number, number], r: { x0: number; y0: number; x1: number; y1: number }): boolean =>
+  a[0] <= r.x1 && a[2] >= r.x0 && a[1] <= r.y1 && a[3] >= r.y0;
 
 /** Resource images cap their long edge here: the largest edge the mainstream
  * vision models take without downscaling — these renders exist to be looked at
@@ -320,6 +349,98 @@ export class Session {
         ...(opts.overlay ? { shapes_drawn: sheetShapes.length } : {}),
         grid_px_per_foot: ppf ? round2(ppf) : 0,
       },
+    };
+  }
+
+  /** sheet_context (issue #29): the classified vectors, the positioned text,
+   * and the hatch-family instances of ONE region, in ONE frame — image px,
+   * the space every other tool already speaks. There is deliberately no
+   * transform in this method: everything below is a containment test against
+   * a rect, so frame agreement with view_sheet is a contract on the echoed
+   * region, not on a second renderer.
+   *
+   * Decimation is declared and ordered (issue #29 design comment): clip to
+   * region → drop segments shorter than min_len_px → cap at max_segments
+   * LONGEST-FIRST (walls are long, hatch strokes are short — truncation
+   * degrades toward structure). Whole segments drop with their meta intact;
+   * nothing is simplified or merged, because these are CLASSIFIED segments
+   * and a merge would silently rewrite the classification. The counts ride
+   * on every reply, truncated or not. */
+  async sheetContext(name: string, opts: { region?: { x0: number; y0: number; x1: number; y1: number }; min_len_px?: number; max_segments?: number }) {
+    const s = this.sheet(name);
+    const clampX = (v: number) => Math.max(0, Math.min(v, s.widthPx));
+    const clampY = (v: number) => Math.max(0, Math.min(v, s.heightPx));
+    const r = opts.region
+      ? { x0: clampX(opts.region.x0), y0: clampY(opts.region.y0), x1: clampX(opts.region.x1), y1: clampY(opts.region.y1) }
+      : { x0: 0, y0: 0, x1: s.widthPx, y1: s.heightPx };
+    if (!(r.x1 - r.x0 >= 1 && r.y1 - r.y0 >= 1)) {
+      throw new UserError(`Empty context region — need x1 > x0 and y1 > y0 in image px inside the sheet (${s.widthPx} × ${s.heightPx}).`);
+    }
+    const minLen = opts.min_len_px ?? CONTEXT_MIN_LEN_PX;
+    const cap = opts.max_segments ?? CONTEXT_MAX_SEGMENTS;
+
+    const geo = await this.ensureGeometry(s);
+    const hasVectors = geo.segs.length > 0;
+    if (!s.hatch) s.hatch = hasVectors ? hatchFamilies(geo.segs, geo.meta) : [];
+    if (!s.spans) s.spans = textSpans(s.page);
+
+    // family membership index → id, for the per-segment annotation
+    const famBySeg = new Map<number, string>();
+    for (const f of s.hatch) for (const i of f.memberIdx) famBySeg.set(i, f.id);
+
+    // 1. clip to region (keep test, endpoints untouched)
+    const inRegion: { i: number; len: number }[] = [];
+    const nSeg = geo.segs.length >> 2;
+    for (let i = 0; i < nSeg; i++) {
+      const x1 = geo.segs[i * 4], y1 = geo.segs[i * 4 + 1], x2 = geo.segs[i * 4 + 2], y2 = geo.segs[i * 4 + 3];
+      if (segIntersectsRect(x1, y1, x2, y2, r)) inRegion.push({ i, len: Math.hypot(x2 - x1, y2 - y1) });
+    }
+    // 2. drop invisible ink
+    const visible = inRegion.filter((e) => e.len >= minLen);
+    const droppedShort = inRegion.length - visible.length;
+    // 3. cap, longest-first
+    let kept = visible;
+    let droppedCap = 0;
+    if (visible.length > cap) {
+      kept = visible.slice().sort((a, b) => b.len - a.len).slice(0, cap);
+      droppedCap = visible.length - cap;
+    }
+
+    const segments: number[][] = [], metaOut: number[] = [], family: (string | null)[] = [];
+    for (const { i } of kept) {
+      segments.push([
+        round1(geo.segs[i * 4]), round1(geo.segs[i * 4 + 1]),
+        round1(geo.segs[i * 4 + 2]), round1(geo.segs[i * 4 + 3]),
+      ]);
+      metaOut.push(geo.meta[i]);
+      family.push(famBySeg.get(i) ?? null);
+    }
+
+    const spans = s.spans.filter((sp) => sp.x0 <= r.x1 && sp.x1 >= r.x0 && sp.y0 <= r.y1 && sp.y1 >= r.y0);
+    const keptIdx = new Set(kept.map((k) => k.i));
+    const families = s.hatch
+      .filter((f) => rectsOverlap(f.bbox, r))
+      .map(({ memberIdx, ...f }) => ({
+        ...f,
+        segments_in_region: memberIdx.reduce((acc, i) => acc + (keptIdx.has(i) ? 1 : 0), 0),
+      }));
+
+    return {
+      sheet: s.key,
+      page: s.pageNum,
+      sheet_px: [s.widthPx, s.heightPx],
+      region: [round1(r.x0), round1(r.y0), round1(r.x1), round1(r.y1)],
+      has_vector_linework: hasVectors,
+      vectors: {
+        segments, meta: metaOut, family,
+        kept: kept.length,
+        total_in_region: inRegion.length,
+        truncated: droppedShort + droppedCap > 0,
+        dropped: { short: droppedShort, cap: droppedCap },
+        ...(droppedCap > 0 ? { note: `Region exceeds max_segments — the ${droppedCap} SHORTEST segments were dropped, so structure (walls) survives and fill (hatch) goes first. Narrow the region or raise max_segments for the full set.` } : {}),
+      },
+      text: { spans, count: spans.length },
+      hatch: { families, count: families.length },
     };
   }
 

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -1,17 +1,17 @@
-// The fourteen tools — thin zod-validated handlers over the Session. Replies are
+// The fifteen tools — thin zod-validated handlers over the Session. Replies are
 // compact JSON (format.ts); view_sheet alone replies with an image content
 // item plus a JSON meta text item. Failures are isError results, never thrown
 // protocol errors.
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ok, okImage, fail, UserError, type ToolReply } from "./format.ts";
-import { UNDO_CAP, type Session } from "./session.ts";
+import { UNDO_CAP, CONTEXT_MIN_LEN_PX, CONTEXT_MAX_SEGMENTS, CONTEXT_MAX_SEGMENTS_CEIL, type Session } from "./session.ts";
 import { traceToolCall } from "./trace.ts";
 import {
   loadPlanOutput, sheetInfoOutput, setScaleOutput, oneClickOutput, detectRoomsOutput,
   measurePolygonOutput, measureLineOutput, takeoffSummaryOutput,
   exportTakeoffOutput, deleteShapeOutput, readSheetTextOutput,
-  editShapeOutput, undoLastOutput,
+  editShapeOutput, undoLastOutput, sheetContextOutput,
 } from "./outputs.ts";
 
 // The coordinate contract, stated on every tool so any agent reading any one
@@ -138,6 +138,20 @@ export function registerTools(server: McpServer, session: Session): void {
     inputSchema: { shape_id: z.string() },
     outputSchema: deleteShapeOutput,
   }, run("delete_shape", ({ shape_id }) => session.deleteShape(shape_id)));
+
+  server.registerTool("sheet_context", {
+    description: `The sheet's STRUCTURE in one call and one frame: the classified vector segments, the positioned text spans, and the hatch-family instances of a region — everything the engine itself floods against, exposed as data instead of pixels. Use it when you need to REASON about a region rather than look at it: which lines bound this space and at what pen weight, what the region says, and which periodic fill pattern covers it. The join is the point — all three arrive in image px with no reconciliation left to do, and the reply echoes the post-clamp region so passing that same rect to view_sheet gives you the matching render by construction. Hatch families carry a content-derived id (same pattern spec ⇒ same id, anywhere on the sheet), so matching a plan region to a legend swatch is comparing two ids, not guessing from a render — read the legend region, read the room region, match ids, and cite both bboxes as evidence. Decimation is declared, ordered, and counted on every reply: segments shorter than min_len_px drop first (invisible ink), then a max_segments cap applies LONGEST-FIRST so walls survive and hatch strokes go; kept + dropped always reconciles to total_in_region, and whole segments drop with their meta intact — nothing is ever simplified or merged, because these are classified segments and a merge would rewrite the classification. A scan returns has_vector_linework: false with empty vectors — absence of linework, never a claim the region is blank. ${COORDS}`,
+    inputSchema: {
+      sheet: z.string(),
+      region: z.object({ x0: z.number(), y0: z.number(), x1: z.number(), y1: z.number() }).optional()
+        .describe("Rect in image px (origin top-left, y down); omit for the full sheet"),
+      min_len_px: z.number().min(0).default(CONTEXT_MIN_LEN_PX)
+        .describe(`Drop segments shorter than this (default ${CONTEXT_MIN_LEN_PX} — one PDF point at render scale 2.0, below any pen width). 0 keeps everything`),
+      max_segments: z.number().int().min(1).max(CONTEXT_MAX_SEGMENTS_CEIL).default(CONTEXT_MAX_SEGMENTS)
+        .describe(`Segment cap, applied longest-first (default ${CONTEXT_MAX_SEGMENTS}). The reply's dropped.cap says exactly what a smaller region would recover`),
+    },
+    outputSchema: sheetContextOutput,
+  }, run("sheet_context", (a) => session.sheetContext(a.sheet, { region: a.region, min_len_px: a.min_len_px, max_segments: a.max_segments })));
 
   server.registerTool("edit_shape", {
     description: `REVISE a shape you already committed, instead of deleting it and starting over: pass new verts to move the geometry, condition to reassign it to a different finish tag, role to switch between floor_area / deduct / linear, or any combination. Quantities are recomputed from the result — a role flip alone re-measures (closed area vs open length). The loop this is for: one_click or measure_polygon to commit, view_sheet with overlay:true to LOOK at what landed, then edit_shape to fix the two vertices that overshot into the corridor. Shapes a human affirmed (origin.reviewed) are ink and are refused — an agent revises its own pencil and nothing else. Agent self-revision is tallied on origin.agent_edits, kept deliberately separate from the human-correction fields. ${COORDS}`,

--- a/mcp/test/context.test.ts
+++ b/mcp/test/context.test.ts
@@ -1,0 +1,169 @@
+// sheet_context (issue #29) — vectors + text + hatch families of one region,
+// one frame, over the real demo plan through a real client/server pair.
+//
+// The contracts pinned here are the ones the design comment called
+// expensive-to-reverse:
+//   - structured-only reply, region echoed post-clamp (frame agreement is a
+//     contract on ONE rect, not on a second renderer);
+//   - clip-don't-transform: every returned segment actually intersects the
+//     requested region, endpoints exactly as drawn;
+//   - decimation is declared, ordered, and COUNTED: kept + dropped always
+//     reconciles to total_in_region, and the cap keeps the LONGEST segments;
+//   - the aligned arrays (segments / meta / family) never drift in length.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { buildServer } from "../server.ts";
+import { Session } from "../src/session.ts";
+
+const PLAN = fileURLToPath(new URL("../../demo/sample-plan.pdf", import.meta.url));
+const KEY = "sample-plan.pdf";
+
+async function pair(): Promise<Client> {
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  const server = buildServer(new Session());
+  await server.connect(st);
+  const client = new Client({ name: "context-test", version: "0.0.0" });
+  await client.connect(ct);
+  return client;
+}
+
+interface Reply { isError: boolean; data: any }
+async function call(client: Client, name: string, args: Record<string, unknown> = {}): Promise<Reply> {
+  const res: any = await client.callTool({ name, arguments: args });
+  return { isError: !!res.isError, data: JSON.parse(res.content[0].text) };
+}
+
+const segLen = (s: number[]): number => Math.hypot(s[2] - s[0], s[3] - s[1]);
+
+test("sheet_context: full sheet — counts reconcile, arrays align, region echoes the clamp", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+
+  // an oversized region clamps to the sheet and the reply SAYS so
+  const r = await call(client, "sheet_context", { sheet: KEY, region: { x0: -500, y0: -500, x1: 99999, y1: 99999 } });
+  assert.equal(r.isError, false);
+  const d = r.data;
+  assert.equal(d.has_vector_linework, true);
+  assert.deepEqual(d.region, [0, 0, d.sheet_px[0], d.sheet_px[1]], "post-clamp region echoed, full sheet");
+
+  // the decimation ledger always reconciles — this is the honesty contract
+  const v = d.vectors;
+  assert.ok(v.kept > 0, "the demo plan has visible linework");
+  assert.equal(v.kept + v.dropped.short + v.dropped.cap, v.total_in_region, "kept + dropped === total, always");
+  assert.equal(v.truncated, v.dropped.short + v.dropped.cap > 0);
+
+  // aligned arrays: one meta byte and one family slot per segment, no drift
+  assert.equal(v.segments.length, v.kept);
+  assert.equal(v.meta.length, v.kept);
+  assert.equal(v.family.length, v.kept);
+  for (const m of v.meta) assert.ok(Number.isInteger(m) && m >= 0 && m <= 255, "meta is the engine's byte, verbatim");
+  for (const f of v.family) assert.ok(f === null || /^h-a/.test(f), "family is a hatch id or null");
+
+  // text arrived in the same frame, with real boxes
+  assert.ok(d.text.count > 0, "the demo plan has labels and a title block");
+  for (const sp of d.text.spans) assert.ok(sp.x1 >= sp.x0 && sp.y1 >= sp.y0, "spans are well-formed boxes");
+});
+
+test("sheet_context: clip keeps exactly the segments that intersect the region", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  const full = (await call(client, "sheet_context", { sheet: KEY })).data;
+
+  // a window around room 101's label — found from the text layer, not
+  // hardcoded. pdf.js folds one show-text op into one item, so the label
+  // arrives as "OFFICE 101"; the (^|\s) guard keeps the title block's
+  // "A-101" from matching.
+  const label = full.text.spans.find((sp: any) => /(^|\s)101$/.test(sp.str.trim()));
+  assert.ok(label, "the demo plan labels room 101");
+  const cx = (label.x0 + label.x1) / 2, cy = (label.y0 + label.y1) / 2;
+  const region = { x0: cx - 150, y0: cy - 150, x1: cx + 150, y1: cy + 150 };
+
+  const r = (await call(client, "sheet_context", { sheet: KEY, region })).data;
+  assert.deepEqual(r.region, [region.x0, region.y0, region.x1, region.y1], "in-bounds region echoes verbatim");
+  assert.ok(r.text.spans.some((sp: any) => /(^|\s)101$/.test(sp.str.trim())), "the label is inside its own window");
+  assert.ok(r.vectors.total_in_region < full.vectors.total_in_region, "a window sees fewer segments than the sheet");
+
+  // clip-don't-transform: every returned segment truly overlaps the region box,
+  // and its endpoints are untouched (present verbatim in the full-sheet set)
+  const fullSet = new Set(full.vectors.segments.map((s: number[]) => s.join(",")));
+  for (const s of r.vectors.segments) {
+    const inX = Math.max(s[0], s[2]) >= region.x0 && Math.min(s[0], s[2]) <= region.x1;
+    const inY = Math.max(s[1], s[3]) >= region.y0 && Math.min(s[1], s[3]) <= region.y1;
+    assert.ok(inX && inY, `segment ${s} overlaps the region's bbox`);
+    assert.ok(fullSet.has(s.join(",")), "endpoints exactly as drawn — never rewritten by the clip");
+  }
+
+  // a far-corner window must NOT contain the label
+  const far = (await call(client, "sheet_context", { sheet: KEY, region: { x0: 0, y0: 0, x1: 40, y1: 40 } })).data;
+  assert.ok(!far.text.spans.some((sp: any) => /(^|\s)101$/.test(sp.str.trim())), "containment is real, not decorative");
+});
+
+test("sheet_context: the cap keeps the LONGEST segments and confesses the rest", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  const full = (await call(client, "sheet_context", { sheet: KEY, max_segments: 20000 })).data;
+  const capped = (await call(client, "sheet_context", { sheet: KEY, max_segments: 5 })).data;
+
+  assert.equal(capped.vectors.kept, 5);
+  assert.equal(capped.vectors.truncated, true);
+  assert.ok(capped.vectors.dropped.cap > 0);
+  assert.match(capped.vectors.note, /SHORTEST segments were dropped/, "truncation explains itself");
+  assert.equal(capped.vectors.kept + capped.vectors.dropped.short + capped.vectors.dropped.cap,
+    capped.vectors.total_in_region, "the ledger reconciles even under a tiny cap");
+
+  // longest-first is checkable: the five kept are the five longest visible ones
+  const wantTop = full.vectors.segments.map(segLen).sort((a: number, b: number) => b - a).slice(0, 5);
+  const got = capped.vectors.segments.map(segLen).sort((a: number, b: number) => b - a);
+  for (let i = 0; i < 5; i++) {
+    assert.ok(Math.abs(got[i] - wantTop[i]) < 0.5, `kept[${i}] is the ${i + 1}th-longest segment (${got[i]} vs ${wantTop[i]})`);
+  }
+});
+
+test("sheet_context: min_len_px is a real floor, and the degenerate region refuses", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+
+  const strict = (await call(client, "sheet_context", { sheet: KEY, min_len_px: 1e9 })).data;
+  assert.equal(strict.vectors.kept, 0);
+  assert.equal(strict.vectors.dropped.short, strict.vectors.total_in_region, "everything below an absurd floor is 'short'");
+
+  const empty = await call(client, "sheet_context", { sheet: KEY, region: { x0: 500, y0: 500, x1: 500, y1: 500 } });
+  assert.equal(empty.isError, true);
+  assert.match(empty.data.error, /Empty context region/);
+
+  const ghost = await call(client, "sheet_context", { sheet: "nope.pdf" });
+  assert.equal(ghost.isError, true);
+  assert.match(ghost.data.error, /Unknown sheet/);
+});
+
+test("sheet_context: frame agreement with the write path — a context wall bounds a one_click room", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  await call(client, "set_scale", { sheet: KEY, use_detected: true });
+
+  // trace room 101 through the flood, then ask sheet_context about the ring's
+  // bbox: the flood's boundary linework must be present as vector segments in
+  // the SAME coordinates — the two tools are two views of one frame.
+  const clicked = (await call(client, "one_click", { sheet: KEY, x: 600, y: 1084, return_verts: true })).data;
+  assert.ok(clicked.verts?.length >= 4);
+  const xs = clicked.verts.map((v: number[]) => v[0]), ys = clicked.verts.map((v: number[]) => v[1]);
+  const region = { x0: Math.min(...xs) - 10, y0: Math.min(...ys) - 10, x1: Math.max(...xs) + 10, y1: Math.max(...ys) + 10 };
+  const ctx = (await call(client, "sheet_context", { sheet: KEY, region })).data;
+  assert.ok(ctx.vectors.kept >= 4, "the room's boundary linework is in its own bbox");
+  // every traced vertex sits ON the linework sheet_context returned — on a
+  // segment, not necessarily at an endpoint: a corner at a T-junction lands
+  // mid-span of the through wall. Point-to-segment distance is the real claim.
+  const distToSeg = (px: number, py: number, s: number[]): number => {
+    const dx = s[2] - s[0], dy = s[3] - s[1];
+    const L2 = dx * dx + dy * dy;
+    const t = L2 ? Math.max(0, Math.min(1, ((px - s[0]) * dx + (py - s[1]) * dy) / L2)) : 0;
+    return Math.hypot(px - (s[0] + t * dx), py - (s[1] + t * dy));
+  };
+  for (const v of clicked.verts) {
+    const near = ctx.vectors.segments.some((s: number[]) => distToSeg(v[0], v[1], s) <= 8);
+    assert.ok(near, `traced vertex ${v} lands on the linework sheet_context returned`);
+  }
+});

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -49,12 +49,12 @@ async function captureStderr(fn: () => Promise<void>): Promise<string> {
 // speaks image px and says so.
 const NO_COORDS = new Set(["undo_last"]);
 
-test("tools/list: all fourteen tools, each described with the coordinate contract", async () => {
+test("tools/list: all fifteen tools, each described with the coordinate contract", async () => {
   const client = await pair();
   const { tools } = await client.listTools();
   assert.deepEqual(tools.map((t) => t.name).sort(), [
     "delete_shape", "detect_rooms", "edit_shape", "export_takeoff", "load_plan", "measure_line", "measure_polygon",
-    "one_click", "read_sheet_text", "set_scale", "sheet_info", "takeoff_summary", "undo_last", "view_sheet",
+    "one_click", "read_sheet_text", "set_scale", "sheet_context", "sheet_info", "takeoff_summary", "undo_last", "view_sheet",
   ]);
   for (const t of tools) {
     if (NO_COORDS.has(t.name)) continue;

--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -230,15 +230,45 @@ export function extractVectorGeometry(opList: OpList, transform: number[], OPS: 
 // coincide with walls), and heavier-pen members stay hard (wall overprint).
 interface HatchCand { i: number; ang: number; x1: number; y1: number; x2: number; y2: number; w: number; }
 interface HatchRow { d: number; t0: number; t1: number; segs: HatchCand[]; }
-export function classifyHatchSegs(segs: number[], meta: Uint8Array, ws: number): Uint8Array {
+
+/** One periodic family found by the sweep — the (angle, pitch, pen-width)
+ * signature plus its membership, in the caller's coordinate unit (ws-scaled).
+ * This is the data `classifyHatchSegs` always computed and then threw away
+ * (issue #29): the classifier's view keeps only `softIdx`; the context view
+ * (`hatchFamilies`) keeps the signature, which is what makes legend↔plan
+ * matching a comparison instead of a vision guess. */
+export interface HatchRunInfo {
+  /** Mean member angle, folded to [0, 180) — direction-free. */
+  angleDeg: number;
+  /** Median row-to-row gap (the pattern's pitch), in the caller's unit. */
+  pitch: number;
+  /** Modal device pen width of the members (meta high nibble). */
+  modalW: number;
+  rowCount: number;
+  /** Tight bbox over member segments [x0, y0, x1, y1], caller's unit. */
+  bbox: [number, number, number, number];
+  /** Every segment index belonging to the run's rows. */
+  memberIdx: number[];
+  /** The subset the classifier softens — members minus the wall guards
+   * (extremal rows, span-protected rows, heavy-pen overprints). */
+  softIdx: number[];
+}
+
+/** The sweep core, shared verbatim-in-logic by both views: collect stroked
+ * non-curve candidates, cluster by angle (folding the 0°/180° seam), merge
+ * collinear pieces into rows, and keep maximal regularly-pitched
+ * tangentially-stacking runs. Returns the runs plus the clip-only indices
+ * (invisible ink — soft outright, independent of any family). */
+function sweepHatchRuns(segs: number[], meta: Uint8Array, ws: number): { clipSoft: number[]; runs: HatchRunInfo[] } {
   const n = segs.length >> 2;
-  const soft = new Uint8Array(n);
-  if (!meta || !n) return soft;
+  const clipSoft: number[] = [];
+  const runs: HatchRunInfo[] = [];
+  if (!meta || !n) return { clipSoft, runs };
   const cand: HatchCand[] = [];
   for (let i = 0; i < n; i++) {
     const mt = meta[i];
     if (mt & SEG_CURVE) continue;
-    if (mt & SEG_CLIP) { soft[i] = 1; continue; }
+    if (mt & SEG_CLIP) { clipSoft.push(i); continue; }
     // Filled-not-stroked outlines bound SOLID ink (wall poché). Their short
     // 0°/90° edges ride a tile grid's rhythm and would classify as hatch — but
     // making them transparent lets the escalated fill cross a solid black band
@@ -253,7 +283,7 @@ export function classifyHatchSegs(segs: number[], meta: Uint8Array, ws: number):
     if (ang < 0) ang += 180; if (ang >= 180) ang -= 180;
     cand.push({ i, ang, x1, y1, x2, y2, w: meta[i] >> 4 });
   }
-  if (cand.length < HATCH_MIN_RUN) return soft;
+  if (cand.length < HATCH_MIN_RUN) return { clipSoft, runs };
   cand.sort((a, b) => a.ang - b.ang);
   // sweep into angle clusters; a near-0° cluster merges with a near-180° one
   const clusters: HatchCand[][] = [];
@@ -313,11 +343,25 @@ export function classifyHatchSegs(segs: number[], meta: Uint8Array, ws: number):
       const spans: number[] = [];
       for (let k = a; k <= b; k++) spans.push(rows[k].t1 - rows[k].t0);
       const medSpan = Math.max(1, median(spans));
-      for (let k = a + 1; k < b; k++) {                 // extremal rows stay hard
-        if (rows[k].t1 - rows[k].t0 > SPAN_PROTECT_RATIO * medSpan) continue;
-        for (const s of rows[k].segs)
-          if (s.w < WIDE_PROTECT_RATIO * modalW) soft[s.i] = 1;
+      const memberIdx: number[] = [];
+      const softIdx: number[] = [];
+      let bx0 = Infinity, by0 = Infinity, bx1 = -Infinity, by1 = -Infinity;
+      let angSum = 0, angN = 0;
+      for (let k = a; k <= b; k++) {
+        const guarded = rows[k].t1 - rows[k].t0 > SPAN_PROTECT_RATIO * medSpan;
+        for (const s of rows[k].segs) {
+          memberIdx.push(s.i);
+          angSum += s.ang; angN++;
+          bx0 = Math.min(bx0, s.x1, s.x2); by0 = Math.min(by0, s.y1, s.y2);
+          bx1 = Math.max(bx1, s.x1, s.x2); by1 = Math.max(by1, s.y1, s.y2);
+          // the classifier's wall guards: extremal rows stay hard, span-
+          // protected rows stay hard, heavy-pen overprints stay hard
+          if (k > a && k < b && !guarded && s.w < WIDE_PROTECT_RATIO * modalW) softIdx.push(s.i);
+        }
       }
+      const meanAng = ((angSum / Math.max(1, angN)) % 180 + 180) % 180;
+      runs.push({ angleDeg: meanAng, pitch: med, modalW, rowCount: count,
+                  bbox: [bx0, by0, bx1, by1], memberIdx, softIdx });
     };
     for (let k = 1; k < rows.length; k++) {
       const gap = rows[k].d - rows[k - 1].d;
@@ -327,7 +371,68 @@ export function classifyHatchSegs(segs: number[], meta: Uint8Array, ws: number):
     }
     flushRun(runStart, rows.length - 1);
   }
+  return { clipSoft, runs };
+}
+
+/** The classifier's view of the sweep: clip-only paths soft outright, then
+ * every run member the wall guards allow. Bit-compatible with the historical
+ * implementation — the guards moved into `sweepHatchRuns` unchanged. */
+export function classifyHatchSegs(segs: number[], meta: Uint8Array, ws: number): Uint8Array {
+  const soft = new Uint8Array(segs.length >> 2);
+  const { clipSoft, runs } = sweepHatchRuns(segs, meta, ws);
+  for (const i of clipSoft) soft[i] = 1;
+  for (const r of runs) for (const i of r.softIdx) soft[i] = 1;
   return soft;
+}
+
+// Signature quantization for the stable family id (issue #29): coarse enough
+// to absorb CAD jitter (≪ the classifier's own tolerances), fine enough that
+// distinct pattern specs never collide. The RAW signature values ride along
+// beside the id so a caller can run its own tolerance match when an instance
+// sits on a bucket boundary.
+export const HATCH_ID_ANGLE_Q = 0.5;  // degrees
+export const HATCH_ID_PITCH_Q = 0.1;  // px
+
+/** One hatch-family INSTANCE: a periodic region of the sheet, carrying the
+ * content-derived id that makes instances comparable. Two regions drawn with
+ * the same pattern spec — a legend swatch and the plan region it labels — get
+ * the SAME id, which is the whole point: matching them is `id === id`. The id
+ * identifies a pattern, not a material; the legend maps pattern → material. */
+export interface HatchFamily {
+  /** Content hash of the quantized signature: `h-a{angle}p{pitch}w{penW}`.
+   * Derived from geometry alone — stable across calls, crops, and sessions. */
+  id: string;
+  angle_deg: number;
+  pitch_px: number;
+  pen_w_px: number;
+  rows: number;
+  segments: number;
+  /** Tight bbox over the instance's members, image px [x0, y0, x1, y1]. */
+  bbox: [number, number, number, number];
+  /** Member segment indices into the sheet's segs/meta arrays. */
+  memberIdx: number[];
+}
+
+/** The context view of the sweep (issue #29): every periodic family on the
+ * sheet as an instance record with its (angle, pitch, pen-width) signature —
+ * in IMAGE PX (ws = 1), the frame every tool speaks. Pure and deterministic;
+ * same input, same ids. */
+export function hatchFamilies(segs: number[], meta: Uint8Array): HatchFamily[] {
+  const { runs } = sweepHatchRuns(segs, meta, 1);
+  const q = (v: number, step: number): number => Math.round(v / step) * step;
+  return runs.map((r) => {
+    const a = q(r.angleDeg, HATCH_ID_ANGLE_Q), p = q(r.pitch, HATCH_ID_PITCH_Q);
+    return {
+      id: `h-a${a.toFixed(1)}p${p.toFixed(1)}w${r.modalW}`,
+      angle_deg: +r.angleDeg.toFixed(2),
+      pitch_px: +r.pitch.toFixed(2),
+      pen_w_px: r.modalW,
+      rows: r.rowCount,
+      segments: r.memberIdx.length,
+      bbox: r.bbox.map((v) => +v.toFixed(1)) as [number, number, number, number],
+      memberIdx: r.memberIdx,
+    };
+  });
 }
 
 // ── 3. boundary mask ───────────────────────────────────────────────────────

--- a/web/test/hatchFamilies.test.ts
+++ b/web/test/hatchFamilies.test.ts
@@ -1,0 +1,90 @@
+// hatchFamilies — the context view of the hatch sweep (issue #29).
+//
+// The classifier (classifyHatchSegs) and the family view (hatchFamilies) share
+// one sweep; these tests pin the family half: the (angle, pitch, pen-width)
+// signature is reported faithfully, and the content-derived id delivers the
+// property the feature exists for — two instances of the same pattern spec,
+// drawn in different places (a legend swatch and the plan region it labels),
+// get the SAME id, while a different spec gets a different one.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { hatchFamilies, classifyHatchSegs, SEG_CURVE } from "../src/lib/oneclick.ts";
+
+/** A vertical-line hatch field: lines at `pitch` apart, penW in the meta high
+ * nibble — the synthetic pattern geometry.test.ts already floods against. */
+function hatchField(x0: number, y0: number, x1: number, y1: number, pitch: number, penW: number, segs: number[], meta: number[]): void {
+  for (let x = x0; x <= x1; x += pitch) {
+    segs.push(x, y0, x, y1);
+    meta.push(penW << 4);
+  }
+}
+
+test("hatchFamilies: signature reported faithfully — angle, pitch, pen width, rows", () => {
+  const segs: number[] = [], meta: number[] = [];
+  hatchField(100, 100, 700, 500, 4, 1, segs, meta);
+  const fams = hatchFamilies(segs, Uint8Array.from(meta));
+  assert.equal(fams.length, 1, "one field, one family");
+  const f = fams[0];
+  assert.equal(f.angle_deg, 90, "vertical lines fold to 90°");
+  assert.equal(f.pitch_px, 4, "the drawing pitch, in image px");
+  assert.equal(f.pen_w_px, 1);
+  assert.equal(f.rows, segs.length >> 2, "every line is a row");
+  assert.equal(f.segments, segs.length >> 2);
+  // tight bbox over the members
+  assert.deepEqual(f.bbox, [100, 100, 700, 500]);
+  // memberIdx addresses the caller's segs array
+  assert.ok(f.memberIdx.every((i) => i >= 0 && i < (segs.length >> 2)));
+});
+
+test("hatchFamilies: the legend-match property — same spec, different place, SAME id", () => {
+  const segs: number[] = [], meta: number[] = [];
+  hatchField(100, 100, 400, 400, 6, 1, segs, meta);   // "plan region"
+  hatchField(900, 700, 1000, 760, 6, 1, segs, meta);  // "legend swatch", far away
+  const fams = hatchFamilies(segs, Uint8Array.from(meta));
+  assert.equal(fams.length, 2, "two instances, reported separately");
+  assert.equal(fams[0].id, fams[1].id, "same (angle, pitch, penW) spec ⇒ same id — matching is id === id");
+  assert.notDeepEqual(fams[0].bbox, fams[1].bbox, "…but they are distinct instances in distinct places");
+});
+
+test("hatchFamilies: a different pattern spec gets a different id", () => {
+  const segs: number[] = [], meta: number[] = [];
+  hatchField(100, 100, 400, 400, 6, 1, segs, meta);   // 6px pitch, hairline
+  hatchField(900, 100, 1200, 400, 12, 2, segs, meta); // 12px pitch, heavier pen
+  const fams = hatchFamilies(segs, Uint8Array.from(meta));
+  assert.equal(fams.length, 2);
+  assert.notEqual(fams[0].id, fams[1].id, "pitch and pen width both separate the ids");
+});
+
+test("hatchFamilies: id is deterministic across calls and unaffected by unrelated linework", () => {
+  const base: number[] = [], baseMeta: number[] = [];
+  hatchField(100, 100, 400, 400, 6, 1, base, baseMeta);
+  const alone = hatchFamilies(base, Uint8Array.from(baseMeta));
+
+  // same field plus walls and a door swing elsewhere on the sheet
+  const segs = base.slice(), meta = baseMeta.slice();
+  segs.push(600, 100, 1100, 100); meta.push(4 << 4);          // a heavy wall
+  segs.push(600, 100, 600, 500); meta.push(4 << 4);
+  segs.push(700, 300, 760, 360); meta.push(SEG_CURVE);        // door-swing chord
+  const crowded = hatchFamilies(segs, Uint8Array.from(meta));
+
+  assert.equal(alone.length, 1);
+  assert.equal(crowded.length, 1, "walls and curves never join a family");
+  assert.equal(alone[0].id, crowded[0].id, "the id depends on the pattern, not the neighborhood");
+});
+
+test("hatchFamilies and classifyHatchSegs agree on membership (one sweep, two views)", () => {
+  const segs: number[] = [], meta: number[] = [];
+  hatchField(100, 100, 700, 500, 4, 1, segs, meta);
+  const n = segs.length >> 2;
+  // heavy-pen overprint riding the field's rhythm — a member, but wall-guarded
+  segs.push(400.5, 100, 400.5, 500); meta.push(4 << 4);
+  const fams = hatchFamilies(segs, Uint8Array.from(meta));
+  const soft = classifyHatchSegs(segs, Uint8Array.from(meta), 1);
+  assert.equal(fams.length, 1);
+  const members = new Set(fams[0].memberIdx);
+  // every softened segment is a member of some family…
+  for (let i = 0; i <= n; i++) if (soft[i]) assert.ok(members.has(i), `soft ${i} must be a family member`);
+  // …but membership is wider than softness: the guards keep walls hard
+  assert.ok(members.has(n), "the heavy overprint is a member of the family");
+  assert.equal(soft[n], 0, "…and still hard — the wall guard held");
+});


### PR DESCRIPTION
Closes #29. Built to the design posted in the issue thread — structured-only reply, clip-don't-transform, longest-first decimation with a reconciling ledger, content-hash family ids.

## What

**`sheet_context(sheet, region?, min_len_px?, max_segments?)`** — tool 15. For one region, in one call, in image px:

- **vectors** — the classified segments the engine itself floods against: endpoints exactly as drawn, one meta byte each (curve/clip/poché bits + device pen width), plus a per-segment `family` annotation.
- **text** — every span with its bbox (new `textSpans` extraction; `positionedText` stays for the tools that want points).
- **hatch** — the sheet's periodic-family instances, each with a **content-derived id** built from the quantized (angle, pitch, pen-width) signature: `h-a45.0p12.4w1`. Same pattern spec ⇒ same id anywhere on the sheet, so plan↔legend matching is `id === id` — a comparison with bbox evidence, not a vision guess. Raw signature values ride beside the id for tolerance matching at bucket boundaries.

## The engine change

`classifyHatchSegs` always computed the full signature and threw it away. The sweep is now one algorithm with two views: `sweepHatchRuns` (internal) feeds both the classifier — **bit-compatible, guards moved not changed, existing tests pass untouched** — and the new pure `hatchFamilies`. The legend-match property (same spec, different place, same id; different spec, different id; id independent of the neighborhood) is pinned in `web/test/hatchFamilies.test.ts`, and a cross-view test asserts every softened segment is a family member while the wall guards stay hard.

## Frame reconciliation — there isn't one

Everything already lives in image px. The method clips (Liang–Barsky **keep** test — endpoints never rewritten) and echoes the post-clamp region; pass that same rect to `view_sheet` and the render matches by construction. A scan returns `has_vector_linework: false` with empty vectors — absence of linework, never a claim the region is blank.

## Decimation, measured (the issue's finish-line ask)

Policy: drop `< min_len_px` (default 2.0 — one PDF pt at render scale) → cap at `max_segments` (default 4000) **longest-first** → report `{kept, total_in_region, truncated, dropped: {short, cap}}` on every reply. `kept + dropped === total` is pinned by test. No Douglas–Peucker: these are classified segments, and a merge would silently rewrite the classification.

Measured on a real 140k-segment E-size architectural unit plan (local file, not committed — no real plans in the repo):

| query | total | kept | dropped short | dropped cap | families | bytes | time |
|---|---|---|---|---|---|---|---|
| full sheet, defaults | 140,167 | 4,000 | 71,100 | 65,067 | 17 | 205 KB | ~100 ms |
| quarter-sheet window | 6,657 | 3,142 | 3,515 | 0 | 5 | 132 KB | ~8 ms |
| full, cap 8,000 | 140,167 | 8,000 | 71,100 | 61,067 | 17 | 364 KB | — |
| full, cap 2,000 | 140,167 | 2,000 | 71,100 | 67,067 | 17 | 125 KB | — |

Two findings worth the read: **half the sheet's segments are sub-2px invisible ink**, and the window workflow the tool teaches (narrow the region instead of raising the cap) hits no cap at quarter-sheet on the densest page we have. And the family sweep found **17 instances on the exact sheet class where flood-based room detection is weakest** — the semantic layer arriving where the geometric one struggles.

## Verification

- `web`: typecheck, build, and the full suite — including the untouched `classifyHatchSegs` guard test (refactor is behavior-compatible) and 5 new `hatchFamilies` tests.
- `mcp`: typecheck, 52 tests (5 new in `test/context.test.ts`: ledger reconciliation, clip-keeps-verbatim-endpoints, longest-first checked against the full set, floors/refusals, and a frame-agreement test where a `one_click` ring's snapped vertices land on the linework `sheet_context` returns), build, `smoke:dist` (15 tools).
- The output-contract test loops every tool automatically, so `sheet_context`'s schema is validated on every call.

## Deliberately not here

The room-158 legend narrative end-to-end needs a plan with a drawn finish legend — the demo plan has none and real plans don't enter this repo. The mechanism it needs (stable ids across distant regions) is pinned by unit test and measured live above; the narrative run happens on a real project driveside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)