### PR TITLE
opentakeoff-mcp 0.7.0

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.6.1",
+  "version": "0.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Version bump only — the four feature/security commits are already merged (#93 edit_shape+undo_last, #94 sheet_context, #95 detect_rooms seed ladder + sensitivity knob, #96 dependabot cleanup) but npm has been stuck on 0.6.1 since. Bumps `mcp/package.json` + `mcp/server.json` (all three version fields, matching the release workflow's consistency check) to 0.7.0 and syncs the lockfile.

## Gate
- `npm run typecheck` clean
- `npm test` — 52/52 passed
- `npm run build` clean

Merging this then tagging `mcp-v0.7.0` publishes via trusted publishing (OIDC, no token) per `.github/workflows/publish-mcp.yml`.