### PR TITLE
chore(mcp): bump to 0.8.0 for find_text/edit_materials release

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.8.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
Version bump only, no functional changes — ships #100's two new tools (`find_text`, `edit_materials`) to npm/the MCP registry. Bumps all three version-carrying fields per the release runbook (`mcp/README.md` § Releasing): `package.json`, `server.json .version`, `server.json .packages[0].version`. Lockfile regenerated.

## Test plan
- [x] `npm run typecheck` / `npm test` (54/54) / `npm run build` / `npm run smoke:dist` all clean at 0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)