### PR TITLE
Signal-set hatches: six trade-agnostic patterns with faithful marked-set export

### DIFF
--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -23,7 +23,9 @@ import { gridPxPerFoot, drawGrid, drawShapes, type Ctx2D, type ToCanvas } from "
 const SNAP_CELL = 24; // snap-grid bucket, raster px
 const SNAP_TOL = 7;   // one-click vertex-snap tolerance, image px
 const PALETTE = ["#c96442", "#2f7d54", "#2563eb", "#9333ea", "#b8860b", "#0d9488", "#be185d", "#1f2937", "#dc2626", "#0891b2"];
-const HATCH_IDS = ["solid", "diag", "diag2", "cross", "diagdense", "horiz", "vert", "grid", "brick", "plank", "herring", "basket", "checker", "wave", "fleur", "speckle"];
+// (2026-07: dropped a drifted "fleur" entry that never existed in this app's
+// HATCHES, restoring "dots", and appended the signal-set ids.)
+const HATCH_IDS = ["solid", "diag", "diag2", "cross", "diagdense", "horiz", "vert", "grid", "brick", "plank", "herring", "basket", "checker", "wave", "dots", "speckle", "iso", "honeycomb", "scan", "plus", "circuit", "topo"];
 // uid mirrors web/src/lib/provenance.js mintUuid: crypto.randomUUID is a
 // global in Node 20+, with the same non-secure-context fallback the browser
 // build carries so the two sides mint identically-shaped ids.

--- a/web/src/components/hatches.jsx
+++ b/web/src/components/hatches.jsx
@@ -26,6 +26,12 @@ export const HATCHES = [
   { id: "wave", label: "Wave / scallop" },
   { id: "dots", label: "Sand / dots" },
   { id: "speckle", label: "Terrazzo / speckle" },
+  { id: "iso", label: "Isometric grid" },
+  { id: "honeycomb", label: "Honeycomb" },
+  { id: "scan", label: "Scanline" },
+  { id: "plus", label: "Plus grid" },
+  { id: "circuit", label: "Circuit / traces" },
+  { id: "topo", label: "Contour / topo" },
 ];
 export const PALETTE = ["#c96442", "#2f7d54", "#2563eb", "#9333ea", "#b8860b", "#0d9488", "#be185d", "#1f2937", "#dc2626", "#0891b2"];
 export const NO_FILL = "none";
@@ -36,9 +42,13 @@ export function HatchPattern({ id, type, line, fill, dark }) {
   // dark mode legibility comes from brighter alphas baked into the pattern —
   // never a CSS filter over the shape overlay (that re-rasterizes the whole
   // layer on every sync)
-  const bg = fill && fill !== NO_FILL ? <rect width={10} height={10} fill={fill} opacity={dark ? 0.32 : 0.18} /> : null;
   const s = (d) => <path d={d} stroke={line} strokeWidth={sw} fill="none" />;
-  const wrap = (kids) => <pattern id={id} patternUnits="userSpaceOnUse" width={10} height={10}>{bg}{kids}</pattern>;
+  const wrap = (kids, w = 10, h = 10) => (
+    <pattern id={id} patternUnits="userSpaceOnUse" width={w} height={h}>
+      {fill && fill !== NO_FILL ? <rect width={w} height={h} fill={fill} opacity={dark ? 0.32 : 0.18} /> : null}
+      {kids}
+    </pattern>
+  );
   switch (type) {
     case "diag": return wrap(s("M0,10 L10,0 M-3,3 L3,-3 M7,13 L13,7"));
     case "diag2": return wrap(s("M0,0 L10,10 M-3,7 L3,13 M7,-3 L13,3"));
@@ -55,6 +65,25 @@ export function HatchPattern({ id, type, line, fill, dark }) {
     case "wave": return wrap(<>{s("M0,4 Q2.5,1 5,4 T10,4")}{s("M0,8 Q2.5,5 5,8 T10,8")}</>);
     case "dots": return wrap(<>{[2, 6].map((y) => [2, 6].map((x) => <circle key={`${x}-${y}`} cx={x} cy={y} r={1.1} fill={line} />))}</>);
     case "speckle": return wrap(<>{[[1.5, 2, 1.3], [6, 1.5, 0.8], [3.5, 5, 1], [8, 5.5, 1.4], [1.5, 8, 0.9], [6.5, 8.5, 1.2]].map(([x, y, r], i) => <circle key={i} cx={x} cy={y} r={r} fill={line} />)}</>);
+    // ── signal set (2026-07): trade-agnostic, engineering-read patterns ──
+    case "iso": return wrap(s("M-1.73,9 L15.59,-1 M-1.73,-1 L15.59,9 M6.93,0 L6.93,8"), 13.86, 8);
+    case "honeycomb": {
+      // Flat-top hex lattice, side 4: tile 12 × 4√3. Center hex + the four
+      // corner hexes (clipped quarters) keep the lattice seamless.
+      const H = 6.9282, hx = (cx, cy) =>
+        s(`M${cx - 4},${cy} L${cx - 2},${cy - 3.4641} L${cx + 2},${cy - 3.4641} L${cx + 4},${cy} L${cx + 2},${cy + 3.4641} L${cx - 2},${cy + 3.4641} Z`);
+      return wrap(<>{hx(0, 0)}{hx(12, 0)}{hx(0, H)}{hx(12, H)}{hx(6, H / 2)}</>, 12, H);
+    }
+    case "scan": return wrap(s("M0,2 L10,2 M8,6 L16,6 M0,6 L2,6"), 16, 8);
+    case "plus": return wrap(s("M6,3.5 L6,8.5 M3.5,6 L8.5,6 M0,0 L0,2.5 M0,9.5 L0,12 M12,0 L12,2.5 M12,9.5 L12,12 M0,0 L2.5,0 M9.5,0 L12,0 M0,12 L2.5,12 M9.5,12 L12,12"), 12, 12);
+    case "circuit": return wrap(<>
+      {s("M2,2 L10,2 L10,10")}{s("M14,18 L14,13 L18,13")}
+      {[[2, 2], [10, 10], [14, 18], [18, 13]].map(([x, y], i) => <circle key={i} cx={x} cy={y} r={1.2} fill={line} />)}
+    </>, 20, 20);
+    case "topo": return wrap(<>
+      <ellipse cx={12} cy={12} rx={8} ry={5} fill="none" stroke={line} strokeWidth={sw} transform="rotate(-18 12 12)" />
+      <ellipse cx={12} cy={12} rx={4.6} ry={2.6} fill="none" stroke={line} strokeWidth={sw} transform="rotate(-18 12 12)" />
+    </>, 24, 24);
     default: return wrap(null);  // solid: only the fill bg
   }
 }

--- a/web/src/lib/markedset.js
+++ b/web/src/lib/markedset.js
@@ -41,6 +41,58 @@ const HATCH_FAMILIES = {
   checker: [[45, 7]], wave: [[0, 10]], dots: [[45, 20]], speckle: [[45, 20]],
 };
 
+// Signal-set (2026-07) hatches carry real per-tile segments instead of a
+// line-family approximation — every one of them is segment-representable, so
+// the print keeps pattern identity. Authored in canvas SVG tile units and
+// scaled ×2 at draw time, matching the line families' print pitch convention.
+const TILE_K = 2;
+const hexSegs = (cx, cy, s) => {
+  const h = 0.866 * s;
+  const p = [[cx - s, cy], [cx - s / 2, cy - h], [cx + s / 2, cy - h], [cx + s, cy], [cx + s / 2, cy + h], [cx - s / 2, cy + h]];
+  return p.map((a, i) => [...a, ...p[(i + 1) % 6]]);
+};
+const ovalSegs = (cx, cy, rx, ry, rotDeg, n = 16) => {
+  const rot = (rotDeg * Math.PI) / 180, c = Math.cos(rot), s = Math.sin(rot), pts = [];
+  for (let i = 0; i <= n; i++) {
+    const a = (2 * Math.PI * i) / n, ex = rx * Math.cos(a), ey = ry * Math.sin(a);
+    pts.push([cx + ex * c - ey * s, cy + ex * s + ey * c]);
+  }
+  return pts.slice(1).map((p, i) => [...pts[i], ...p]);
+};
+const HATCH_TILES = {
+  iso: { w: 13.86, h: 8, segs: [[0, 8, 13.86, 0], [0, 0, 13.86, 8], [6.93, 0, 6.93, 8]] },
+  honeycomb: { w: 12, h: 6.9282, segs: [...hexSegs(0, 0, 4), ...hexSegs(6, 3.4641, 4)] },
+  scan: { w: 16, h: 8, segs: [[0, 2, 10, 2], [8, 6, 16, 6], [0, 6, 2, 6]] },
+  plus: { w: 12, h: 12, segs: [[6, 3.5, 6, 8.5], [3.5, 6, 8.5, 6], [0, -2.5, 0, 2.5], [-2.5, 0, 2.5, 0]] },
+  circuit: {
+    w: 20, h: 20,
+    segs: [[2, 2, 10, 2], [10, 2, 10, 10], [14, 18, 14, 13], [14, 13, 18, 13]],
+    dots: [[2, 2], [10, 10], [14, 18], [18, 13]],
+  },
+  topo: { w: 24, h: 24, segs: [...ovalSegs(12, 12, 8, 5, -18), ...ovalSegs(12, 12, 4.6, 2.6, -18, 12)] },
+};
+
+// tile-based hatch (image px): per-tile segments clipped to the polygon; a
+// spec's dots come back separately for the caller to draw as filled circles.
+function hatchTiles(poly, spec) {
+  let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
+  for (const [x, y] of poly) { x0 = Math.min(x0, x); y0 = Math.min(y0, y); x1 = Math.max(x1, x); y1 = Math.max(y1, y); }
+  const w = spec.w * TILE_K, h = spec.h * TILE_K;
+  const segs = [], dots = [];
+  for (let ty = Math.floor(y0 / h) * h; ty < y1 + h; ty += h) {
+    for (let tx = Math.floor(x0 / w) * w; tx < x1 + w; tx += w) {
+      for (const [ax, ay, bx, by] of spec.segs) {
+        segs.push(...clipSegToPoly(tx + ax * TILE_K, ty + ay * TILE_K, tx + bx * TILE_K, ty + by * TILE_K, poly));
+      }
+      for (const [cx, cy] of spec.dots || []) {
+        const x = tx + cx * TILE_K, y = ty + cy * TILE_K;
+        if (pointInPoly(x, y, poly)) dots.push([x, y]);
+      }
+    }
+  }
+  return { segs, dots };
+}
+
 const hex = (h) => {
   const s = String(h || "#888").replace("#", "");
   const v = s.length === 3 ? s.split("").map((c) => c + c).join("") : s.padEnd(6, "0");
@@ -446,7 +498,17 @@ export async function buildMarkedSetPdf({ projectName, dark, sheets, shapes, mar
         const fill = cond?.fill && cond.fill !== "none" && !isDeduct ? rgb(...hex(cond.fill)) : col;
         pg.drawSvgPath(svgPath(pts), { x: 0, y: 0, color: fill, opacity: (isDeduct ? 0.14 : 0.16) + alphaBoost / 2, borderColor: col, borderWidth: 1.1, borderOpacity: 0.95, ...(borderDash ? { borderDashArray: borderDash } : {}) });
         if (!isDeduct && cond?.hatch && cond.hatch !== "solid") {
-          for (const [ax, ay, bx, by] of hatchLines(pts, cond.hatch)) line(ax, ay, bx, by, col, 0.5, 0.55 + alphaBoost);
+          const tiled = HATCH_TILES[cond.hatch];
+          if (tiled) {
+            const { segs, dots } = hatchTiles(pts, tiled);
+            for (const [ax, ay, bx, by] of segs) line(ax, ay, bx, by, col, 0.5, 0.55 + alphaBoost);
+            for (const [dx, dy] of dots) {
+              const [px, py] = toPage(dx, dy);
+              pg.drawEllipse({ x: px, y: py, xScale: 1.4, yScale: 1.4, color: col, opacity: 0.55 + alphaBoost });
+            }
+          } else {
+            for (const [ax, ay, bx, by] of hatchLines(pts, cond.hatch)) line(ax, ay, bx, by, col, 0.5, 0.55 + alphaBoost);
+          }
         }
         chip(shapeChip(s, cond, M), ...centroid(pts), col);
       } else if (s.measure_role === "linear" || s.measure_role === "surface_area") {


### PR DESCRIPTION
## What

Grows the hatch library from 16 to 22 with a trade-agnostic, engineering-read set: **isometric grid**, **honeycomb**, **scanline**, **plus grid**, **circuit / traces**, **contour / topo**.

- `HatchPattern`'s wrapper now takes per-pattern tile sizes (existing 16 patterns unchanged at 10×10)
- No new UI — the picker maps over `HATCHES` and picks these up automatically

## Marked-set export

Every new pattern is segment-representable, so `markedset.js` gains `HATCH_TILES` + `hatchTiles()`: per-tile segments (and circuit vias) clipped through the existing `clipSegToPoly`. The set prints as drawn, not as a line-family approximation.

## Fix

`mcp/src/session.ts`'s hand-copied `HATCH_IDS` had drifted to a `"fleur"` id that doesn't exist in this app (position 15 should be `"dots"`). Repaired and extended with the new ids so agent-minted conditions rotate through the full set.

## Checks

web: typecheck, lint, build clean; 932 passing (the 4 "without localStorage" failures are the known Node 25-vs-24 gap, reproduced on clean main). mcp: typecheck, 54/54 tests, build + dist smoke green.

**Staged — hold merge** until the in-flight branch work lands, then rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)