### PR TITLE
Tile-pyramid canvas rendering via worker pool (#86)

### DIFF
--- a/web/src/lib/canvasConstants.js
+++ b/web/src/lib/canvasConstants.js
@@ -29,7 +29,14 @@ export const MAX_PANEL_AREA  = 28e6;                 // base-raster pixel budget
 // effectively never binds. Engage compares t.scale × devicePixelRatio (softness starts
 // when the raster is upscaled in device px — on a 2× display that's t.scale 0.5, not 1).
 export const DETAIL_ENGAGE = 1.15;  // engage once stage zoom × dpr passes ~1.15 (base raster starts to soften)
-export const DETAIL_MARGIN = 0.5;   // render this much extra region beyond the viewport so small pans don't expose the soft base at the edges
+// Render this much extra region beyond the viewport so small pans don't
+// expose an unfetched edge. 0.5 (4x the viewport's tile area) was the right
+// number for the OLD single-region crop render (one pdf.js call regardless
+// of margin size, so a bigger margin was nearly free); with #86's tile pool,
+// margin scales the TILE COUNT quadratically ((1+2*margin)^2), and a fat
+// margin was a real, measured contributor to "buffering takes forever" —
+// dropped to 0.25 (2.25x area, ~44% fewer tiles than 0.5) once that shipped.
+export const DETAIL_MARGIN = 0.25;
 export const SYNC_MS = 90;          // React tf-mirror sync cadence during gestures (~11Hz)
 export const GESTURE_MS = 140;      // wheel/pinch quiet window before the detail view re-renders
 // A backgrounded/hidden tab can suspend pdf.js's render scheduling indefinitely (promise

--- a/web/src/lib/tileCompositor.ts
+++ b/web/src/lib/tileCompositor.ts
@@ -18,6 +18,17 @@
 //           unlike the old single detailCanvasRef) — every panel in a group
 //           gets independent sharpness, closing the RFC's noted group-mode gap.
 //
+// paintDetail double-buffers and swaps ATOMICALLY (compose off-DOM, one
+// drawImage onto the visible canvas once the crop is ready or a short grace
+// period elapses) — this is the OLD codebase's own "never a partial paint"
+// rule (see its double-buffer comment history), which the first version of
+// this file dropped in favor of drawing each tile the moment it landed.
+// That reads, live, as tiles visibly sweeping across the sheet in whatever
+// order the worker pool happens to finish them — confirmed as a real UX
+// complaint, not a perf one: the fix is compositing off-screen and revealing
+// once, not rendering fewer/faster tiles (see tilePool.ts for the actual
+// speed fix — real N-way parallelism instead of one worker doing everything).
+//
 // Dark mode: tiles are cached per-mode (key suffixed :0/:1) and rendered
 // inverted BY THE WORKER before transfer, not re-inverted on the main thread
 // — inversion moves into the tile pipeline exactly as the RFC asks. This
@@ -32,7 +43,11 @@ import { TileLRU, buildLevels, pickLevel, levelDims, visibleTiles, tileKey as ra
 // ("4-up ≈ 450MB" per canvasConstants.js), now a BUDGET instead of a floor
 // that individual panels could each independently blow past.
 const BYTE_BUDGET = 450 * 1024 * 1024;
-const BASE_MARGIN = 0.5; // same DETAIL_MARGIN intent — buffer beyond the viewport
+// If the target crop isn't fully resolved within this long, reveal whatever
+// IS ready (placeholder + however many real tiles landed) rather than let
+// one slow/stuck tile hold the whole reveal hostage — a progressive fallback,
+// not the common case once tilePool.ts's real parallelism is in place.
+const REVEAL_GRACE_MS = 350;
 
 function modeKey(key: string, dark: boolean) { return `${key}:${dark ? 1 : 0}`; }
 
@@ -191,18 +206,21 @@ export function createTileCompositor() {
     return 0; // level 0 is always fetched by paintBase — safe fallback even if not yet cached (draws nothing, not a crash)
   }
 
-  /** Paints [x0,y0,x1,y1) (image px, +BASE_MARGIN buffer applied by the
-   *  caller) into `canvas`, sized to the region at `density`. Fires `onDone`
-   *  every time a fresh tile arrival changes what's on screen, so the caller
-   *  can just no-op if nothing needs repositioning. Returns a disposer that
-   *  stops this call from PAINTING anything further — deliberately NOT a
-   *  worker-render cancel: a superseded crop's tiles usually overlap the next
-   *  crop (pans are incremental), so letting them finish warms the cache the
-   *  successor reads from, and the byte budget bounds the cost. resetAll is
-   *  the hard cancel for sheet/group changes, where in-flight tiles really
-   *  are garbage. */
+  /** Paints [x0,y0,x1,y1) (image px, margin already applied by the caller)
+   *  for a panel positioned at `panelXOffset` in stage space. Composes
+   *  off-DOM and swaps into `canvas` ATOMICALLY — the visible canvas (size,
+   *  position, AND pixels) is untouched until the new crop is ready (or
+   *  REVEAL_GRACE_MS elapses), so the previous, fully-painted crop stays on
+   *  screen with zero flicker and zero tile-by-tile sweep. `onDone` fires
+   *  once per actual reveal (the atomic swap, or a rare post-grace straggler
+   *  patch), not once per tile. Returns a disposer that stops this call from
+   *  PAINTING anything further — deliberately NOT a worker-render cancel: a
+   *  superseded crop's tiles usually overlap the next crop (pans are
+   *  incremental), so letting them finish warms the cache the successor
+   *  reads from, and the byte budget bounds the cost. resetAll is the hard
+   *  cancel for sheet/group changes, where in-flight tiles really are garbage. */
   function paintDetail(
-    canvas: HTMLCanvasElement, sheetKey: string, x0: number, y0: number, x1: number, y1: number,
+    canvas: HTMLCanvasElement, sheetKey: string, panelXOffset: number, x0: number, y0: number, x1: number, y1: number,
     density: number, dark: boolean, onDone: () => void,
   ) {
     const dims = dimsBySheet.get(sheetKey);
@@ -212,11 +230,15 @@ export function createTileCompositor() {
     const targetDensity = levels[level];
     const bw = Math.max(1, Math.round((x1 - x0) * targetDensity));
     const bh = Math.max(1, Math.round((y1 - y0) * targetDensity));
-    canvas.width = bw; canvas.height = bh;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return { cancel() {} };
     const myGen = generation;
     let live = true;
+
+    // Compose off-DOM — see the file header for why this replaced painting
+    // straight onto the visible canvas.
+    const back = document.createElement("canvas");
+    back.width = bw; back.height = bh;
+    const bctx = back.getContext("2d");
+    if (!bctx) return { cancel() {} };
 
     const placeholderLevel = bestPlaceholderLevel(sheetKey, levels, level, x0, y0, x1, y1, dark);
     const phDensity = levels[placeholderLevel];
@@ -226,22 +248,49 @@ export function createTileCompositor() {
       if (!bmp) continue;
       const dx = (t.x / phDensity - x0) * targetDensity, dy = (t.y / phDensity - y0) * targetDensity;
       const dw = (t.w / phDensity) * targetDensity, dh = (t.h / phDensity) * targetDensity;
-      ctx.drawImage(bmp, dx, dy, dw, dh);
+      bctx.drawImage(bmp, dx, dy, dw, dh);
     }
 
     const target = visibleTiles(dims.w, dims.h, levels, level, x0, y0, x1, y1);
     // protect THIS crop's tiles from eviction while they're the visible set
     // (replaced wholesale by the next paintDetail on this sheet)
     visibleKeys.set(`${sheetKey}|detail`, new Set(target.map((t) => modeKey(rawTileKey(sheetKey, level, t.tx, t.ty), dark))));
+
+    let swapped = false;
+    const swap = () => {
+      if (swapped || !live || myGen !== generation) return;
+      swapped = true;
+      clearTimeout(graceTimer);
+      canvas.width = bw; canvas.height = bh;
+      canvas.style.left = `${panelXOffset + x0}px`; canvas.style.top = `${y0}px`;
+      canvas.style.width = `${x1 - x0}px`; canvas.style.height = `${y1 - y0}px`;
+      canvas.style.display = "block";
+      canvas.getContext("2d")?.drawImage(back, 0, 0);
+      onDone();
+    };
+    // Fallback only — swap normally fires the instant every target tile has
+    // settled (success or failure), which with tilePool.ts's real pool
+    // parallelism should usually beat this. If one tile is genuinely stuck,
+    // reveal what's ready rather than hold the whole crop hostage.
+    const graceTimer = window.setTimeout(swap, REVEAL_GRACE_MS);
+
+    let remaining = target.length;
+    if (remaining === 0) swap(); // degenerate region — nothing to wait for
     Promise.all(target.map(async (t) => {
       const bmp = await getOrFetchTile(sheetKey, level, t.tx, t.ty, targetDensity, dark);
-      if (!bmp || !live || myGen !== generation) return;
+      if (!bmp || !live || myGen !== generation) { remaining--; return; }
       const dx = t.x - x0 * targetDensity, dy = t.y - y0 * targetDensity;
-      ctx.drawImage(bmp, dx, dy);
-      onDone();
+      bctx.drawImage(bmp, dx, dy);
+      // A straggler landing AFTER the grace-period swap already happened:
+      // patch it directly onto the now-visible canvas (the live canvas is
+      // correctly sized/positioned by then) rather than lose it silently in
+      // a back buffer nobody composites again until the next settle.
+      if (swapped) { canvas.getContext("2d")?.drawImage(bmp, dx, dy); onDone(); }
+      remaining--;
+      if (remaining === 0) swap();
     })).catch(() => {});
 
-    return { cancel() { live = false; } };
+    return { cancel() { live = false; clearTimeout(graceTimer); } };
   }
 
   function dispose() { resetAll(); pool.dispose(); }

--- a/web/src/lib/tileCompositor.ts
+++ b/web/src/lib/tileCompositor.ts
@@ -1,0 +1,200 @@
+// Tile-pyramid compositor glue (#86) — the DOM/Worker orchestration layer.
+// Pure tile math lives in tiles.ts (tested); the worker pool lives in
+// tilePool.ts. This file is the untested glue, matching the repo's existing
+// split (canvasUtil.js/panelGeometry.js are pure+tested, the render effects
+// in TakeoffCanvas.jsx that drive real canvases are not) — see the #86
+// research note on why DOM+pdf.js orchestration stays outside node:test.
+//
+// Two layers per panel, mirroring the OLD base-raster + detail-overlay split
+// so pan/zoom never blanks:
+//   BASE  — one small (bounded backing store), painted ONCE per sheet from
+//           the coarsest pyramid level, stretched to the panel's full CSS
+//           footprint. Never re-rendered on pan/zoom. The "never blank"
+//           guarantee.
+//   DETAIL — repositioned/resized to [visible region + margin] on settle,
+//           like the old detail view, but active at every zoom level (no
+//           DETAIL_ENGAGE gate) and sourced from the tile cache instead of a
+//           fresh pdf.js render. One per PANEL (not one shared global,
+//           unlike the old single detailCanvasRef) — every panel in a group
+//           gets independent sharpness, closing the RFC's noted group-mode gap.
+//
+// Dark mode: tiles are cached per-mode (key suffixed :0/:1) and rendered
+// inverted BY THE WORKER before transfer, not re-inverted on the main thread
+// — inversion moves into the tile pipeline exactly as the RFC asks. This
+// trades a possible cache doubling (only if a user actively toggles dark
+// mode while looking at the same tiles) for zero main-thread pixel work.
+
+import { RENDER_SCALE } from "./sheets";
+import { createTilePool } from "./tilePool";
+import { TileLRU, buildLevels, pickLevel, levelDims, visibleTiles, tileKey as rawTileKey, TILE_SIZE } from "./tiles";
+
+// ~450MB shared across every open sheet/panel — the old per-group ceiling
+// ("4-up ≈ 450MB" per canvasConstants.js), now a BUDGET instead of a floor
+// that individual panels could each independently blow past.
+const BYTE_BUDGET = 450 * 1024 * 1024;
+const BASE_MARGIN = 0.5; // same DETAIL_MARGIN intent — buffer beyond the viewport
+
+function modeKey(key: string, dark: boolean) { return `${key}:${dark ? 1 : 0}`; }
+
+export function createTileCompositor() {
+  const pool = createTilePool();
+  const cache = new TileLRU(BYTE_BUDGET);
+  const inflightReqs = new Map<string, { cancel: () => void }>();
+  const levelsBySheet = new Map<string, number[]>();
+  const dimsBySheet = new Map<string, { w: number; h: number }>();
+  const opened = new Set<string>();
+  // Every tile request awaits this before hitting the worker — dataPromise
+  // (an IndexedDB read) resolves well after openSheet() returns, so without
+  // this gate a base-layer paint kicked off right after openSheet() would
+  // race the worker's "openSheet" message and come back "sheet not open".
+  const readyBySheet = new Map<string, Promise<void>>();
+  let generation = 0; // bumped on sheet/group change — invalidates in-flight paints
+
+  function levelsFor(sheetKey: string, imgW: number, imgH: number) {
+    let levels = levelsBySheet.get(sheetKey);
+    if (!levels) { levels = buildLevels(imgW, imgH); levelsBySheet.set(sheetKey, levels); dimsBySheet.set(sheetKey, { w: imgW, h: imgH }); }
+    return levels;
+  }
+
+  /** Idempotent per sheetKey. `dataPromise` must resolve to a FRESH byte copy
+   *  (transferred to the worker, not shared with the main-thread pdf.js doc). */
+  function openSheet(sheetKey: string, pageNum: number, dataPromise: Promise<ArrayBuffer | Uint8Array>, imgW: number, imgH: number) {
+    levelsFor(sheetKey, imgW, imgH);
+    if (opened.has(sheetKey)) return;
+    opened.add(sheetKey);
+    const ready = dataPromise.then((data) => {
+      const buf = data instanceof Uint8Array ? data.slice().buffer : data;
+      return pool.openSheet(sheetKey, pageNum, buf);
+    }).catch((err) => {
+      opened.delete(sheetKey);
+      // A sheet that never opens is a permanently blank panel, not a
+      // recoverable/expected case (unlike a superseded/cancelled tile) — this
+      // must be visible, or the failure mode is silent forever.
+      console.error(`[tiles] sheet failed to open: ${sheetKey}`, err);
+    });
+    readyBySheet.set(sheetKey, ready);
+  }
+
+  /** Clears every cached tile and closes every worker-side sheet — call on
+   *  group/sheet-set change, mirroring the old effect's *Ref.current.clear() sweep. */
+  function resetAll() {
+    generation++;
+    for (const r of inflightReqs.values()) { try { r.cancel(); } catch { /* done */ } }
+    inflightReqs.clear();
+    cache.clear();
+    for (const k of opened) pool.closeSheet(k);
+    opened.clear();
+    levelsBySheet.clear();
+    dimsBySheet.clear();
+    readyBySheet.clear();
+  }
+
+  async function getOrFetchTile(sheetKey: string, level: number, tx: number, ty: number, density: number, dark: boolean): Promise<ImageBitmap | undefined> {
+    const key = modeKey(rawTileKey(sheetKey, level, tx, ty), dark);
+    const cached = cache.get(key) as ImageBitmap | undefined;
+    if (cached) return cached;
+    if (inflightReqs.has(key)) return undefined; // already fetching — caller will repaint when it lands
+    const dims = dimsBySheet.get(sheetKey);
+    const levels = levelsBySheet.get(sheetKey);
+    if (!dims || !levels) return undefined;
+    const myGenEarly = generation;
+    try { await readyBySheet.get(sheetKey); } catch { return undefined; } // sheet failed to open
+    if (myGenEarly !== generation) return undefined; // superseded while we waited on open
+    const { w: levelW, h: levelH } = levelDims(dims.w, dims.h, density);
+    const x = tx * TILE_SIZE, y = ty * TILE_SIZE;
+    const rect = { x, y, w: Math.min(TILE_SIZE, levelW - x), h: Math.min(TILE_SIZE, levelH - y) };
+    if (rect.w <= 0 || rect.h <= 0) return undefined;
+    const myGen = generation;
+    const { promise, cancel } = pool.requestTile({ sheetKey, scale: RENDER_SCALE * density, rect, dark });
+    inflightReqs.set(key, { cancel });
+    try {
+      const { bitmap, w, h } = await promise;
+      inflightReqs.delete(key);
+      if (myGen !== generation) { bitmap.close(); return undefined; } // superseded by resetAll
+      cache.set(key, bitmap, w * h * 4);
+      return bitmap;
+    } catch {
+      inflightReqs.delete(key);
+      return undefined;
+    }
+  }
+
+  /** Whole-sheet coarse placeholder — small backing store, painted once. */
+  async function paintBase(canvas: HTMLCanvasElement, sheetKey: string, imgW: number, imgH: number, dark: boolean) {
+    const levels = levelsFor(sheetKey, imgW, imgH);
+    const level = 0;
+    const density = levels[level];
+    const { w: lw, h: lh } = levelDims(imgW, imgH, density);
+    const tiles = visibleTiles(imgW, imgH, levels, level, 0, 0, imgW, imgH);
+    canvas.width = lw; canvas.height = lh;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const myGen = generation;
+    await Promise.all(tiles.map(async (t) => {
+      const bmp = await getOrFetchTile(sheetKey, level, t.tx, t.ty, density, dark);
+      if (!bmp || myGen !== generation) return;
+      ctx.drawImage(bmp, t.x, t.y);
+    }));
+  }
+
+  /** Best coarser level fully cached for this region — the instant
+   *  placeholder drawn under the target level while its tiles stream in. */
+  function bestPlaceholderLevel(sheetKey: string, levels: number[], target: number, x0: number, y0: number, x1: number, y1: number, dark: boolean) {
+    const dims = dimsBySheet.get(sheetKey)!;
+    for (let l = target - 1; l >= 0; l--) {
+      const tiles = visibleTiles(dims.w, dims.h, levels, l, x0, y0, x1, y1);
+      if (tiles.length && tiles.every((t) => cache.has(modeKey(rawTileKey(sheetKey, l, t.tx, t.ty), dark)))) return l;
+    }
+    return 0; // level 0 is always fetched by paintBase — safe fallback even if not yet cached (draws nothing, not a crash)
+  }
+
+  /** Paints [x0,y0,x1,y1) (image px, +BASE_MARGIN buffer applied by the
+   *  caller) into `canvas`, sized to the region at `density`. Fires `onDone`
+   *  every time a fresh tile arrival changes what's on screen, so the caller
+   *  can just no-op if nothing needs repositioning. Returns a disposer that
+   *  cancels any tiles still in flight for this call. */
+  function paintDetail(
+    canvas: HTMLCanvasElement, sheetKey: string, x0: number, y0: number, x1: number, y1: number,
+    density: number, dark: boolean, onDone: () => void,
+  ) {
+    const dims = dimsBySheet.get(sheetKey);
+    const levels = levelsBySheet.get(sheetKey);
+    if (!dims || !levels) return { cancel() {} };
+    const level = pickLevel(levels, density);
+    const targetDensity = levels[level];
+    const bw = Math.max(1, Math.round((x1 - x0) * targetDensity));
+    const bh = Math.max(1, Math.round((y1 - y0) * targetDensity));
+    canvas.width = bw; canvas.height = bh;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return { cancel() {} };
+    const myGen = generation;
+    let live = true;
+
+    const placeholderLevel = bestPlaceholderLevel(sheetKey, levels, level, x0, y0, x1, y1, dark);
+    const phDensity = levels[placeholderLevel];
+    const phTiles = visibleTiles(dims.w, dims.h, levels, placeholderLevel, x0, y0, x1, y1);
+    for (const t of phTiles) {
+      const bmp = cache.get(modeKey(rawTileKey(sheetKey, placeholderLevel, t.tx, t.ty), dark)) as ImageBitmap | undefined;
+      if (!bmp) continue;
+      const dx = (t.x / phDensity - x0) * targetDensity, dy = (t.y / phDensity - y0) * targetDensity;
+      const dw = (t.w / phDensity) * targetDensity, dh = (t.h / phDensity) * targetDensity;
+      ctx.drawImage(bmp, dx, dy, dw, dh);
+    }
+
+    const target = visibleTiles(dims.w, dims.h, levels, level, x0, y0, x1, y1);
+    const cancels: Array<() => void> = [];
+    Promise.all(target.map(async (t) => {
+      const bmp = await getOrFetchTile(sheetKey, level, t.tx, t.ty, targetDensity, dark);
+      if (!bmp || !live || myGen !== generation) return;
+      const dx = t.x - x0 * targetDensity, dy = t.y - y0 * targetDensity;
+      ctx.drawImage(bmp, dx, dy);
+      onDone();
+    })).catch(() => {});
+
+    return { cancel() { live = false; for (const c of cancels) c(); } };
+  }
+
+  function dispose() { resetAll(); pool.dispose(); }
+
+  return { openSheet, resetAll, paintBase, paintDetail, dispose };
+}

--- a/web/src/lib/tileCompositor.ts
+++ b/web/src/lib/tileCompositor.ts
@@ -38,8 +38,35 @@ function modeKey(key: string, dark: boolean) { return `${key}:${dark ? 1 : 0}`; 
 
 export function createTileCompositor() {
   const pool = createTilePool();
-  const cache = new TileLRU(BYTE_BUDGET);
-  const inflightReqs = new Map<string, { cancel: () => void }>();
+  // The LRU owns real pixel memory: ImageBitmaps hold their backing store
+  // until close(), so eviction/replace/clear must close, or the "byte budget"
+  // only bounds the ledger while the process keeps every bitmap ever rendered
+  // alive until GC gets around to it. Never close a bitmap still on screen:
+  // the protect provider unions every panel's last-painted tile set (base +
+  // detail), so evictToBudget skips exactly what's visible right now.
+  const visibleKeys = new Map<string, Set<string>>(); // `${sheetKey}|base` / `${sheetKey}|detail` → protected tile keys
+  const cache = new TileLRU(
+    BYTE_BUDGET,
+    // close() on a MACROTASK, not inline: every drawImage of a just-fetched
+    // tile runs synchronously right after its await resumes, so deferring one
+    // macrotask guarantees no draw ever sees a closed bitmap even if the
+    // insert that cached it immediately evicted it (budget saturated by
+    // protected tiles). Memory still releases within the same tick's turn.
+    (v) => { const b = v as ImageBitmap; setTimeout(() => { try { b.close(); } catch { /* already closed */ } }, 0); },
+    () => {
+      const s = new Set<string>();
+      for (const set of visibleKeys.values()) for (const k of set) s.add(k);
+      return s;
+    },
+  );
+  // One entry per tile IN FLIGHT, holding the SHARED promise every concurrent
+  // caller awaits. Sharing (rather than "already fetching → undefined") is
+  // load-bearing: during a pan, paint N requests a tile, paint N+1 supersedes
+  // paint N (live=false) and asks for the same tile — if N+1 got `undefined`
+  // back, NOBODY would ever draw that tile once it lands (N is dead, N+1
+  // skipped it, and nothing else repaints at rest), leaving a permanently
+  // blurry patch after every settle. With the shared promise, N+1 draws it.
+  const inflightReqs = new Map<string, { cancel: () => void; promise: Promise<ImageBitmap | undefined> }>();
   const levelsBySheet = new Map<string, number[]>();
   const dimsBySheet = new Map<string, { w: number; h: number }>();
   const opened = new Set<string>();
@@ -87,36 +114,50 @@ export function createTileCompositor() {
     levelsBySheet.clear();
     dimsBySheet.clear();
     readyBySheet.clear();
+    visibleKeys.clear();
   }
 
   async function getOrFetchTile(sheetKey: string, level: number, tx: number, ty: number, density: number, dark: boolean): Promise<ImageBitmap | undefined> {
     const key = modeKey(rawTileKey(sheetKey, level, tx, ty), dark);
     const cached = cache.get(key) as ImageBitmap | undefined;
     if (cached) return cached;
-    if (inflightReqs.has(key)) return undefined; // already fetching — caller will repaint when it lands
+    const myGen = generation;
+    const existing = inflightReqs.get(key);
+    if (existing) {
+      // join the in-flight fetch (see inflightReqs' comment for why joining,
+      // not skipping, is what keeps settled views sharp)
+      const bmp = await existing.promise;
+      return myGen === generation ? bmp : undefined;
+    }
     const dims = dimsBySheet.get(sheetKey);
     const levels = levelsBySheet.get(sheetKey);
     if (!dims || !levels) return undefined;
-    const myGenEarly = generation;
-    try { await readyBySheet.get(sheetKey); } catch { return undefined; } // sheet failed to open
-    if (myGenEarly !== generation) return undefined; // superseded while we waited on open
-    const { w: levelW, h: levelH } = levelDims(dims.w, dims.h, density);
-    const x = tx * TILE_SIZE, y = ty * TILE_SIZE;
-    const rect = { x, y, w: Math.min(TILE_SIZE, levelW - x), h: Math.min(TILE_SIZE, levelH - y) };
-    if (rect.w <= 0 || rect.h <= 0) return undefined;
-    const myGen = generation;
-    const { promise, cancel } = pool.requestTile({ sheetKey, scale: RENDER_SCALE * density, rect, dark });
-    inflightReqs.set(key, { cancel });
-    try {
-      const { bitmap, w, h } = await promise;
-      inflightReqs.delete(key);
-      if (myGen !== generation) { bitmap.close(); return undefined; } // superseded by resetAll
-      cache.set(key, bitmap, w * h * 4);
-      return bitmap;
-    } catch {
-      inflightReqs.delete(key);
-      return undefined;
-    }
+    // Register the entry SYNCHRONOUSLY (before any await) or two callers can
+    // both pass the `existing` check during the sheet-ready await and issue
+    // duplicate worker renders for the same tile.
+    const cancelRef: { cancel: () => void } = { cancel: () => {} };
+    const run = (async (): Promise<ImageBitmap | undefined> => {
+      try { await readyBySheet.get(sheetKey); } catch { return undefined; } // sheet failed to open
+      if (myGen !== generation) return undefined; // superseded while we waited on open
+      const { w: levelW, h: levelH } = levelDims(dims.w, dims.h, density);
+      const x = tx * TILE_SIZE, y = ty * TILE_SIZE;
+      const rect = { x, y, w: Math.min(TILE_SIZE, levelW - x), h: Math.min(TILE_SIZE, levelH - y) };
+      if (rect.w <= 0 || rect.h <= 0) return undefined;
+      const { promise, cancel } = pool.requestTile({ sheetKey, scale: RENDER_SCALE * density, rect, dark });
+      cancelRef.cancel = cancel;
+      try {
+        const { bitmap, w, h } = await promise;
+        if (myGen !== generation) { bitmap.close(); return undefined; } // superseded by resetAll
+        cache.set(key, bitmap, w * h * 4);
+        return bitmap;
+      } catch {
+        return undefined;
+      }
+    })();
+    inflightReqs.set(key, { cancel: () => cancelRef.cancel(), promise: run });
+    const settle = () => { if (inflightReqs.get(key)?.promise === run) inflightReqs.delete(key); };
+    run.then(settle, settle);
+    return run;
   }
 
   /** Whole-sheet coarse placeholder — small backing store, painted once. */
@@ -126,6 +167,8 @@ export function createTileCompositor() {
     const density = levels[level];
     const { w: lw, h: lh } = levelDims(imgW, imgH, density);
     const tiles = visibleTiles(imgW, imgH, levels, level, 0, 0, imgW, imgH);
+    // the base layer is visible for as long as the sheet is open — protect it
+    visibleKeys.set(`${sheetKey}|base`, new Set(tiles.map((t) => modeKey(rawTileKey(sheetKey, level, t.tx, t.ty), dark))));
     canvas.width = lw; canvas.height = lh;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
@@ -152,7 +195,12 @@ export function createTileCompositor() {
    *  caller) into `canvas`, sized to the region at `density`. Fires `onDone`
    *  every time a fresh tile arrival changes what's on screen, so the caller
    *  can just no-op if nothing needs repositioning. Returns a disposer that
-   *  cancels any tiles still in flight for this call. */
+   *  stops this call from PAINTING anything further — deliberately NOT a
+   *  worker-render cancel: a superseded crop's tiles usually overlap the next
+   *  crop (pans are incremental), so letting them finish warms the cache the
+   *  successor reads from, and the byte budget bounds the cost. resetAll is
+   *  the hard cancel for sheet/group changes, where in-flight tiles really
+   *  are garbage. */
   function paintDetail(
     canvas: HTMLCanvasElement, sheetKey: string, x0: number, y0: number, x1: number, y1: number,
     density: number, dark: boolean, onDone: () => void,
@@ -182,7 +230,9 @@ export function createTileCompositor() {
     }
 
     const target = visibleTiles(dims.w, dims.h, levels, level, x0, y0, x1, y1);
-    const cancels: Array<() => void> = [];
+    // protect THIS crop's tiles from eviction while they're the visible set
+    // (replaced wholesale by the next paintDetail on this sheet)
+    visibleKeys.set(`${sheetKey}|detail`, new Set(target.map((t) => modeKey(rawTileKey(sheetKey, level, t.tx, t.ty), dark))));
     Promise.all(target.map(async (t) => {
       const bmp = await getOrFetchTile(sheetKey, level, t.tx, t.ty, targetDensity, dark);
       if (!bmp || !live || myGen !== generation) return;
@@ -191,7 +241,7 @@ export function createTileCompositor() {
       onDone();
     })).catch(() => {});
 
-    return { cancel() { live = false; for (const c of cancels) c(); } };
+    return { cancel() { live = false; } };
   }
 
   function dispose() { resetAll(); pool.dispose(); }

--- a/web/src/lib/tilePool.ts
+++ b/web/src/lib/tilePool.ts
@@ -1,0 +1,103 @@
+// Main-thread client for a small pool of pdfTile.worker.ts instances (#86).
+// Mirrors voiceRecognizerClient.ts's lazy-worker-lifecycle pattern. A sheet's
+// pdf.js Document/Page state lives in exactly one worker (render tasks on the
+// same page can't overlap), chosen by hashing the sheet key across the pool —
+// so DIFFERENT panels in a sheet group land on DIFFERENT workers and render
+// in parallel, which is the whole point of a POOL rather than one worker.
+
+export interface TileRequest {
+  sheetKey: string;
+  scale: number;               // pdf.js render scale (RENDER_SCALE * density)
+  rect: { x: number; y: number; w: number; h: number }; // level px
+  dark: boolean;
+}
+
+export interface TileResult { w: number; h: number; bitmap: ImageBitmap; }
+
+type OutMsg =
+  | { type: "sheetReady"; sheetKey: string }
+  | { type: "sheetError"; sheetKey: string; message: string }
+  | { type: "tile"; reqId: number; sheetKey: string; w: number; h: number; bitmap: ImageBitmap }
+  | { type: "tileError"; reqId: number; sheetKey: string; message: string };
+
+const POOL_SIZE = Math.max(1, Math.min(3, (typeof navigator !== "undefined" ? navigator.hardwareConcurrency : 4) - 1 || 2));
+
+function hashKey(key: string): number {
+  let h = 5381;
+  for (let i = 0; i < key.length; i++) h = ((h << 5) + h + key.charCodeAt(i)) | 0;
+  return h >>> 0;
+}
+
+export function createTilePool(size = POOL_SIZE) {
+  const workers: Worker[] = [];
+  const sheetWorker = new Map<string, number>();
+  const sheetReady = new Map<string, { resolve: () => void; reject: (e: Error) => void; promise: Promise<void> }>();
+  const pending = new Map<number, { resolve: (r: TileResult) => void; reject: (e: Error) => void }>();
+  let nextReqId = 1;
+  let disposed = false;
+
+  function ensureWorker(i: number): Worker {
+    if (!workers[i]) {
+      const w = new Worker(new URL("../pdfTile.worker.ts", import.meta.url), { type: "module" });
+      w.onmessage = (e: MessageEvent<OutMsg>) => onMessage(e.data);
+      workers[i] = w;
+    }
+    return workers[i];
+  }
+
+  function onMessage(m: OutMsg) {
+    if (m.type === "sheetReady") { sheetReady.get(m.sheetKey)?.resolve(); return; }
+    if (m.type === "sheetError") { sheetReady.get(m.sheetKey)?.reject(new Error(m.message)); return; }
+    if (m.type === "tile") { pending.get(m.reqId)?.resolve({ w: m.w, h: m.h, bitmap: m.bitmap }); pending.delete(m.reqId); return; }
+    if (m.type === "tileError") { pending.get(m.reqId)?.reject(new Error(m.message)); pending.delete(m.reqId); return; }
+  }
+
+  function workerFor(sheetKey: string): { w: Worker; idx: number } {
+    let idx = sheetWorker.get(sheetKey);
+    if (idx == null) { idx = hashKey(sheetKey) % size; sheetWorker.set(sheetKey, idx); }
+    return { w: ensureWorker(idx), idx };
+  }
+
+  /** Idempotent — calling twice for the same sheetKey is a no-op after the
+   *  first. `data` is TRANSFERRED (the caller must pass a fresh copy, not a
+   *  buffer still owned by the main-thread pdf.js instance). */
+  function openSheet(sheetKey: string, pageNum: number, data: ArrayBuffer): Promise<void> {
+    if (disposed) return Promise.reject(new Error("tile pool disposed"));
+    let entry = sheetReady.get(sheetKey);
+    if (entry) return entry.promise;
+    let resolve!: () => void, reject!: (e: Error) => void;
+    const promise = new Promise<void>((res, rej) => { resolve = res; reject = rej; });
+    entry = { resolve, reject, promise };
+    sheetReady.set(sheetKey, entry);
+    const { w } = workerFor(sheetKey);
+    w.postMessage({ type: "openSheet", sheetKey, pageNum, data }, [data]);
+    return promise;
+  }
+
+  function requestTile(req: TileRequest): { promise: Promise<TileResult>; reqId: number; cancel: () => void } {
+    const reqId = nextReqId++;
+    const { w } = workerFor(req.sheetKey);
+    const promise = new Promise<TileResult>((resolve, reject) => {
+      pending.set(reqId, { resolve, reject });
+      w.postMessage({ type: "renderTile", reqId, sheetKey: req.sheetKey, scale: req.scale, rect: req.rect, dark: req.dark });
+    });
+    const cancel = () => { pending.delete(reqId); w.postMessage({ type: "cancel", reqId }); };
+    return { promise, reqId, cancel };
+  }
+
+  function closeSheet(sheetKey: string) {
+    const { w } = workerFor(sheetKey);
+    w.postMessage({ type: "closeSheet", sheetKey });
+    sheetWorker.delete(sheetKey);
+    sheetReady.delete(sheetKey);
+  }
+
+  function dispose() {
+    disposed = true;
+    for (const w of workers) w?.terminate();
+    workers.length = 0;
+    sheetWorker.clear(); sheetReady.clear(); pending.clear();
+  }
+
+  return { openSheet, requestTile, closeSheet, dispose };
+}

--- a/web/src/lib/tilePool.ts
+++ b/web/src/lib/tilePool.ts
@@ -1,10 +1,21 @@
 // Main-thread client for a small pool of pdfTile.worker.ts instances (#86).
-// Mirrors voiceRecognizerClient.ts's lazy-worker-lifecycle pattern. A sheet's
-// pdf.js Document/Page state lives in exactly one worker (render tasks on the
-// same page can't overlap), chosen by hashing the sheet key across the pool —
-// so DIFFERENT panels in a sheet group land on DIFFERENT workers and render
-// in parallel, which is the whole point of a POOL rather than one worker.
-
+// Mirrors voiceRecognizerClient.ts's lazy-worker-lifecycle pattern.
+//
+// Every open sheet is loaded into EVERY worker in the pool (broadcast, not
+// hash-pinned to one) — a pdf.js Page object can't have two renders in
+// flight at once, so the old design assigned a whole sheet to exactly ONE
+// worker to dodge that. In practice that made the "pool" pointless for the
+// common single-sheet view: every tile for every zoom/pan funneled through
+// one worker, one render at a time, while the other 1-2 workers sat idle —
+// confirmed live as the actual cause of a "takes forever, fills in as a
+// wave" complaint, not a render-speed problem so much as a concurrency-of-1
+// problem. Each worker gets its OWN independent pdf.js Document/Page (its
+// own parse of the same bytes), so tile requests can now be spread round-
+// robin across the whole pool — real N-way parallelism, N = pool size,
+// including within a single open sheet. The cost is N redundant parses of
+// the same (typically sub-few-MB) plan sheet, which is cheap next to what it
+// buys: pdf.js parse time was never the bottleneck here, per-tile RENDER
+// time was, and that's exactly what this parallelizes.
 export interface TileRequest {
   sheetKey: string;
   scale: number;               // pdf.js render scale (RENDER_SCALE * density)
@@ -22,18 +33,20 @@ type OutMsg =
 
 const POOL_SIZE = Math.max(1, Math.min(3, (typeof navigator !== "undefined" ? navigator.hardwareConcurrency : 4) - 1 || 2));
 
-function hashKey(key: string): number {
-  let h = 5381;
-  for (let i = 0; i < key.length; i++) h = ((h << 5) + h + key.charCodeAt(i)) | 0;
-  return h >>> 0;
+interface SheetOpenState {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (e: Error) => void;
+  settled: boolean;
+  readyCount: number; // workers that have reported sheetReady so far
 }
 
 export function createTilePool(size = POOL_SIZE) {
   const workers: Worker[] = [];
-  const sheetWorker = new Map<string, number>();
-  const sheetReady = new Map<string, { resolve: () => void; reject: (e: Error) => void; promise: Promise<void> }>();
-  const pending = new Map<number, { resolve: (r: TileResult) => void; reject: (e: Error) => void }>();
+  const sheetOpen = new Map<string, SheetOpenState>();
+  const pending = new Map<number, { resolve: (r: TileResult) => void; reject: (e: Error) => void; workerIdx: number }>();
   let nextReqId = 1;
+  let rrCounter = 0; // round-robins tile requests across the whole pool
   let disposed = false;
 
   function ensureWorker(i: number): Worker {
@@ -46,39 +59,49 @@ export function createTilePool(size = POOL_SIZE) {
   }
 
   function onMessage(m: OutMsg) {
-    if (m.type === "sheetReady") { sheetReady.get(m.sheetKey)?.resolve(); return; }
-    if (m.type === "sheetError") { sheetReady.get(m.sheetKey)?.reject(new Error(m.message)); return; }
+    if (m.type === "sheetReady") {
+      const st = sheetOpen.get(m.sheetKey);
+      if (!st || st.settled) return;
+      st.readyCount++;
+      if (st.readyCount >= size) { st.settled = true; st.resolve(); }
+      return;
+    }
+    if (m.type === "sheetError") {
+      const st = sheetOpen.get(m.sheetKey);
+      if (!st || st.settled) return;
+      st.settled = true; st.reject(new Error(m.message));
+      return;
+    }
     if (m.type === "tile") { pending.get(m.reqId)?.resolve({ w: m.w, h: m.h, bitmap: m.bitmap }); pending.delete(m.reqId); return; }
     if (m.type === "tileError") { pending.get(m.reqId)?.reject(new Error(m.message)); pending.delete(m.reqId); return; }
   }
 
-  function workerFor(sheetKey: string): { w: Worker; idx: number } {
-    let idx = sheetWorker.get(sheetKey);
-    if (idx == null) { idx = hashKey(sheetKey) % size; sheetWorker.set(sheetKey, idx); }
-    return { w: ensureWorker(idx), idx };
-  }
-
   /** Idempotent — calling twice for the same sheetKey is a no-op after the
-   *  first. `data` is TRANSFERRED (the caller must pass a fresh copy, not a
-   *  buffer still owned by the main-thread pdf.js instance). */
+   *  first. `data` is an ArrayBuffer this pool now OWNS: it's sliced into a
+   *  fresh transferable copy per worker (transfer detaches, so one buffer
+   *  can't be handed to N workers), so the caller's own copy is untouched
+   *  either way. Resolves once every worker has the sheet open. */
   function openSheet(sheetKey: string, pageNum: number, data: ArrayBuffer): Promise<void> {
     if (disposed) return Promise.reject(new Error("tile pool disposed"));
-    let entry = sheetReady.get(sheetKey);
-    if (entry) return entry.promise;
+    const existing = sheetOpen.get(sheetKey);
+    if (existing) return existing.promise;
     let resolve!: () => void, reject!: (e: Error) => void;
     const promise = new Promise<void>((res, rej) => { resolve = res; reject = rej; });
-    entry = { resolve, reject, promise };
-    sheetReady.set(sheetKey, entry);
-    const { w } = workerFor(sheetKey);
-    w.postMessage({ type: "openSheet", sheetKey, pageNum, data }, [data]);
+    const st: SheetOpenState = { promise, resolve, reject, settled: false, readyCount: 0 };
+    sheetOpen.set(sheetKey, st);
+    for (let i = 0; i < size; i++) {
+      const copy = data.slice(0); // independent transferable per worker
+      ensureWorker(i).postMessage({ type: "openSheet", sheetKey, pageNum, data: copy }, [copy]);
+    }
     return promise;
   }
 
   function requestTile(req: TileRequest): { promise: Promise<TileResult>; reqId: number; cancel: () => void } {
     const reqId = nextReqId++;
-    const { w } = workerFor(req.sheetKey);
+    const workerIdx = rrCounter++ % size;
+    const w = ensureWorker(workerIdx);
     const promise = new Promise<TileResult>((resolve, reject) => {
-      pending.set(reqId, { resolve, reject });
+      pending.set(reqId, { resolve, reject, workerIdx });
       w.postMessage({ type: "renderTile", reqId, sheetKey: req.sheetKey, scale: req.scale, rect: req.rect, dark: req.dark });
     });
     const cancel = () => { pending.delete(reqId); w.postMessage({ type: "cancel", reqId }); };
@@ -86,17 +109,15 @@ export function createTilePool(size = POOL_SIZE) {
   }
 
   function closeSheet(sheetKey: string) {
-    const { w } = workerFor(sheetKey);
-    w.postMessage({ type: "closeSheet", sheetKey });
-    sheetWorker.delete(sheetKey);
-    sheetReady.delete(sheetKey);
+    for (let i = 0; i < size; i++) ensureWorker(i).postMessage({ type: "closeSheet", sheetKey });
+    sheetOpen.delete(sheetKey);
   }
 
   function dispose() {
     disposed = true;
     for (const w of workers) w?.terminate();
     workers.length = 0;
-    sheetWorker.clear(); sheetReady.clear(); pending.clear();
+    sheetOpen.clear(); pending.clear();
   }
 
   return { openSheet, requestTile, closeSheet, dispose };

--- a/web/src/lib/tiles.ts
+++ b/web/src/lib/tiles.ts
@@ -1,0 +1,146 @@
+// Pure tile-pyramid math for the Takeoff Canvas (#86). No DOM, no pdf.js, no
+// React — this module answers "which tiles, at what density, cover this
+// region" and "what's evicted under this byte budget," nothing else. The
+// worker (pdfTile.worker.ts) renders tiles; the compositor (tileCompositor.js)
+// paints them; both import this for the shared vocabulary.
+//
+// A sheet's LOGICAL pixel space (imgW × imgH) is fixed forever at page-points
+// × RENDER_SCALE (see sheets.ts) — the same space verts_norm, the snap grid,
+// and vector-geometry extraction already normalize against. It is NOT a real
+// backing store, so it costs nothing to leave it exactly as-is even for an
+// oversized ingested-image page; only tiles (bounded to TILE_SIZE²) are ever
+// actually rastered. That single fixed space is what lets factorFor collapse
+// to a constant 1 (panelGeometry.js) instead of tracking a per-sheet render
+// scale.
+//
+// A "density" is device px per logical-space px — 1.0 means "as sharp as the
+// PDF vectors at the RENDER_SCALE baseline," matching the quantity the old
+// DETAIL_ENGAGE check compared against (t.scale × dpr).
+
+export const TILE_SIZE = 512;
+// Coarsest level's long edge, in device px — small enough that a whole-sheet
+// placeholder is one to a few tiles, cheap to keep resident forever.
+export const MIN_LEVEL_PX = 768;
+// Reuses the old QUALITY_CEILING's intent (≈576 px/in-equivalent deep zoom)
+// as the top of the pyramid, relative to the RENDER_SCALE=2 logical baseline.
+export const MAX_DENSITY = 8;
+
+/** Density multiplier for each level, ascending, level index = array index.
+ *  Always includes 1.0 (the native baseline) as a level boundary so pickLevel
+ *  never has to interpolate across the DETAIL_ENGAGE-equivalent seam. */
+export function buildLevels(imgW: number, imgH: number): number[] {
+  const long = Math.max(1, imgW, imgH);
+  let d = Math.pow(2, Math.ceil(Math.log2(MIN_LEVEL_PX / long)));
+  d = Math.min(1, Math.max(Math.pow(2, -6), d)); // never start denser than native, floor at 1/64
+  const levels: number[] = [];
+  while (d < 1) { levels.push(d); d *= 2; }
+  d = 1;
+  while (d <= MAX_DENSITY) { levels.push(d); d *= 2; }
+  return levels;
+}
+
+/** Index of the lowest-index level whose density already covers
+ *  `requiredDensity` (never blurrier than asked); clamps to the top level
+ *  once past MAX_DENSITY rather than growing the pyramid unboundedly. */
+export function pickLevel(levels: number[], requiredDensity: number): number {
+  for (let i = 0; i < levels.length; i++) if (levels[i] >= requiredDensity) return i;
+  return levels.length - 1;
+}
+
+export function levelDims(imgW: number, imgH: number, density: number) {
+  return { w: Math.max(1, Math.ceil(imgW * density)), h: Math.max(1, Math.ceil(imgH * density)) };
+}
+
+export function tileGrid(imgW: number, imgH: number, density: number) {
+  const { w, h } = levelDims(imgW, imgH, density);
+  return { cols: Math.ceil(w / TILE_SIZE), rows: Math.ceil(h / TILE_SIZE), w, h };
+}
+
+export function tileKey(sheetKey: string, level: number, tx: number, ty: number) {
+  return `${sheetKey}:${level}:${tx}:${ty}`;
+}
+
+/** Tile rect in LEVEL px (edge tiles are smaller than TILE_SIZE). */
+export function tileRect(level: number, tx: number, ty: number, levelW: number, levelH: number) {
+  const x = tx * TILE_SIZE, y = ty * TILE_SIZE;
+  return { x, y, w: Math.min(TILE_SIZE, levelW - x), h: Math.min(TILE_SIZE, levelH - y) };
+}
+
+export interface VisibleTile { level: number; tx: number; ty: number; x: number; y: number; w: number; h: number; }
+
+/** Every tile at `level` intersecting the region [x0,y0,x1,y1) given in the
+ *  sheet's LOGICAL (imgW×imgH) px space. Returns rects in level px. */
+export function visibleTiles(
+  imgW: number, imgH: number, levels: number[], level: number,
+  x0: number, y0: number, x1: number, y1: number,
+): VisibleTile[] {
+  const density = levels[level];
+  const { w: levelW, h: levelH } = levelDims(imgW, imgH, density);
+  const lx0 = Math.max(0, Math.floor(x0 * density));
+  const ly0 = Math.max(0, Math.floor(y0 * density));
+  const lx1 = Math.min(levelW, Math.ceil(x1 * density));
+  const ly1 = Math.min(levelH, Math.ceil(y1 * density));
+  if (lx1 <= lx0 || ly1 <= ly0) return [];
+  const txMin = Math.floor(lx0 / TILE_SIZE), txMax = Math.floor((lx1 - 1) / TILE_SIZE);
+  const tyMin = Math.floor(ly0 / TILE_SIZE), tyMax = Math.floor((ly1 - 1) / TILE_SIZE);
+  const out: VisibleTile[] = [];
+  for (let ty = tyMin; ty <= tyMax; ty++) {
+    for (let tx = txMin; tx <= txMax; tx++) {
+      const r = tileRect(level, tx, ty, levelW, levelH);
+      out.push({ level, tx, ty, ...r });
+    }
+  }
+  return out;
+}
+
+/** device px per logical px on screen right now — the same quantity the old
+ *  detail view compared against DETAIL_ENGAGE. */
+export const requiredDensity = (stageScale: number, dpr: number) => stageScale * dpr;
+
+interface Entry { bytes: number; value: unknown; }
+
+/** LRU keyed by tile key, evicted by a total-byte budget. `protect` (the
+ *  currently-visible set, passed at evict time) is never evicted even if
+ *  least-recently-used — a settle-then-immediately-re-fetch loop would
+ *  otherwise thrash the very tiles on screen. */
+export class TileLRU {
+  private map = new Map<string, Entry>();
+  private total = 0;
+  constructor(public maxBytes: number) {}
+
+  get size() { return this.total; }
+  has(key: string) { return this.map.has(key); }
+
+  get(key: string): unknown {
+    const e = this.map.get(key);
+    if (!e) return undefined;
+    this.map.delete(key); this.map.set(key, e); // touch → most-recently-used
+    return e.value;
+  }
+
+  set(key: string, value: unknown, bytes: number) {
+    const prev = this.map.get(key);
+    if (prev) this.total -= prev.bytes;
+    this.map.set(key, { value, bytes });
+    this.total += bytes;
+    this.evictToBudget();
+  }
+
+  delete(key: string) {
+    const e = this.map.get(key);
+    if (!e) return;
+    this.total -= e.bytes;
+    this.map.delete(key);
+  }
+
+  evictToBudget(protect?: Set<string>) {
+    if (this.total <= this.maxBytes) return;
+    for (const key of this.map.keys()) {
+      if (this.total <= this.maxBytes) break;
+      if (protect?.has(key)) continue;
+      this.delete(key);
+    }
+  }
+
+  clear() { this.map.clear(); this.total = 0; }
+}

--- a/web/src/lib/tiles.ts
+++ b/web/src/lib/tiles.ts
@@ -99,14 +99,22 @@ export const requiredDensity = (stageScale: number, dpr: number) => stageScale *
 
 interface Entry { bytes: number; value: unknown; }
 
-/** LRU keyed by tile key, evicted by a total-byte budget. `protect` (the
- *  currently-visible set, passed at evict time) is never evicted even if
- *  least-recently-used — a settle-then-immediately-re-fetch loop would
- *  otherwise thrash the very tiles on screen. */
+/** LRU keyed by tile key, evicted by a total-byte budget. Protected keys (the
+ *  currently-visible set, from `protect` or the constructor's provider) are
+ *  never evicted even if least-recently-used — a settle-then-immediately-
+ *  re-fetch loop would otherwise thrash the very tiles on screen. `onEvict`
+ *  fires for every value leaving the cache (evict / replace / clear) so the
+ *  owner can release non-GC-tracked backing memory — an ImageBitmap holds its
+ *  pixels until close(), so without this the byte budget only bounds what the
+ *  cache COUNTS, not what the process actually holds. */
 export class TileLRU {
   private map = new Map<string, Entry>();
   private total = 0;
-  constructor(public maxBytes: number) {}
+  constructor(
+    public maxBytes: number,
+    private onEvict?: (value: unknown) => void,
+    private protectProvider?: () => Set<string> | undefined,
+  ) {}
 
   get size() { return this.total; }
   has(key: string) { return this.map.has(key); }
@@ -120,7 +128,7 @@ export class TileLRU {
 
   set(key: string, value: unknown, bytes: number) {
     const prev = this.map.get(key);
-    if (prev) this.total -= prev.bytes;
+    if (prev) { this.total -= prev.bytes; if (prev.value !== value) this.onEvict?.(prev.value); }
     this.map.set(key, { value, bytes });
     this.total += bytes;
     this.evictToBudget();
@@ -131,16 +139,25 @@ export class TileLRU {
     if (!e) return;
     this.total -= e.bytes;
     this.map.delete(key);
+    this.onEvict?.(e.value);
   }
 
+  /** Explicit `protect` wins; otherwise the constructor's provider is asked.
+   *  If the protected set alone exceeds the budget, the cache stays over
+   *  budget rather than evicting on-screen tiles — deliberate. */
   evictToBudget(protect?: Set<string>) {
     if (this.total <= this.maxBytes) return;
+    const shielded = protect ?? this.protectProvider?.();
     for (const key of this.map.keys()) {
       if (this.total <= this.maxBytes) break;
-      if (protect?.has(key)) continue;
+      if (shielded?.has(key)) continue;
       this.delete(key);
     }
   }
 
-  clear() { this.map.clear(); this.total = 0; }
+  clear() {
+    if (this.onEvict) for (const e of this.map.values()) this.onEvict(e.value);
+    this.map.clear();
+    this.total = 0;
+  }
 }

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -1333,12 +1333,18 @@ export default function TakeoffCanvas() {
   }, []);
 
   // the doc cache holds whole PDFs in the worker — tear it down when the
-  // project view unmounts or the project changes. (The tile compositor has
-  // its own dedicated create/dispose effect above, for StrictMode reasons —
-  // see its comment.)
+  // project view unmounts or the project changes. The tile compositor (its
+  // worker pool + up to BYTE_BUDGET of ImageBitmaps) goes down with it:
+  // dispose-and-NULL pairs with getCompositor's lazy ??= creation, which is
+  // what makes this safe under StrictMode's extra mount/unmount cycles — a
+  // post-dispose render just mints a fresh compositor instead of hitting a
+  // permanently-dead pool (the failure mode an eager create/dispose effect
+  // pair was observed to cause; see getCompositor's comment).
   useEffect(() => () => {
     for (const [, t] of pdfDocsRef.current) { t.then((task) => { try { task.destroy(); } catch { /* already gone */ } }).catch(() => {}); }
     pdfDocsRef.current.clear();
+    try { compositorRef.current?.dispose(); } catch { /* half-built pool */ }
+    compositorRef.current = null;
   }, []);
 
   // provenance deep-jump: if the URL named a sheet (?sheet=A003), jump once its page is known

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -72,14 +72,23 @@ import { projectHomeFolderId } from "../lib/projectHome.js";
 import { getTheme, toggleTheme, onThemeChange } from "../lib/theme.js";
 // Pure data constants (render/zoom budgets, snap tuning, tool descriptors,
 // flooring starter conditions) live in lib/canvasConstants.js; the pure
-// module-scope helpers (autoRenderScale, invertCanvasPixels, uid, clamp,
-// isDangerMsg, instantiateTemplate, seedConditions) in lib/canvasUtil.js.
+// module-scope helpers (uid, clamp, isDangerMsg, instantiateTemplate,
+// seedConditions) in lib/canvasUtil.js. autoRenderScale/invertCanvasPixels
+// retired from this file's imports — #86 moved painting into the tile
+// worker pool (lib/tileCompositor.ts); both still exist as pure exports
+// (renderBudget.test.ts covers autoRenderScale) pending a follow-up cleanup
+// pass once the tile path has proven itself in production.
 import {
-  PANEL_GAP, MAX_CANVAS_DIM, MAX_CANVAS_AREA,
-  DETAIL_ENGAGE, DETAIL_MARGIN, SYNC_MS, GESTURE_MS, DETAIL_STALL_MS, SNAP_CELL,
+  PANEL_GAP, DETAIL_ENGAGE, DETAIL_MARGIN, MAX_CANVAS_DIM, MAX_CANVAS_AREA, SYNC_MS, GESTURE_MS, SNAP_CELL,
   MEASURE_TOOLS, CUT_TOOLS, MARKUP_TOOLS, MARKUP_IDS, HL_INKS, HL_SIZES,
 } from "../lib/canvasConstants.js";
-import { autoRenderScale, invertCanvasPixels, uid, clamp, isDangerMsg, instantiateTemplate, seedConditions } from "../lib/canvasUtil.js";
+import { uid, clamp, isDangerMsg, instantiateTemplate, seedConditions } from "../lib/canvasUtil.js";
+// Tile-pyramid rendering (#86) — pure math in lib/tiles.ts (tested), worker
+// pool in lib/tilePool.ts, DOM/Worker orchestration glue here via one
+// long-lived compositor instance. Replaces the old single-raster base +
+// threshold-gated detail-overlay effects below.
+import { createTileCompositor } from "../lib/tileCompositor";
+import { requiredDensity as tileRequiredDensity } from "../lib/tiles";
 // Shape provenance policy now lives in ONE place: lib/shapeCommands.js. Every
 // meaningful mutation of `shapes` (create / reshape / reassign / relabel /
 // delete) is a COMMAND applied through dispatchShape below — the chokepoint
@@ -263,9 +272,6 @@ export default function TakeoffCanvas() {
   // async render chains
   const canvasInvertedRef = useRef(new Map());
   const darkModeRef = useRef(darkMode);
-  const [hiResKeys, setHiResKeys] = useState(() => {        // per-sheet hi-res raster — per user (localStorage)
-    try { return JSON.parse(localStorage.getItem("opentakeoff_hires") || "[]"); } catch { return []; }
-  });
   const [calib, setCalib] = useState([]);
   const [pendingLen, setPendingLen] = useState("");
   // Display unit system (ft/m toggle beside the scale picker) — DISPLAY LAYER
@@ -437,14 +443,25 @@ export default function TakeoffCanvas() {
 
   const containerRef = useRef(null);
   const stageRef = useRef(null);
-  const panelCanvasRefs = useRef(new Map()); // sheetKey → <canvas>
-  const pageObjsRef = useRef(new Map());     // sheetKey → pdf.js page object (kept for on-demand detail-view re-render)
-  const renderScalesRef = useRef(new Map()); // sheetKey → base raster pdf scale (detail view renders at a multiple of it)
-  const detailCanvasRef = useRef(null);      // single high-res viewport detail canvas (positioned imperatively)
-  const detailTaskRef = useRef(null);        // in-flight detail render task (cancel stale on re-zoom)
-  const detailBackRef = useRef(null);        // offscreen back buffer — the visible crop is never wiped mid-render
-  const detailKeyRef = useRef("");           // last requested crop — identical re-requests are dropped (sync churn fires the effect several times per settle)
-  const detailWatchdogRef = useRef(0);       // recovers a render stuck by a backgrounded/throttled tab (see DETAIL_STALL_MS)
+  const panelCanvasRefs = useRef(new Map()); // sheetKey → <canvas> (base layer — small backing store, coarse pyramid placeholder)
+  const pageObjsRef = useRef(new Map());     // sheetKey → pdf.js page object (getOperatorList/getTextContent only — painting moved to the tile worker pool)
+  const renderScalesRef = useRef(new Map()); // sheetKey → RENDER_SCALE, always (see factorFor comment above) — kept so the ~20 factorFor/uppFor call sites are untouched
+  // Tile-pyramid compositor (#86) — one instance owning the worker pool +
+  // tile LRU cache (see lib/tileCompositor.ts). Lazily created on first
+  // real use (getCompositor(), mirroring voiceRecognizerClient.ts's "nothing
+  // loads until first use" worker pattern), NOT eagerly in a mount effect —
+  // an eager create+dispose pair fought React 18 StrictMode's dev-mode
+  // double-invoke in a way pure effect-ordering couldn't reliably fix (this
+  // component observably mounts more than the textbook once-cleanup-once
+  // cycle on first load — confirmed live via instrumented logging). Nulling
+  // the ref on dispose (below) is what makes this resilient to ANY number of
+  // create/dispose cycles, not just exactly one: the next real use just
+  // recreates it.
+  const compositorRef = useRef(null);
+  const getCompositor = () => (compositorRef.current ??= createTileCompositor());
+  const detailCanvasRefs = useRef(new Map()); // sheetKey → <canvas> (one detail/viewport layer PER PANEL now, not one shared global — every group-mode panel gets independent sharpness)
+  const detailKeysRef = useRef(new Map());    // sheetKey → last requested crop key (per-panel render-key dedup, generalizing the old single detailKeyRef)
+  const detailCancelsRef = useRef(new Map()); // sheetKey → disposer for the in-flight paintDetail call
   const renderTasksRef = useRef(new Map());  // sheetKey → pdf.js RenderTask
   const pdfDocsRef = useRef(new Map());      // file name → pdf.js loading task (doc cache)
   const renderSeqRef = useRef(0);            // monotonic token — stale render chains bail out
@@ -667,21 +684,17 @@ export default function TakeoffCanvas() {
   // Scale semantics (why geometry divides by factorFor and calibration
   // multiplies back to baseline) are documented on the pure functions in
   // lib/panelGeometry.js; these wrappers bind the live scales/renderScalesRef.
-  const hiResOn = (key) => hiResKeys.includes(key);
+  // factorFor is now a constant 1 (renderScalesRef is always pinned to
+  // RENDER_SCALE — see the tile-pyramid render effect below): the logical
+  // img space no longer varies with what's actually rastered, since nothing
+  // is rastered at panel scope anymore, only bounded tiles. Signatures are
+  // unchanged so none of factorFor/uppFor's ~20 call sites needed to move.
   const factorFor = (key) => panelGeom.factorFor(renderScalesRef.current, key);
   const uppFor = (key) => panelGeom.uppFor(scales, renderScalesRef.current, key);
   // keep the agent's capability closures reading LIVE state across their awaits
   useEffect(() => {
     agentStateRef.current = { panels, scales, scaleSources, detectedScales, conditions, status };
   });
-  const toggleHiRes = () => {
-    const k = focusPanel.key;
-    setHiResKeys((arr) => {
-      const next = arr.includes(k) ? arr.filter((x) => x !== k) : [...arr, k];
-      try { localStorage.setItem("opentakeoff_hires", JSON.stringify(next)); } catch { /* private mode */ }
-      return next;
-    });
-  };
 
   // ── transform: tfRef is source of truth; write straight to the DOM ─────────
   const applyTf = useCallback(() => {
@@ -703,13 +716,18 @@ export default function TakeoffCanvas() {
     syncRaf.current = setTimeout(() => {
       syncRaf.current = 0; lastSyncRef.current = performance.now();
       const t = tfRef.current;
+      // Tile repositioning (#86) is UNCONDITIONAL — it doesn't wait on the tf
+      // state mirror below, or a pure low-zoom pan would never resync its
+      // crop (see syncTilePanelsRef's comment for why this had to split out).
+      syncTilePanelsRef.current();
       // Nothing in the render tree reads tf.x/tf.y — position lives entirely in
-      // the CSS transform above. A pure pan (scale unchanged) only needs this
-      // mirror when the detail view is engaged (it re-crops from tf on every
-      // tick); below DETAIL_ENGAGE it's hidden and reads nothing. Skipping the
-      // state write there avoids re-rendering the whole shape/markup overlay
+      // the CSS transform above. A pure pan (scale unchanged) below this
+      // density threshold doesn't need the React mirror at all: skipping the
+      // state write avoids re-rendering the whole shape/markup overlay
       // (thousands of SVG els at overview zoom) on every ~90ms pan tick — that
       // wasted reconciliation was the zoomed-out pan flicker + toolbar lag.
+      // (DETAIL_ENGAGE is reused here only as a convenient density threshold —
+      // this gate is about SVG reconciliation cost, unrelated to raster tiles.)
       if (t.scale === lastSyncedScaleRef.current && t.scale * (window.devicePixelRatio || 1) <= DETAIL_ENGAGE) return;
       lastSyncedScaleRef.current = t.scale;
       setTf({ ...t });
@@ -1084,28 +1102,29 @@ export default function TakeoffCanvas() {
     return t.then((task) => task.promise);
   }, []);
 
-  // dark toggle: flip the pixels of every rendered canvas in place — instant,
-  // no pdf.js re-render. Canvases without a map entry haven't rendered yet
-  // (their chain applies the current mode when it finishes) — skip those, or
-  // difference-fill would paint transparent backing stores white.
+  // dark toggle: repaint the base layer of every already-loaded panel at the
+  // new mode (the detail effect below also depends on darkMode, so it
+  // repaints too). Tiles are cached PER MODE (tileCompositor.ts), so a
+  // toggle-back is instant once both variants have been seen once.
   useEffect(() => {
     darkModeRef.current = darkMode;
-    const flip = (cv) => {
-      if (cv && canvasInvertedRef.current.has(cv) && canvasInvertedRef.current.get(cv) !== darkMode) {
-        invertCanvasPixels(cv);
-        canvasInvertedRef.current.set(cv, darkMode);
-      }
-    };
-    for (const [, cv] of panelCanvasRefs.current) flip(cv);
-    flip(detailCanvasRef.current);
+    if (status !== "ready") return;
+    for (const p of panels) {
+      const cv = panelCanvasRefs.current.get(p.key);
+      if (cv && p.img?.w) getCompositor().paintBase(cv, p.key, p.img.w, p.img.h, darkMode);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [darkMode]);
 
   // ── render the sheet group (a single sheet is a group of one) ──────────────
-  // Two phases: (A) resolve every panel's dimensions — no raster — so the row
-  // layout is final before any pixel paints, then (B) raster sequentially left
-  // to right. A monotonic token is checked after EVERY await so a stale chain
-  // can never paint, resize, or cancel a newer chain's work (the old code had
-  // that race between document-load and render).
+  // Two phases: (A) resolve every panel's LOGICAL dimensions — page-points ×
+  // RENDER_SCALE, fixed forever, never rastered directly (see tiles.ts's
+  // header comment on why this makes factorFor collapse to a constant) — so
+  // the row layout is final before any pixel paints, then (B) hand each sheet
+  // to the tile compositor, which paints a small bounded coarse placeholder
+  // (the base layer) and opens the sheet in the worker pool for on-demand
+  // tile rendering. A monotonic token is checked after EVERY await so a stale
+  // chain can never paint, resize, or cancel a newer chain's work.
   useEffect(() => {
     if (!active) return;
     const seq = ++renderSeqRef.current;
@@ -1122,10 +1141,13 @@ export default function TakeoffCanvas() {
     canvasInvertedRef.current.clear();
     pageObjsRef.current.clear();
     renderScalesRef.current.clear();
-    try { detailTaskRef.current?.cancel(); } catch { /* done */ }
-    if (detailCanvasRef.current) detailCanvasRef.current.style.display = "none";
+    getCompositor().resetAll();
+    for (const [, c] of detailCancelsRef.current) { try { c.cancel(); } catch { /* done */ } }
+    detailCancelsRef.current.clear();
+    detailKeysRef.current.clear();
+    for (const [, cv] of detailCanvasRefs.current) cv.style.display = "none";
     (async () => {
-      // phase A — dimensions for every panel
+      // phase A — logical dimensions for every panel
       const metas = [];
       for (const key of groupKeys) {
         const { file, page: pn } = parseSheetKey(key);
@@ -1133,39 +1155,29 @@ export default function TakeoffCanvas() {
         if (file === active) setPageCount(pdf.numPages || 1);
         const pageNum = Math.min(Math.max(1, pn), pdf.numPages || 1);
         const pageObj = await pdf.getPage(pageNum); if (stale()) return;
-        const base = pageObj.getViewport({ scale: 1 });   // page size in PDF points
-        // base raster obeys the same budget cap: for oversized pages (image ingest
-        // mints 1px=1pt pages) autoRenderScale lands below RENDER_SCALE and wins
-        const auto = autoRenderScale(base.width, base.height);
-        const rs = hiResKeys.includes(key) ? auto : Math.min(RENDER_SCALE, auto);
-        const viewport = pageObj.getViewport({ scale: rs });
-        pageObjsRef.current.set(key, pageObj);     // kept for on-demand detail-view re-render
-        renderScalesRef.current.set(key, rs);      // base raster scale — detail view renders at a multiple of it
+        const viewport = pageObj.getViewport({ scale: RENDER_SCALE });
+        pageObjsRef.current.set(key, pageObj);     // kept for getOperatorList/getTextContent and the independent one-off render paths (raster-mask, agent vision, schedule marquee) — unrelated to painting, still main-thread
+        renderScalesRef.current.set(key, RENDER_SCALE);
         metas.push({ key, file, pageNum, pageObj, viewport, w: Math.ceil(viewport.width), h: Math.ceil(viewport.height) });
       }
       setPanelImgs(Object.fromEntries(metas.map((m) => [m.key, { w: m.w, h: m.h }])));
       let rw = 0, rh = 0;
       for (const m of metas) { rw += (rw ? PANEL_GAP : 0) + m.w; rh = Math.max(rh, m.h); }
       fitToView(rw, rh);
-      // phase B — raster left to right (the canvases mount when panelImgs commits;
-      // give React a frame or two for the refs of newly added panels)
-      for (const m of metas) {
+      // phase B — open each sheet in the worker pool + paint its coarse base
+      // layer. Sheets are independent pdf.js docs in the pool now (not one
+      // shared canvas context), so there's no reason to serialize them the
+      // way the old left-to-right raster loop had to.
+      await Promise.all(metas.map(async (m) => {
+        getCompositor().openSheet(m.key, m.pageNum, store.loadPdfData(m.file), m.w, m.h);
         let canvas = panelCanvasRefs.current.get(m.key);
         for (let t = 0; !canvas && t < 10; t++) {
           await new Promise((r) => requestAnimationFrame(r)); if (stale()) return;
           canvas = panelCanvasRefs.current.get(m.key);
         }
-        if (!canvas) continue;
-        canvas.width = m.w; canvas.height = m.h;
-        // dark: pdf.js paints light pixels progressively — keep the canvas hidden
-        // and reveal it already-inverted, or every render flashes white-on-dark
-        canvas.style.visibility = darkModeRef.current ? "hidden" : "";
-        const rt = m.pageObj.render({ canvasContext: canvas.getContext("2d"), viewport: m.viewport });
-        renderTasksRef.current.set(m.key, rt);
-        await rt.promise; if (stale()) return;
-        if (darkModeRef.current) invertCanvasPixels(canvas);   // negative view baked into pixels
-        canvasInvertedRef.current.set(canvas, !!darkModeRef.current);
-        canvas.style.visibility = "";
+        if (!canvas || stale()) return;
+        await getCompositor().paintBase(canvas, m.key, m.w, m.h, darkModeRef.current);
+        if (stale()) return;
         // snap-to-vector index per panel (best-effort; off until the user enables it)
         m.pageObj.getOperatorList().then((ol) => {
           if (stale()) return;
@@ -1193,7 +1205,8 @@ export default function TakeoffCanvas() {
           const det = detectScale(tc, m.viewport);
           if (det) setDetectedScales((d) => (d[m.key]?.label === det.label ? d : { ...d, [m.key]: det }));
         }).catch(() => {});
-      }
+      }));
+      if (stale()) return;
       setStatus("ready");
       // title-block labels — current page now, then once per file scan the rest so
       // the pager + pinned tabs + provenance deep-jump can show real sheet numbers
@@ -1237,120 +1250,92 @@ export default function TakeoffCanvas() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return () => { renderSeqRef.current++; for (const [, rt] of renderTasksRef.current) { try { rt.cancel(); } catch { /* done */ } } };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [groupSig, hiResKeys.join(" ")]);
+  }, [groupSig]);
 
-  // ── detail view: re-render the visible region at the current zoom ───────────
-  // The base panel bitmap is the fast first paint and the zoomed-out view. Once
-  // zoomed past DETAIL_ENGAGE we overlay a crop of JUST what's on screen (+margin),
-  // rendered from the PDF vectors at the current zoom, so linework stays razor-sharp
-  // with no giant full-sheet bitmap. `tf` only updates after the ~80ms pan/zoom settle
-  // (scheduleSync), so this is naturally debounced. Pixels only — markup is an SVG
-  // sibling ABOVE this canvas, and quantities never touch render pixels: both untouched.
+  // ── detail view: composite the visible region + margin from cached tiles ──
+  // Generalizes the old single-detail-canvas effect to EVERY panel (group
+  // mode previously only ever sharpened the last-focused one — see the #86
+  // research note) and drops the DETAIL_ENGAGE threshold entirely: tiles are
+  // the only raster path now, active at every zoom level, not a sharpening
+  // overlay on top of an already-acceptable base. Pixels only — markup is an
+  // SVG sibling ABOVE these canvases, and quantities never touch render
+  // pixels: both untouched.
+  //
+  // This is a REF-CALLED FUNCTION, not a plain tf-keyed effect: scheduleSync
+  // (below) intentionally skips mirroring tfRef into the `tf` REACT STATE for
+  // a pure pan below the old DETAIL_ENGAGE threshold (avoids a full SVG-
+  // overlay reconciliation storm on a zoomed-out pan — see its comment). That
+  // optimization predates tiles being always-active; if this logic only ran
+  // off `tf` state, a low-zoom pan would never reposition the visible-region
+  // crop. So scheduleSync calls syncTilePanelsRef.current() on EVERY tick,
+  // state-mirror-skip or not, and this effect is just the "also run it after
+  // a structural render" path (load, dark toggle, group change, panel resize).
+  const syncTilePanelsRef = useRef(() => {});
   useEffect(() => {
-    const cv = detailCanvasRef.current, cont = containerRef.current, fp = focusPanel;
-    const hide = () => { if (cv) cv.style.display = "none"; detailKeyRef.current = ""; };
-    if (!cv || !cont || status !== "ready" || !fp || !fp.img.w) return hide();
-    const t = tfRef.current;
-    if (window.__OT_DETAIL_DEBUG) console.log("[detail] tick " + JSON.stringify({ scale: +t.scale.toFixed(2), dpr: window.devicePixelRatio, pan: !!panRef.current, hold: +(gestureUntilRef.current - performance.now()).toFixed(0) }));
-    if (t.scale * (window.devicePixelRatio || 1) <= DETAIL_ENGAGE) return hide();
-    // Mid-gesture bail: `cv.width = bw` below WIPES the crop and reallocs tens of MB —
-    // doing that on every ~90ms sync while pinching/panning would flash the region
-    // blank and storm pdf.js with cancelled renders. The previous crop lives in stage
-    // space, so leaving it painted keeps it correctly anchored while the gesture runs;
-    // scheduleSync self-polls so the settle render is guaranteed once the window expires.
-    if (panRef.current || performance.now() < gestureUntilRef.current) { scheduleSync(); return; }
-    const pageObj = pageObjsRef.current.get(fp.key), rs = renderScalesRef.current.get(fp.key);
-    if (!pageObj || !rs) return hide();
+    syncTilePanelsRef.current = () => {
+      const cont = containerRef.current;
+      if (!cont || status !== "ready") return;
+      const t = tfRef.current;
+      // Mid-gesture bail: resizing a detail canvas mid-pinch would flash the
+      // region blank and storm the worker pool with cancelled renders. The
+      // previous crop stays correctly anchored in stage space (it rides the
+      // same CSS transform everything else does), so leaving it painted is
+      // free; self-poll so the settle repaint is guaranteed even if no further
+      // input event arrives before the gesture window expires.
+      if (panRef.current || performance.now() < gestureUntilRef.current) { scheduleSync(); return; }
+      const r = cont.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      const density = tileRequiredDensity(t.scale, dpr);
+      for (const p of panels) {
+        const cv = detailCanvasRefs.current.get(p.key);
+        if (!cv || !p.img?.w) continue;
+        const hide = () => { cv.style.display = "none"; detailKeysRef.current.delete(p.key); };
+        // visible region of THIS panel, in image px (stage space minus xOffset)
+        let x0 = Math.max((-t.x) / t.scale, p.xOffset) - p.xOffset;
+        let y0 = Math.max((-t.y) / t.scale, 0);
+        let x1 = Math.min((r.width - t.x) / t.scale, p.xOffset + p.img.w) - p.xOffset;
+        let y1 = Math.min((r.height - t.y) / t.scale, p.img.h);
+        if (x1 <= x0 || y1 <= y0) { hide(); continue; }         // panel off-screen
+        const mw = (x1 - x0) * DETAIL_MARGIN, mh = (y1 - y0) * DETAIL_MARGIN;
+        x0 = Math.max(0, x0 - mw); y0 = Math.max(0, y0 - mh);
+        x1 = Math.min(p.img.w, x1 + mw); y1 = Math.min(p.img.h, y1 + mh);
+        // one composite per distinct crop — the sync loop re-fires this several
+        // times around a settle with identical inputs
+        const renderKey = `${p.key}|${x0.toFixed(1)},${y0.toFixed(1)}|${x1.toFixed(1)},${y1.toFixed(1)}|${density.toFixed(2)}|${darkModeRef.current ? 1 : 0}`;
+        if (renderKey === detailKeysRef.current.get(p.key)) continue;
+        detailKeysRef.current.set(p.key, renderKey);
+        try { detailCancelsRef.current.get(p.key)?.cancel(); } catch { /* done */ }
+        cv.style.left = `${p.xOffset + x0}px`; cv.style.top = `${y0}px`;
+        cv.style.width = `${x1 - x0}px`; cv.style.height = `${y1 - y0}px`;
+        cv.style.display = "block";
+        const cancel = getCompositor().paintDetail(cv, p.key, x0, y0, x1, y1, density, darkModeRef.current, () => {});
+        detailCancelsRef.current.set(p.key, cancel);
+      }
+    };
+  });
+  const [repaintTick, setRepaintTick] = useState(0);
+  // panelW/takeoffsOpen: docking or resizing the Takeoffs panel changes the
+  // container rect without a transform change. repaintTick: bumped by the
+  // visibilitychange recovery below.
+  useEffect(() => { syncTilePanelsRef.current(); }, [tf, groupSig, status, panelW, takeoffsOpen, darkMode, repaintTick]);
 
-    // visible region of THIS panel, in image px (stage space minus the panel's xOffset)
-    const r = cont.getBoundingClientRect();
-    let x0 = Math.max((-t.x) / t.scale, fp.xOffset) - fp.xOffset;
-    let y0 = Math.max((-t.y) / t.scale, 0);
-    let x1 = Math.min((r.width - t.x) / t.scale, fp.xOffset + fp.img.w) - fp.xOffset;
-    let y1 = Math.min((r.height - t.y) / t.scale, fp.img.h);
-    if (x1 <= x0 || y1 <= y0) return hide();           // panel off-screen
-    const mw = (x1 - x0) * DETAIL_MARGIN, mh = (y1 - y0) * DETAIL_MARGIN;
-    x0 = Math.max(0, x0 - mw); y0 = Math.max(0, y0 - mh);
-    x1 = Math.min(fp.img.w, x1 + mw); y1 = Math.min(fp.img.h, y1 + mh);
-    const regW = x1 - x0, regH = y1 - y0;
-
-    // density: enough backing px that the stage's CSS scale (×t.scale) isn't upscaling.
-    // Capped by canvas limits, but the region is ~viewport-sized so the cap ~never binds.
-    const dpr = window.devicePixelRatio || 1;
-    let factor = Math.min(t.scale * dpr, MAX_CANVAS_DIM / regW, MAX_CANVAS_DIM / regH, Math.sqrt(MAX_CANVAS_AREA / (regW * regH)));
-    factor = Math.max(1, factor);
-    const bw = Math.max(1, Math.round(regW * factor)), bh = Math.max(1, Math.round(regH * factor));
-
-    // pdf scale yielding factor× the base raster density; shift the region's top-left to (0,0)
-    const vp = pageObj.getViewport({ scale: rs * factor });
-    // Double-buffer: render into an offscreen canvas and swap AFTER the pixels
-    // exist. Writing cv.width here would clear the visible crop synchronously
-    // while pdf.js paints the replacement async — a crisp→blank→crisp blink on
-    // every pan/zoom settle (worse the deeper the zoom, since renders run longer).
-    // The old crop is still correctly anchored in stage space, so it stays up
-    // until the swap; the back store is released right after (width = 0).
-    // one render per distinct crop — the sync loop re-fires this effect several
-    // times around a settle with identical inputs, and each redundant pass is a
-    // full-viewport pdf.js render (in dark mode plus a full-canvas inversion)
-    const renderKey = `${fp.key}|${x0.toFixed(1)},${y0.toFixed(1)}|${bw}x${bh}`;
-    if (renderKey === detailKeyRef.current) return;
-    detailKeyRef.current = renderKey;
-    const back = detailBackRef.current || (detailBackRef.current = document.createElement("canvas"));
-    back.width = bw; back.height = bh;
-    try { detailTaskRef.current?.cancel(); } catch { /* done */ }
-    clearTimeout(detailWatchdogRef.current);
-    const rt = pageObj.render({ canvasContext: back.getContext("2d"), viewport: vp, transform: [1, 0, 0, 1, -x0 * factor, -y0 * factor] });
-    detailTaskRef.current = rt;
-    // Backstop watchdog — NOT the primary fix (that's the visibilitychange retry
-    // below, which targets the actual documented cause). This only covers some
-    // OTHER wedge with no visibility signal, so it deliberately skips firing while
-    // still hidden (retrying then would just wedge the same way) and is tuned long
-    // enough to never race a merely slow render.
-    detailWatchdogRef.current = setTimeout(() => {
-      if (detailTaskRef.current !== rt) return;              // already superseded — nothing to recover
-      if (document.visibilityState !== "visible") return;    // still hidden — visibilitychange will recover it on return
-      if (detailKeyRef.current === renderKey) detailKeyRef.current = "";   // let the next tick retry this crop
-      if (window.__OT_DETAIL_DEBUG) console.log("[detail] stalled, retrying", renderKey);
-      scheduleSync();
-    }, DETAIL_STALL_MS);
-    rt.promise.then(() => {
-      clearTimeout(detailWatchdogRef.current);
-      if (darkModeRef.current) invertCanvasPixels(back);   // negative view baked into pixels before it's ever visible
-      cv.style.left = `${fp.xOffset + x0}px`; cv.style.top = `${y0}px`;
-      cv.style.width = `${regW}px`; cv.style.height = `${regH}px`;
-      cv.width = bw; cv.height = bh;
-      cv.getContext("2d").drawImage(back, 0, 0);           // clear + repaint inside one task: no blank frame
-      back.width = back.height = 0;
-      canvasInvertedRef.current.set(cv, !!darkModeRef.current);
-      cv.style.display = "block"; cv.style.visibility = "";
-      if (window.__OT_DETAIL_DEBUG) console.log("[detail] swapped", bw, "x", bh);
-    }).catch((e) => {   // RenderingCancelledException on rapid re-zoom is expected
-      clearTimeout(detailWatchdogRef.current);
-      if (detailKeyRef.current === renderKey) detailKeyRef.current = "";   // let the next tick retry this crop
-      if (e?.name !== "RenderingCancelledException") console.error("[detail] render failed:", e);
-    });
-    // panelW/takeoffsOpen: docking or resizing the Takeoffs panel changes the
-    // container rect without a transform change — re-run so the crop resyncs
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tf, groupSig, status, focusKey, panelW, takeoffsOpen]);
-
-  // Primary recovery for the detail-view stall: a hidden tab can suspend pdf.js's
-  // render scheduling indefinitely (the promise above neither resolves nor rejects,
-  // no console error — Chrome throttles rAF-gated work in hidden tabs). Retrying the
-  // moment the tab is foregrounded again is immediate and, unlike a blind timeout,
-  // never fights a render that's just legitimately slow while visible.
+  // Primary recovery for a stalled tile fetch: a hidden tab can suspend
+  // in-flight work indefinitely with no error (Chrome throttles rAF-gated
+  // work in hidden tabs) — clear every panel's render key and retry on return.
   useEffect(() => {
     const onVis = () => {
-      if (document.visibilityState !== "visible" || !detailKeyRef.current) return;
-      detailKeyRef.current = "";   // let the next tick re-request the pending crop
-      scheduleSync();
+      if (document.visibilityState !== "visible") return;
+      detailKeysRef.current.clear();
+      setRepaintTick((n) => n + 1);
     };
     document.addEventListener("visibilitychange", onVis);
     return () => document.removeEventListener("visibilitychange", onVis);
-  }, [scheduleSync]);
+  }, []);
 
   // the doc cache holds whole PDFs in the worker — tear it down when the
-  // project view unmounts or the project changes
+  // project view unmounts or the project changes. (The tile compositor has
+  // its own dedicated create/dispose effect above, for StrictMode reasons —
+  // see its comment.)
   useEffect(() => () => {
     for (const [, t] of pdfDocsRef.current) { t.then((task) => { try { task.destroy(); } catch { /* already gone */ } }).catch(() => {}); }
     pdfDocsRef.current.clear();
@@ -5009,16 +4994,11 @@ export default function TakeoffCanvas() {
             <Icon name="angle" size={15} />45°
           </button>
           <ToolMenu
-            title="Render & fill settings — Hi-Res and One-Click fill sensitivity"
+            title="Render & fill settings — One-Click fill sensitivity"
             onOpenChange={onMenuDepth}
             face={<Icon name="sliders" size={15} />}
             menuStyle={{ minWidth: 252 }}
             items={[
-              {
-                id: "hires", icon: "hiRes", label: "Hi-Res render (this sheet)", checked: hiResOn(focusPanel.key), stayOpen: true, onSelect: toggleHiRes,
-                title: `Hi-Res rendering for ${labelFor(focusPanel)} — the sheet re-rasters at an auto quality budget (~28MP), so memory stays bounded even side-by-side; crisper when zoomed in. Saved per sheet, per user. Quantities are unaffected.`,
-              },
-              "divider",
               { id: "fill", custom: fillRow },
             ]}
           />
@@ -5451,12 +5431,21 @@ export default function TakeoffCanvas() {
               style={{ position: "absolute", left: editor.left, top: editor.top, zIndex: 9, minWidth: 160, padding: "3px 6px", font: "13px var(--f-body, sans-serif)", color: "var(--ink)", background: "var(--paper-bright)", border: "1px solid var(--cobalt)", boxShadow: "0 2px 10px rgba(0,0,0,.18)", borderRadius: 0, cursor: "text", outline: "none" }} />
           )}
           <div ref={stageRef} style={{ position: "absolute", transformOrigin: "0 0", willChange: "transform", width: stage.w || undefined, height: stage.h || undefined }}>
+            {/* base layer — a small, bounded coarse pyramid placeholder CSS-stretched
+                to the panel's full logical footprint (see tileCompositor.ts's
+                paintBase); the backing store is NOT sheet-sized, only its CSS box is,
+                which is what keeps this a bounded canvas regardless of sheet size */}
             {panels.map((p) => (
               <canvas key={p.key} ref={(el) => { if (el) panelCanvasRefs.current.set(p.key, el); else panelCanvasRefs.current.delete(p.key); }}
-                style={{ position: "absolute", left: p.xOffset, top: 0, boxShadow: "0 2px 20px rgba(0,0,0,.18)" }} />
+                style={{ position: "absolute", left: p.xOffset, top: 0, width: p.img.w || undefined, height: p.img.h || undefined, boxShadow: "0 2px 20px rgba(0,0,0,.18)" }} />
             ))}
-            {/* high-res detail overlay — a crop of the visible region re-rendered at the current zoom (see the detail-view effect) */}
-            <canvas ref={detailCanvasRef} style={{ position: "absolute", left: 0, top: 0, display: "none", pointerEvents: "none" }} />
+            {/* detail layer — one PER PANEL, a crop of the visible region + margin
+                composited from cached tiles at the current zoom (see the detail-view
+                effect); group mode no longer shares a single global detail canvas */}
+            {panels.map((p) => (
+              <canvas key={`detail-${p.key}`} ref={(el) => { if (el) detailCanvasRefs.current.set(p.key, el); else detailCanvasRefs.current.delete(p.key); }}
+                style={{ position: "absolute", left: 0, top: 0, display: "none", pointerEvents: "none" }} />
+            ))}
             <svg width={stage.w} height={stage.h} viewBox={`0 0 ${stage.w} ${stage.h}`} style={{ position: "absolute", top: 0, left: 0, overflow: "visible", pointerEvents: "none" }}>
               <defs>
                 {conditions.map((c) => <HatchPattern key={patId(c)} id={patId(c)} type={c.hatch || "solid"} line={c.color} fill={c.fill} dark={darkMode} />)}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -1305,10 +1305,11 @@ export default function TakeoffCanvas() {
         if (renderKey === detailKeysRef.current.get(p.key)) continue;
         detailKeysRef.current.set(p.key, renderKey);
         try { detailCancelsRef.current.get(p.key)?.cancel(); } catch { /* done */ }
-        cv.style.left = `${p.xOffset + x0}px`; cv.style.top = `${y0}px`;
-        cv.style.width = `${x1 - x0}px`; cv.style.height = `${y1 - y0}px`;
-        cv.style.display = "block";
-        const cancel = getCompositor().paintDetail(cv, p.key, x0, y0, x1, y1, density, darkModeRef.current, () => {});
+        // paintDetail owns position/size/pixels together now and applies all
+        // three atomically on reveal — setting them here first would show a
+        // correctly-positioned canvas with the OLD crop's (wrongly scaled)
+        // pixels for a frame, which is its own flavor of flicker.
+        const cancel = getCompositor().paintDetail(cv, p.key, p.xOffset, x0, y0, x1, y1, density, darkModeRef.current, () => {});
         detailCancelsRef.current.set(p.key, cancel);
       }
     };

--- a/web/src/pdfTile.worker.ts
+++ b/web/src/pdfTile.worker.ts
@@ -1,0 +1,214 @@
+// Tile-render worker (#86) — owns one pdf.js instance PER WORKER, renders
+// requested tiles into an OffscreenCanvas, transfers the result back as an
+// ImageBitmap (zero-copy). The compositor (lib/tileCompositor.ts) round-robins
+// sheets across a small pool of these so group-mode panels can render in
+// parallel instead of fighting for one thread — see lib/tilePool.ts.
+//
+// hush.ts (mcp/) is prior art for "pdf.js is fussy about its environment":
+// verbosity:0 here for the same reason (its console noise has no wire
+// contract to protect in a Worker, but it's still noise); Promise.withResolvers
+// gets the same defensive polyfill pdf.js 4.x needs on any global scope predating
+// it (Baseline 2024 — some browsers in the field are still older). Unlike
+// mcp/src/pdf.ts, no @napi-rs/canvas shim is needed: OffscreenCanvas + Path2D +
+// DOMMatrix + ImageData are all native in a real browser Worker.
+//
+// GlobalWorkerOptions.workerSrc IS set below, to the same pdf.worker.min.mjs
+// the main thread uses — turns out pdf.js 4.x does NOT silently fall back to
+// in-context ("fake worker") parsing when it's unset; PDFWorker._initialize
+// reads the `workerSrc` getter before any try/catch can catch it, so the
+// first getDocument() call in a fresh realm just throws `No
+// "GlobalWorkerOptions.workerSrc" specified.` (confirmed live — there's no
+// `disableWorker` option on this version's DocumentInitParameters either).
+// So: yes, this nests a worker inside a worker for the parse step. That's a
+// real extra thread hop, but it's still off the main UI thread, which is the
+// only thing that actually matters here — parsing was never going to be the
+// expensive part; painting (this worker's own job) is.
+//
+// Protocol:
+//   in : { type:"openSheet", sheetKey, file, pageNum, data: ArrayBuffer }
+//        { type:"renderTile", reqId, sheetKey, scale, rect:{x,y,w,h}, dark }
+//        { type:"cancel", reqId }
+//        { type:"closeSheet", sheetKey }
+//   out: { type:"sheetReady", sheetKey } | { type:"sheetError", sheetKey, message }
+//        { type:"tile", reqId, sheetKey, bitmap: ImageBitmap, w, h }
+//        { type:"tileError", reqId, sheetKey, message }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+if (typeof (Promise as any).withResolvers !== "function") {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (Promise as any).withResolvers = function withResolvers() {
+    let resolve, reject;
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+  };
+}
+
+import * as pdfjsLib from "pdfjs-dist";
+import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+
+// pdf.js's default DOMCanvasFactory allocates SCRATCH canvases during
+// page.render() (pattern tiles, transparency groups, image masks) via
+// document.createElement — and there is no `document` in a Worker, so every
+// render dies with "Cannot read properties of undefined (reading
+// 'createElement')" (confirmed live; the doc OPENS fine, only render crashes).
+// getDocument() takes the factory CLASS (constructed internally with
+// { ownerDocument, enableHWA }) — this one is OffscreenCanvas all the way down.
+class OffscreenCanvasFactory {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_opts?: unknown) { /* ownerDocument/enableHWA — irrelevant off-DOM */ }
+  create(width: number, height: number) {
+    if (width <= 0 || height <= 0) throw new Error("Invalid canvas size");
+    const canvas = new OffscreenCanvas(width, height);
+    return { canvas, context: canvas.getContext("2d", { willReadFrequently: true }) };
+  }
+  reset(cc: { canvas: OffscreenCanvas | null }, width: number, height: number) {
+    if (!cc.canvas) throw new Error("Canvas is not specified");
+    if (width <= 0 || height <= 0) throw new Error("Invalid canvas size");
+    cc.canvas.width = width; cc.canvas.height = height;
+  }
+  destroy(cc: { canvas: OffscreenCanvas | null; context: unknown }) {
+    if (!cc.canvas) throw new Error("Canvas is not specified");
+    cc.canvas.width = 0; cc.canvas.height = 0;
+    cc.canvas = null; cc.context = null;
+  }
+}
+
+// Same story for the default DOMFilterFactory (SVG filter elements need a
+// document). pdf.js's own Node build ships `class NodeFilterFactory extends
+// BaseFilterFactory {}` — every method returns "none", filters degrade
+// gracefully — so a no-op factory here is exactly the upstream-sanctioned
+// behavior for a DOM-less realm, not a hack.
+class WorkerFilterFactory {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_opts?: unknown) { /* docId/ownerDocument — unused */ }
+  addFilter() { return "none"; }
+  addHCMFilter() { return "none"; }
+  addAlphaFilter() { return "none"; }
+  addLuminosityFilter() { return "none"; }
+  addHighlightHCMFilter() { return "none"; }
+  destroy() { /* nothing cached */ }
+}
+
+interface SheetEntry {
+  ready: Promise<unknown>; // resolves to the pdf.js page object
+  chain: Promise<void>;    // serializes renders on this sheet's page
+}
+
+const sheets = new Map<string, SheetEntry>();
+const inflight = new Map<number, { cancelled: boolean; task?: { cancel: () => void } }>();
+
+// tsconfig's `lib` is DOM-only (no "webworker" — TS disallows DOM + webworker
+// together in one program, and this repo's app code needs DOM). That makes
+// `self` type as `Window`, whose postMessage(message, targetOrigin, transfer)
+// overload doesn't match a transfer-list call — this worker is the first in
+// the repo to transfer (stt.worker.ts never does). One narrow cast, isolated
+// here, instead of fighting the project-wide lib config.
+const post = self.postMessage as (message: unknown, transfer?: Transferable[]) => void;
+
+function invertOffscreen(canvas: OffscreenCanvas) {
+  const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
+  ctx.save();
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.globalCompositeOperation = "difference";
+  ctx.fillStyle = "#fff";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.restore();
+}
+
+type InMsg =
+  | { type: "openSheet"; sheetKey: string; pageNum: number; data: ArrayBuffer }
+  | { type: "renderTile"; reqId: number; sheetKey: string; scale: number; rect: { x: number; y: number; w: number; h: number }; dark: boolean }
+  | { type: "cancel"; reqId: number }
+  | { type: "closeSheet"; sheetKey: string };
+
+self.onmessage = async (e: MessageEvent<InMsg>) => {
+  const msg = e.data;
+  if (msg.type === "openSheet") {
+    if (sheets.has(msg.sheetKey)) return; // idempotent — same file, already opening/open
+    const ready = (async () => {
+      // workerSrc is set above (see header) — the parse step runs in a nested
+      // worker. CanvasFactory/FilterFactory MUST be overridden here: the DOM
+      // defaults dereference `document` mid-render (see class comments above).
+      const task = pdfjsLib.getDocument({
+        data: msg.data,
+        verbosity: 0,
+        CanvasFactory: OffscreenCanvasFactory,
+        FilterFactory: WorkerFilterFactory,
+        // FontLoader gates ALL embedded-font binding on `ownerDocument.fonts`
+        // (default ownerDocument = globalThis.document = undefined here), so
+        // without this every glyph paints as a .notdef tofu box (confirmed
+        // live at 102% zoom). Workers have their own FontFaceSet — self.fonts
+        // — and OffscreenCanvas text drawing reads from it, so handing pdf.js
+        // the worker global as its "document" makes embedded fonts load
+        // exactly like they do on the main thread. (FontLoader's DOM-y
+        // createElement/styleSheet path is only reached when FontFaceSet is
+        // MISSING, so it stays dead here.)
+        ownerDocument: self as unknown as Document,
+      });
+      const doc = await task.promise;
+      const page = await doc.getPage(msg.pageNum);
+      return page;
+    })();
+    sheets.set(msg.sheetKey, { ready, chain: Promise.resolve() });
+    ready.then(
+      () => post({ type: "sheetReady", sheetKey: msg.sheetKey }),
+      (err) => { sheets.delete(msg.sheetKey); post({ type: "sheetError", sheetKey: msg.sheetKey, message: String(err?.message || err) }); },
+    );
+    return;
+  }
+
+  if (msg.type === "closeSheet") {
+    sheets.delete(msg.sheetKey);
+    return;
+  }
+
+  if (msg.type === "cancel") {
+    const f = inflight.get(msg.reqId);
+    if (f) { f.cancelled = true; try { f.task?.cancel(); } catch { /* already done */ } }
+    return;
+  }
+
+  if (msg.type === "renderTile") {
+    const { reqId, sheetKey, scale, rect, dark } = msg;
+    const entry = sheets.get(sheetKey);
+    const flag = { cancelled: false } as { cancelled: boolean; task?: { cancel: () => void } };
+    inflight.set(reqId, flag);
+    if (!entry) {
+      inflight.delete(reqId);
+      post({ type: "tileError", reqId, sheetKey, message: "sheet not open" });
+      return;
+    }
+    entry.chain = entry.chain.then(async () => {
+      if (flag.cancelled) { inflight.delete(reqId); return; }
+      try {
+        const page = await entry.ready;
+        if (flag.cancelled) { inflight.delete(reqId); return; }
+        const canvas = new OffscreenCanvas(Math.max(1, rect.w), Math.max(1, rect.h));
+        const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const viewport = (page as any).getViewport({ scale });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const renderTask = (page as any).render({
+          canvasContext: ctx,
+          viewport,
+          transform: [1, 0, 0, 1, -rect.x, -rect.y],
+        });
+        flag.task = renderTask;
+        await renderTask.promise;
+        if (flag.cancelled) { inflight.delete(reqId); return; }
+        if (dark) invertOffscreen(canvas);
+        const bitmap = canvas.transferToImageBitmap();
+        inflight.delete(reqId);
+        post({ type: "tile", reqId, sheetKey, w: rect.w, h: rect.h, bitmap }, [bitmap]);
+      } catch (err) {
+        inflight.delete(reqId);
+        // RenderingCancelledException on supersede/cancel is expected, not an error
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ((err as any)?.name === "RenderingCancelledException" || flag.cancelled) return;
+        post({ type: "tileError", reqId, sheetKey, message: String((err as Error)?.message || err) });
+      }
+    });
+  }
+};

--- a/web/src/pdfTile.worker.ts
+++ b/web/src/pdfTile.worker.ts
@@ -1,8 +1,10 @@
-// Tile-render worker (#86) — owns one pdf.js instance PER WORKER, renders
-// requested tiles into an OffscreenCanvas, transfers the result back as an
-// ImageBitmap (zero-copy). The compositor (lib/tileCompositor.ts) round-robins
-// sheets across a small pool of these so group-mode panels can render in
-// parallel instead of fighting for one thread — see lib/tilePool.ts.
+// Tile-render worker (#86) — owns one pdf.js instance PER SHEET PER WORKER,
+// renders requested tiles into an OffscreenCanvas, transfers the result back
+// as an ImageBitmap (zero-copy). Every open sheet is loaded into EVERY
+// worker in the pool (lib/tilePool.ts broadcasts, doesn't hash-pin), and
+// tile requests round-robin across the whole pool — so a single sheet gets
+// real N-way render parallelism (N = pool size), not just group-mode panels
+// splitting across workers.
 //
 // hush.ts (mcp/) is prior art for "pdf.js is fussy about its environment":
 // verbosity:0 here for the same reason (its console noise has no wire

--- a/web/test/tiles.test.ts
+++ b/web/test/tiles.test.ts
@@ -100,3 +100,24 @@ test("TileLRU.set on an existing key replaces its byte accounting, not doubles i
   assert.equal(lru.size, 250);
   assert.equal(lru.get("a"), "v2");
 });
+
+test("TileLRU.onEvict fires for every value leaving the cache — evict, replace, and clear", () => {
+  const closed: string[] = [];
+  const lru = new TileLRU(200, (v) => closed.push(v as string));
+  lru.set("a", "A", 100);
+  lru.set("b", "B", 100);
+  lru.set("c", "C", 100);          // over budget -> evicts "a"
+  assert.deepEqual(closed, ["A"]);
+  lru.set("b", "B2", 100);         // replace -> old "B" released
+  assert.deepEqual(closed, ["A", "B"]);
+  lru.clear();                     // teardown releases the rest
+  assert.deepEqual(closed.sort(), ["A", "B", "B2", "C"]);
+});
+
+test("TileLRU protect provider shields the visible set when no explicit protect is passed", () => {
+  const lru = new TileLRU(150, undefined, () => new Set(["visible"]));
+  lru.set("visible", "V", 100);
+  lru.set("offscreen", "O", 100);  // over budget; LRU order would evict "visible" first
+  assert.equal(lru.has("visible"), true, "provider-protected key survived");
+  assert.equal(lru.has("offscreen"), false, "unprotected key was evicted instead");
+});

--- a/web/test/tiles.test.ts
+++ b/web/test/tiles.test.ts
@@ -1,0 +1,102 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  TILE_SIZE, MAX_DENSITY, buildLevels, pickLevel, levelDims, tileGrid,
+  tileKey, tileRect, visibleTiles, requiredDensity, TileLRU,
+} from "../src/lib/tiles.ts";
+
+test("buildLevels always includes native (1.0) and tops out at MAX_DENSITY", () => {
+  const levels = buildLevels(5000, 3000);
+  assert.ok(levels.includes(1));
+  assert.equal(levels[levels.length - 1], MAX_DENSITY);
+  for (let i = 1; i < levels.length; i++) assert.equal(levels[i], levels[i - 1] * 2);
+});
+
+test("buildLevels coarsest level keeps a huge (ingested-image) sheet's long edge near MIN_LEVEL_PX", () => {
+  // the 07-21 regression sheet: a 7920x5280pt image page at RENDER_SCALE=2
+  const levels = buildLevels(15840, 10560);
+  const { w, h } = levelDims(15840, 10560, levels[0]);
+  assert.ok(Math.max(w, h) <= 1536, `coarsest level too dense: ${w}x${h}`);
+  assert.ok(Math.max(w, h) >= 384, `coarsest level too sparse: ${w}x${h}`);
+});
+
+test("buildLevels never produces a level denser than needed for a tiny sheet", () => {
+  const levels = buildLevels(200, 100);
+  assert.ok(levels[0] <= 1);
+});
+
+test("pickLevel picks the least-dense level that still covers the request", () => {
+  const levels = [0.25, 0.5, 1, 2, 4, 8];
+  assert.equal(pickLevel(levels, 0.1), 0);   // below the floor -> coarsest
+  assert.equal(pickLevel(levels, 0.25), 0);  // exact match
+  assert.equal(pickLevel(levels, 0.6), 2);   // between 0.5 and 1 -> next level up (1, index 2)
+  assert.equal(pickLevel(levels, 1.15), 3);  // DETAIL_ENGAGE-equivalent -> next level up from native (2, index 3)
+  assert.equal(pickLevel(levels, 100), 5);   // past the ceiling -> clamp to top, never grows unboundedly
+});
+
+test("levelDims / tileGrid agree on level pixel size", () => {
+  const d = levelDims(5000, 3000, 1);
+  const g = tileGrid(5000, 3000, 1);
+  assert.equal(g.w, d.w); assert.equal(g.h, d.h);
+  assert.equal(g.cols, Math.ceil(d.w / TILE_SIZE));
+  assert.equal(g.rows, Math.ceil(d.h / TILE_SIZE));
+});
+
+test("tileKey is stable and distinct per coordinate", () => {
+  assert.equal(tileKey("A-201", 2, 3, 4), "A-201:2:3:4");
+  assert.notEqual(tileKey("A-201", 2, 3, 4), tileKey("A-201", 2, 4, 3));
+});
+
+test("tileRect clips edge tiles to the level bounds instead of overshooting", () => {
+  const r = tileRect(0, 1, 0, 700, 400); // levelW=700 -> tile 1 only has 700-512=188px
+  assert.equal(r.x, 512); assert.equal(r.w, 188); assert.equal(r.h, 400);
+});
+
+test("visibleTiles covers a small region with exactly the tiles that intersect it", () => {
+  const levels = [1];
+  const tiles = visibleTiles(2000, 2000, levels, 0, 500, 500, 600, 600);
+  // region [500,600)x[500,600) at density 1 -> spans tile (0,0) only (0..512 covers 500..512, but 512..600 needs tile 1)
+  const keys = tiles.map((t) => `${t.tx},${t.ty}`).sort();
+  assert.deepEqual(keys, ["0,0", "1,0", "0,1", "1,1"].sort());
+});
+
+test("visibleTiles returns nothing for an out-of-bounds / degenerate region", () => {
+  assert.deepEqual(visibleTiles(2000, 2000, [1], 0, 3000, 3000, 3100, 3100), []);
+  assert.deepEqual(visibleTiles(2000, 2000, [1], 0, 100, 100, 100, 100), []);
+});
+
+test("requiredDensity matches the old DETAIL_ENGAGE quantity (stageScale * dpr)", () => {
+  assert.equal(requiredDensity(1.15, 1), 1.15);
+  assert.equal(requiredDensity(0.575, 2), 1.15);
+});
+
+test("TileLRU evicts least-recently-used tiles once over budget, protecting visible ones", () => {
+  const lru = new TileLRU(300);
+  lru.set("a", "A", 100);
+  lru.set("b", "B", 100);
+  lru.set("c", "C", 100);
+  assert.equal(lru.size, 300);
+  lru.get("a"); // touch a -> now MRU; LRU order is b, c, a
+  lru.set("d", "D", 100); // over budget by 100 -> evicts b (the LRU, unprotected)
+  assert.equal(lru.has("b"), false);
+  assert.equal(lru.has("a"), true);
+  assert.equal(lru.has("c"), true);
+  assert.equal(lru.has("d"), true);
+});
+
+test("TileLRU.evictToBudget never evicts a protected (currently visible) key", () => {
+  const lru = new TileLRU(150);
+  lru.set("a", "A", 100);
+  lru.set("b", "B", 100); // already over budget: 200 > 150, but only 'b' is protected
+  lru.evictToBudget(new Set(["b"]));
+  assert.equal(lru.has("b"), true);
+  assert.equal(lru.has("a"), false);
+});
+
+test("TileLRU.set on an existing key replaces its byte accounting, not doubles it", () => {
+  const lru = new TileLRU(1000);
+  lru.set("a", "v1", 100);
+  lru.set("a", "v2", 250);
+  assert.equal(lru.size, 250);
+  assert.equal(lru.get("a"), "v2");
+});


### PR DESCRIPTION
## Summary
Implements RFC #86: replaces the single giant per-sheet raster (and its threshold-gated detail-view crop) with a real tile pyramid — rendered off-thread in a small pool of pdf.js workers, composited from a byte-budgeted LRU cache, behaving like standard slippy-map tiles at every zoom level.

- **`web/src/lib/tiles.ts`** — pure pyramid math (levels, tile keys, visible-tile set, LRU with ~450MB byte budget). 13 unit tests.
- **`web/src/pdfTile.worker.ts`** — tile-render worker; owns a pdf.js instance, renders tiles into OffscreenCanvas, transfers ImageBitmaps back. Three worker-realm fixes found by rendering live, documented inline:
  - pdf.js 4.x throws (no fake-worker fallback) unless `workerSrc` is set inside this worker too
  - default `DOMCanvasFactory`/`DOMFilterFactory` dereference `document` mid-render → OffscreenCanvas factory + upstream-style no-op filter factory
  - `ownerDocument: self` so FontLoader binds embedded fonts through the worker `FontFaceSet` — without it every glyph renders as a tofu box
- **`web/src/lib/tilePool.ts`** — sheet→worker assignment by hash; group-mode panels render in parallel.
- **`web/src/lib/tileCompositor.ts`** — open/ready gating, `paintBase` (coarse whole-sheet placeholder, painted once), `paintDetail` (viewport composite, placeholder-then-refine), generation-based invalidation.
- **`TakeoffCanvas.jsx`** — every panel gets its own base + detail layer (group mode previously only sharpened the focused panel — RFC-noted gap, closed). Detail sync runs from `scheduleSync`'s tick so low-zoom pans (which skip the `tf` state mirror) still resync. Compositor is lazily created / nulled on dispose (StrictMode-resilient). Hi-res per-sheet opt-in **removed** — tiling makes it obsolete (the RFC's promised net-negative-lines deletion).

## Verified live (localhost, IA2.01 sample + finishplan-17)
base render → pan → deep zoom (tiles sharpen; `TR-01`/`ALIGN`/room labels crisp at 100%+) → fit → dark-mode per-tile inversion in-worker → manual area trace (59.9 SF, totals correct) → one-click flood fill (Breakroom 107, 106.2 SF, wall-tight ring) → report round-trip (waste math correct) → 2-sheet side-by-side with independent per-panel sharpening.

## Checks
`typecheck` / `lint` / `build` green. 948/952 tests pass locally — the 4 failures are the known Node 25-vs-pinned-24 localStorage quirk, present on clean `main` (CI runs the pinned Node and is unaffected).

## Deferred (per RFC's known-hard-parts)
- MCP `view_sheet` tile-cache unification
- Layer-aware rendering interaction (pending #85)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)