### PR TITLE
Correction rules — one Cut Out becomes a re-runnable project rule (#88)

### DIFF
--- a/web/src/lib/rules.ts
+++ b/web/src/lib/rules.ts
@@ -1,0 +1,267 @@
+// Correction rules (#88) — one correction, fifty rooms. Pure geometry, no DOM,
+// no model in the loop: a rule is a DETERMINISTIC predicate re-run over the
+// project, never a re-prompt.
+//
+// v1 covers the RFC's literal example and nothing speculative: an estimator
+// draws a Cut Out (deduct) fully inside one of a condition's floor_area rooms
+// — "columns are not finish area on this project". That correction becomes:
+//
+//   { kind: "enclosed_subpolygon_deduct", max_area_sf: N }
+//
+// "Apply to the other 49" then scans every OTHER room of the same condition
+// for small enclosed sub-regions (linework islands — column boxes, shafts,
+// casework) and returns them as CANDIDATE deducts. The caller stages those in
+// an accept gate (dashed pencil, explicit Apply) — nothing here commits, and
+// nothing is ever applied silently. Every candidate carries the container it
+// was found in; the caller stamps rule_id + seed_shape_id provenance so every
+// propagated shape traces back to the correction that seeded it.
+//
+// Scope guards (the RFC's "deltas are ambiguous" warning, applied):
+//   - detection fires ONLY on a deduct fully contained in a same-condition
+//     floor_area on the same sheet, and only when the deduct is small
+//     (≤ SEED_MAX_SF) — a room-scale deduct is a boundary correction, not a
+//     column rule, and proposing a rule from it would be noise;
+//   - propagation finds only CLOSED linework islands (a region of free mask
+//     cells that does NOT connect to the room's own field — door openings
+//     connect, so open bays never match), under the rule's area cap;
+//   - candidates overlapping ANY existing deduct are dropped — re-running a
+//     rule is idempotent by construction.
+//
+// The mask machinery is One-Click Area's own (buildMask/traceRegion) — the
+// same downscaled linework raster the estimator already trusts for tracing.
+
+import { pointInPoly } from "./geometry.js";
+import { ringArea, traceRegion, type MaskObj, type Point } from "./oneclick.ts";
+
+export interface RulePredicate {
+  kind: "enclosed_subpolygon_deduct";
+  max_area_sf: number;
+}
+
+export interface Rule {
+  id: string;
+  created_at: string;
+  seed_shape_id: string;      // the correction that generated this rule — traceability
+  seed_condition_id: string;  // project-scoped: rules never outlive the project file
+  predicate: RulePredicate;
+  label: string;              // plain language, generated once at creation
+  applied_to: string[];       // shape ids minted by this rule — audit trail, not a gate (overlap dedup is the gate)
+  active: boolean;
+}
+
+// Minimal structural slice of a canvas/session shape this module reads.
+export interface RuleShape {
+  id: string;
+  sheet_id: string;
+  condition_id: string;
+  measure_role: string;
+  verts_norm: Point[];
+  computed?: { area_sf?: number };
+}
+
+/** A deduct larger than this is a boundary correction, not a column rule —
+ *  detection stays silent (proposing a bad rule is worse than proposing none). */
+export const SEED_MAX_SF = 100;
+/** Predicate floor — the RFC's literal "under 25 SF". A tiny seed still yields
+ *  a usable cap; a bigger seed raises it (rounded up to 5 SF) so the rule
+ *  catches its own seed's size class. */
+export const RULE_MIN_CAP_SF = 25;
+
+export const ringCentroid = (pts: Point[]): Point => {
+  let x = 0, y = 0;
+  for (const p of pts) { x += p[0]; y += p[1]; }
+  return [x / pts.length, y / pts.length];
+};
+
+const inside = (p: Point, ring: Point[]) => pointInPoly(p[0], p[1], ring) as boolean;
+
+/** Every vertex AND the centroid inside — cheap full-containment test that is
+ *  exact for the convex cutouts this rule targets and conservative otherwise. */
+export function ringContains(outer: Point[], innerRing: Point[]): boolean {
+  if (outer.length < 3 || innerRing.length < 3) return false;
+  return innerRing.every((v) => inside(v, outer)) && inside(ringCentroid(innerRing), outer);
+}
+
+export function defaultMaxAreaSf(seedAreaSf: number): number {
+  return Math.max(RULE_MIN_CAP_SF, Math.ceil(seedAreaSf / 5) * 5);
+}
+
+export interface RuleCandidateSeed {
+  container_shape_id: string;
+  max_area_sf: number;
+  seed_area_sf: number;
+}
+
+/** Did this just-committed deduct sit fully inside a same-condition floor_area
+ *  room on its own sheet, small enough to read as a cutout correction?
+ *  Returns the detected seed (container + derived cap) or null. */
+export function detectCandidateRule(shapes: RuleShape[], deduct: RuleShape): RuleCandidateSeed | null {
+  if (deduct.measure_role !== "deduct" || deduct.verts_norm.length < 3) return null;
+  const seedArea = deduct.computed?.area_sf ?? 0;
+  if (!(seedArea > 0) || seedArea > SEED_MAX_SF) return null;
+  const container = shapes.find((s) =>
+    s.id !== deduct.id &&
+    s.measure_role === "floor_area" &&
+    s.sheet_id === deduct.sheet_id &&
+    s.condition_id === deduct.condition_id &&
+    s.verts_norm.length >= 3 &&
+    ringContains(s.verts_norm, deduct.verts_norm));
+  if (!container) return null;
+  return { container_shape_id: container.id, max_area_sf: defaultMaxAreaSf(seedArea), seed_area_sf: seedArea };
+}
+
+export function buildRuleFromSeed(
+  deduct: RuleShape, seed: RuleCandidateSeed, conditionTag: string,
+  mint: { id: string; now: string },
+): Rule {
+  return {
+    id: mint.id,
+    created_at: mint.now,
+    seed_shape_id: deduct.id,
+    seed_condition_id: deduct.condition_id,
+    predicate: { kind: "enclosed_subpolygon_deduct", max_area_sf: seed.max_area_sf },
+    label: `Exclude enclosed regions under ${seed.max_area_sf} SF in ${conditionTag} rooms`,
+    applied_to: [],
+    active: true,
+  };
+}
+
+/** Enclosed linework islands inside `ringImgPx`: connected components of free
+ *  mask cells (hard walls block — bit 1; hatch is transparent, or every tile
+ *  cell would match) that do NOT touch the ring's own field component.
+ *  Components are found by 4-connected BFS clipped to the ring; anything that
+ *  reaches the room's open field (door bays, alcoves) merges with it and is
+ *  skipped by the size cap. Returns traced rings in IMAGE px. */
+export function findEnclosedRegions(mask: MaskObj, ringImgPx: Point[], maxCells: number, minCells = 4): Point[][] {
+  const { mask: m, mw, mh, ws } = mask;
+  if (ringImgPx.length < 3 || maxCells < minCells) return [];
+  const ringMask: Point[] = ringImgPx.map(([x, y]) => [x * ws, y * ws]);
+  let bx0 = Infinity, by0 = Infinity, bx1 = -Infinity, by1 = -Infinity;
+  for (const [x, y] of ringMask) {
+    if (x < bx0) bx0 = x; if (x > bx1) bx1 = x;
+    if (y < by0) by0 = y; if (y > by1) by1 = y;
+  }
+  const x0 = Math.max(0, Math.floor(bx0)), y0 = Math.max(0, Math.floor(by0));
+  const x1 = Math.min(mw - 1, Math.ceil(bx1)), y1 = Math.min(mh - 1, Math.ceil(by1));
+  if (x1 <= x0 || y1 <= y0) return [];
+  const bw = x1 - x0 + 1, bh = y1 - y0 + 1;
+  // 0 = unvisited, 1 = visited
+  const seen = new Uint8Array(bw * bh);
+  const isFree = (gx: number, gy: number) => !(m[gy * mw + gx] & 1) && inside([gx + 0.5, gy + 0.5], ringMask);
+  const out: Point[][] = [];
+  for (let gy = y0; gy <= y1; gy++) {
+    for (let gx = x0; gx <= x1; gx++) {
+      const li = (gy - y0) * bw + (gx - x0);
+      if (seen[li] || !isFree(gx, gy)) { seen[li] = 1; continue; }
+      // BFS this component (grid coords), capped — a component that exceeds
+      // maxCells is the room's own field (or an open bay): mark and move on.
+      const cells: number[] = [];
+      const stack = [gx, gy];
+      seen[li] = 1;
+      let over = false;
+      let cx0 = gx, cx1 = gx, cy0 = gy, cy1 = gy;
+      while (stack.length) {
+        const cy = stack.pop() as number, cx = stack.pop() as number;
+        cells.push(cx, cy);
+        if (cx < cx0) cx0 = cx; if (cx > cx1) cx1 = cx;
+        if (cy < cy0) cy0 = cy; if (cy > cy1) cy1 = cy;
+        if (!over && cells.length / 2 > maxCells) over = true;
+        const nbrs = [cx - 1, cy, cx + 1, cy, cx, cy - 1, cx, cy + 1];
+        for (let k = 0; k < 8; k += 2) {
+          const nx = nbrs[k], ny = nbrs[k + 1];
+          if (nx < x0 || ny < y0 || nx > x1 || ny > y1) continue;
+          const nli = (ny - y0) * bw + (nx - x0);
+          if (seen[nli]) continue;
+          seen[nli] = 1;
+          if (isFree(nx, ny)) { stack.push(nx, ny); }
+          // over-cap components keep flooding so the whole field is consumed
+          // in ONE component instead of fragmenting into false positives.
+        }
+      }
+      const n = cells.length / 2;
+      if (over || n > maxCells || n < minCells) continue;
+      // thickness guard — a 1-cell-wide sliver is linework noise, not a column
+      if (cx1 - cx0 + 1 < 2 || cy1 - cy0 + 1 < 2) continue;
+      // trace on a cropped canvas (components are small by the cap), then
+      // shift back: traceRegion divides by ws, so offset in image px.
+      const cw = cx1 - cx0 + 1, ch = cy1 - cy0 + 1;
+      const region = new Uint8Array(cw * ch);
+      for (let k = 0; k < cells.length; k += 2) region[(cells[k + 1] - cy0) * cw + (cells[k] - cx0)] = 1;
+      const ring = traceRegion({ region, mw: cw, mh: ch, ws }).map(([px, py]) => [px + cx0 / ws, py + cy0 / ws] as Point);
+      if (ring.length >= 3) out.push(ring);
+    }
+  }
+  return out;
+}
+
+export interface SheetRuleData {
+  mask: MaskObj;
+  upp: number;   // units (ft) per image px
+  imgW: number;
+  imgH: number;
+}
+
+export interface RuleCandidate {
+  sheet_id: string;
+  container_shape_id: string;
+  verts_norm: Point[];
+  area_sf: number;
+}
+
+/** Re-run the rule across the project: every floor_area room of the rule's
+ *  condition (on sheets the caller has data for), minus anything an existing
+ *  deduct already covers. Returns candidates only — the caller owns the
+ *  stage → accept gate and all provenance stamping. Deterministic: same
+ *  inputs, same candidates, every run. */
+export function applyRuleToProject(
+  rule: Rule, shapes: RuleShape[], sheetData: Map<string, SheetRuleData>,
+): RuleCandidate[] {
+  if (!rule.active || rule.predicate.kind !== "enclosed_subpolygon_deduct") return [];
+  const rooms = shapes.filter((s) =>
+    s.measure_role === "floor_area" &&
+    s.condition_id === rule.seed_condition_id &&
+    s.verts_norm.length >= 3 &&
+    sheetData.has(s.sheet_id));
+  // dedup targets: every deduct on a sheet, any condition — if ink already
+  // covers the island, proposing it again is noise, not thoroughness.
+  const deductsBySheet = new Map<string, Point[][]>();
+  for (const s of shapes) {
+    if (s.measure_role !== "deduct" || s.verts_norm.length < 3) continue;
+    const d = sheetData.get(s.sheet_id);
+    if (!d) continue;
+    const ring = s.verts_norm.map(([nx, ny]) => [nx * d.imgW, ny * d.imgH] as Point);
+    let arr = deductsBySheet.get(s.sheet_id);
+    if (!arr) { arr = []; deductsBySheet.set(s.sheet_id, arr); }
+    arr.push(ring);
+  }
+  const out: RuleCandidate[] = [];
+  const acceptedBySheet = new Map<string, Point[][]>();
+  for (const room of rooms) {
+    const d = sheetData.get(room.sheet_id)!;
+    if (!(d.upp > 0)) continue;
+    const ringImg = room.verts_norm.map(([nx, ny]) => [nx * d.imgW, ny * d.imgH] as Point);
+    // mask-cell area in SF: one cell is (1/ws) img px on a side
+    const cellSf = (d.upp / d.mask.ws) ** 2;
+    const maxCells = Math.floor(rule.predicate.max_area_sf / cellSf);
+    const found = findEnclosedRegions(d.mask, ringImg, maxCells);
+    for (const ring of found) {
+      const areaSf = ringArea(ring) * d.upp * d.upp;
+      if (!(areaSf > 0) || areaSf > rule.predicate.max_area_sf) continue;
+      const c = ringCentroid(ring);
+      const existing = deductsBySheet.get(room.sheet_id) || [];
+      const taken = acceptedBySheet.get(room.sheet_id) || [];
+      const covered = (rings: Point[][]) => rings.some((r) => inside(c, r) || inside(ringCentroid(r), ring));
+      if (covered(existing) || covered(taken)) continue;
+      out.push({
+        sheet_id: room.sheet_id,
+        container_shape_id: room.id,
+        verts_norm: ring.map(([x, y]) => [x / d.imgW, y / d.imgH] as Point),
+        area_sf: +areaSf.toFixed(2),
+      });
+      let arr = acceptedBySheet.get(room.sheet_id);
+      if (!arr) { arr = []; acceptedBySheet.set(room.sheet_id, arr); }
+      arr.push(ring);
+    }
+  }
+  return out;
+}

--- a/web/src/lib/shapeCommands.js
+++ b/web/src/lib/shapeCommands.js
@@ -41,6 +41,13 @@
 //   replace   NO stamp, NO counted, inverse null (never recorded): the escape
 //             hatch for whole-array non-edits — hydrate, revision restore,
 //             rescale's computed re-price.
+//   ruleApply the batch-accept gate for correction-rule propagation (#88):
+//             add semantics (created_at + id mint per shape, one undo entry
+//             for the whole batch), but a DISTINCT type because the policy
+//             decision differs — the caller pre-builds each origin with
+//             method "rule_v1", rule_id and seed_shape_id (the propagated
+//             shape must trace to its seed correction), reviewed: true
+//             (the estimator saw the staged batch and clicked Apply).
 //   review    the accept gate for machine proposals already IN the shapes
 //             array (an imported MCP takeoff, a binder run): each named shape
 //             still carrying origin.reviewed === false gets reviewed: true +
@@ -60,6 +67,7 @@ export const PROVENANCE_POLICY = {
   delete: "no stamp; counted per origin.method unless noCount",
   replace: "no stamp, no counted, no undo entry (whole-array non-edit)",
   review: "origin.reviewed → true + accepted_ts per still-pending shape; restore puts the prior origin back verbatim",
+  ruleApply: "add semantics (created_at + id mint per shape, ONE undo entry per batch); caller-built rule_v1 origin carries rule_id + seed_shape_id",
 };
 
 // Undo depth — one bounded gesture history, not an archive (revisions are).
@@ -132,6 +140,11 @@ export function applyShapeCommand(shapes, cmd) {
     throw new Error(`Unknown shape command type: ${cmd && cmd.type} — add it to PROVENANCE_POLICY (and decide what it stamps) first.`);
   }
   switch (cmd.type) {
+    // ruleApply IS an add structurally (mint id/created_at, inverse = noCount
+    // delete of the batch — one undo entry); the separate type exists so the
+    // PROVENANCE_POLICY table forces the policy decision to be made (and
+    // documents it) rather than overloading `add` rows with a rule flag.
+    case "ruleApply":
     case "add": {
       // restore: true = resurrection (undo of a delete) — the shapes go back
       // VERBATIM (created_at kept, no re-mint), at their original indices when

--- a/web/src/lib/store.js
+++ b/web/src/lib/store.js
@@ -42,7 +42,11 @@ const ANN_SCHEMA = "opentakeoff.takeoff_canvas.v1";
 // Drive-backed cloud store (cloudStore.js) hydrate a fresh project identically —
 // a new field added here reaches both, instead of silently drifting apart.
 export function emptyAnnotations() {
-  return { schema: ANN_SCHEMA, conditions: [], shapes: [], markups: [], sheets: [], sheet_group: [], last_group: [], sheet_tabs: [] };
+  // rules (#88): project-scoped correction rules — deterministic predicates
+  // seeded by an estimator's edit, re-runnable across the project. Local to
+  // the project file by the RFC's scope boundary (never on the MCP export or
+  // contribution wire).
+  return { schema: ANN_SCHEMA, conditions: [], shapes: [], markups: [], sheets: [], sheet_group: [], last_group: [], sheet_tabs: [], rules: [] };
 }
 
 function openDB() {

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -38,6 +38,7 @@ import { normalizeTag } from "../lib/scheduleEdit";
 import { isGoogleConfigured, isSignedIn, isAllowedDomain, getAccessToken, orgDomainHint } from "../lib/google/auth.js";
 import { extractVectorGeometry, buildMask, floodRegion, traceRegion, snapVertices, ringArea, MASK_MAX_DIM, SENS_STRICT, SENS_BALANCED, SENS_AGGRESSIVE } from "../lib/oneclick";
 import { buildRasterMask, RASTER_MIN_IMG_FRAC, RASTER_MIN_SEGS, RASTER_RDP_EPS } from "../lib/rastermask";
+import { detectCandidateRule, buildRuleFromSeed, applyRuleToProject } from "../lib/rules";
 import { conditionTotals, verticalWallSf } from "../lib/totals.js";
 import { shapesInZone } from "../lib/zone.js";
 import { sanitizeSheetLevels } from "../lib/sheetLevels.js";
@@ -302,6 +303,15 @@ export default function TakeoffCanvas() {
   // (→ dropped LOCALLY — dismissed geometry never rides the contribution wire).
   // Ephemeral by design: never persisted (buildPayload doesn't read them).
   const [agentProposals, setAgentProposals] = useState([]);
+  // ── correction rules (#88) — one correction, fifty rooms ────────────────────
+  // rules PERSIST (project file, buildPayload/hydrate) — they're the captured
+  // corrections. ruleOffer/ruleStage are ephemeral review state like
+  // agentProposals: the offer banner after a qualifying Cut Out, and the staged
+  // batch awaiting the explicit Apply. Staged candidates are NOT shapes —
+  // nothing commits until Apply dispatches ONE `ruleApply` command.
+  const [rules, setRules] = useState([]);
+  const [ruleOffer, setRuleOffer] = useState(null);   // { deduct, seed, tag }
+  const [ruleStage, setRuleStage] = useState(null);   // { rule, candidates, proposed_ts }
   const [agentOpen, setAgentOpen] = useState(false);      // docked right-rail Agent panel
   const [agentLog, setAgentLog] = useState([]);           // streaming run status [{kind, text}]
   const [agentRunning, setAgentRunning] = useState(false);
@@ -832,6 +842,11 @@ export default function TakeoffCanvas() {
     // conditions/sheets — a loaded/restored timeline starts with none pending
     // (nothing is lost: rejected geometry records nothing by design).
     setAgentProposals([]);
+    // same rule for the correction-rule review state (#88): an offer/staged
+    // batch aimed at pre-load shapes must not survive the load. The RULES
+    // themselves are project data and hydrate below.
+    setRuleOffer(null); setRuleStage(null);
+    setRules(Array.isArray(a.rules) ? a.rules : []);   // additive — old saves without rules load as []
     setProjectName(a.project_name || "");
     // string fields only — a corrupted record must not put an object where
     // the report masthead renders a React child
@@ -1392,7 +1407,7 @@ export default function TakeoffCanvas() {
     // units is additive and diff-only (the sheet_levels convention): imperial —
     // the default — omits the key, so an old imperial project's payload is
     // byte-identical on round-trip; only a metric project carries the field.
-    return { project_name: projectName, ...(units === "metric" ? { units } : {}), ...(Object.values(clientInfo).some((v) => v && String(v).trim()) ? { client_info: clientInfo } : {}), sheets: Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px, ...(scaleSources[sheet_id] ? { scale_source: scaleSources[sheet_id] } : {}) })), conditions, ...(conditionColumns.length ? { condition_columns: conditionColumns } : {}), ...(shapeLabels.length ? { shape_labels: shapeLabels } : {}), ...(pinned.length ? { palette: pinned } : {}), shapes, markups, rfis, sheet_group: sheetGroup, last_group: lastGroup, sheet_tabs: openTabs, ...(Object.keys(sheetLevels).length ? { sheet_levels: sheetLevels } : {}), ...(Object.keys(provCounters.shapes_deleted).length ? { provenance_counters: provCounters } : {}) };
+    return { project_name: projectName, ...(units === "metric" ? { units } : {}), ...(Object.values(clientInfo).some((v) => v && String(v).trim()) ? { client_info: clientInfo } : {}), sheets: Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px, ...(scaleSources[sheet_id] ? { scale_source: scaleSources[sheet_id] } : {}) })), conditions, ...(conditionColumns.length ? { condition_columns: conditionColumns } : {}), ...(shapeLabels.length ? { shape_labels: shapeLabels } : {}), ...(pinned.length ? { palette: pinned } : {}), shapes, markups, rfis, ...(rules.length ? { rules } : {}), sheet_group: sheetGroup, last_group: lastGroup, sheet_tabs: openTabs, ...(Object.keys(sheetLevels).length ? { sheet_levels: sheetLevels } : {}), ...(Object.keys(provCounters.shapes_deleted).length ? { provenance_counters: provCounters } : {}) };
   };
   // Runtime restore of a saved payload — the Revisions panel's Restore lands
   // here. A runtime load (unlike mount) can interrupt work in
@@ -1451,7 +1466,7 @@ export default function TakeoffCanvas() {
     // state it serializes, so listing buildPayload (a new identity each render)
     // would fire a save on every render instead of only on a real change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shapes, conditions, conditionColumns, shapeLabels, palette, scales, scaleSources, markups, rfis, provCounters, sheetGroup, sheetLevels, lastGroup, openTabs, projectName, clientInfo, units]);
+  }, [shapes, conditions, conditionColumns, shapeLabels, palette, scales, scaleSources, markups, rfis, rules, provCounters, sheetGroup, sheetLevels, lastGroup, openTabs, projectName, clientInfo, units]);
   useEffect(() => { saveStateRef.current = saveState; }, [saveState]);
 
   // Flush a pending debounced save on navigate-away (unmount), and warn before a
@@ -2603,7 +2618,7 @@ export default function TakeoffCanvas() {
     if (!activeCond) { setCommitMsg("Pick or add a condition first."); return; }
     const met = closedMetrics(points);
     // id + created_at are minted by the add command — the ONE creation gate
-    dispatchShape({ type: "add", shapes: [{
+    const res = dispatchShape({ type: "add", shapes: [{
       sheet_id: tp.key, condition_id: activeCond,
       measure_role: asDeduct ? "deduct" : "floor_area",
       verts_norm: points.map(([x, y]) => [(x - tp.xOffset) / tp.img.w, y / tp.img.h]),
@@ -2611,6 +2626,9 @@ export default function TakeoffCanvas() {
       ...(activeLabel ? { label: activeLabel } : {}),
       origin: { method: "manual" },
     }] });
+    // A Cut Out fully inside a same-condition room reads as a correction —
+    // offer to make it a rule (#88). Detection only; nothing applies here.
+    if (asDeduct) maybeOfferRule(res.shapes[res.shapes.length - 1], res.shapes);
   }
   function commitLinear(points, curved = false) {
     if (points.length < 2) return;
@@ -4028,6 +4046,70 @@ export default function TakeoffCanvas() {
   // geometry never rides the contribution wire — no rejection records, no
   // counters, nothing for contribute.js to even see (the D34 cut-line).
   const rejectAgentProposal = (id) => setAgentProposals((ps) => ps.filter((p) => p.id !== id));
+
+  // ── correction rules (#88) — detect → offer → preview → Apply ──────────────
+  // The correction carried information: a deduct hand-drawn fully inside a
+  // same-condition room is "this enclosed thing is not finish area on this
+  // project". detectCandidateRule (lib/rules.ts, pure + tested) decides; the
+  // banner offers; Preview stages candidates as dashed pencil; Apply commits
+  // ONE ruleApply command. Never silent, never model-in-the-loop.
+  function maybeOfferRule(deductShape, allShapes) {
+    const seed = detectCandidateRule(allShapes, deductShape);
+    if (!seed) return;
+    setRuleStage(null);
+    setRuleOffer({ deduct: deductShape, seed, tag: condById[deductShape.condition_id]?.finish_tag || "this condition" });
+  }
+  function previewRule() {
+    if (!ruleOffer) return;
+    const rule = buildRuleFromSeed(ruleOffer.deduct, ruleOffer.seed, ruleOffer.tag, { id: `rule-${mintUuid()}`, now: nowIso() });
+    // sheet data for every OPEN panel with linework + a scale — the rule scans
+    // what the estimator can see and review, nothing off-screen.
+    const sheetData = new Map();
+    for (const p of panels) {
+      if (!p.img?.w) continue;
+      const mo = ensureMask(p.key);
+      const upp = uppFor(p.key);
+      if (!mo || !upp) continue;
+      sheetData.set(p.key, { mask: mo, upp, imgW: p.img.w, imgH: p.img.h });
+    }
+    const candidates = applyRuleToProject(rule, shapes, sheetData);
+    setRuleOffer(null);
+    if (!candidates.length) { setCommitMsg("No other enclosed regions match this rule on the open sheets."); return; }
+    setRuleStage({ rule, candidates, proposed_ts: nowIso() });
+  }
+  function applyStagedRule() {
+    if (!ruleStage) return;
+    const { rule, candidates, proposed_ts } = ruleStage;
+    const ts = nowIso();
+    const made = [];
+    for (const c of candidates) {
+      const tp = panels.find((x) => x.key === c.sheet_id && x.img.w);
+      const upp = uppFor(c.sheet_id);
+      if (!tp || !upp) continue;
+      const ringPx = c.verts_norm.map(([nx, ny]) => [nx * tp.img.w, ny * tp.img.h]);
+      made.push({
+        sheet_id: c.sheet_id, condition_id: rule.seed_condition_id, measure_role: "deduct",
+        verts_norm: c.verts_norm.map((v) => [...v]),
+        computed: { area_sf: +(ringArea(ringPx) * upp * upp).toFixed(2), perimeter_lf: +(closedMetrics(ringPx).perim * upp).toFixed(2) },
+        // rule_v1 origin — every propagated shape traces back to the rule and
+        // the seed correction (the RFC's provenance requirement, verbatim).
+        origin: {
+          method: "rule_v1", actor: "rule", reviewed: true,
+          rule_id: rule.id, seed_shape_id: rule.seed_shape_id,
+          container_shape_id: c.container_shape_id,
+          proposed_ts, accepted_ts: ts,
+          proposed_verts_norm: c.verts_norm.map((v) => [...v]),
+        },
+      });
+    }
+    setRuleStage(null);
+    if (!made.length) return;
+    const res = dispatchShape({ type: "ruleApply", shapes: made });   // ONE command — one undo entry for the whole batch
+    const ids = res.shapes.slice(-made.length).map((s) => s.id);
+    // the rule persists WITH its audit trail — inspectable in the project file
+    setRules((rs) => [...rs.filter((r) => r.id !== rule.id), { ...rule, applied_to: ids }]);
+    setCommitMsg(`Rule applied — ${made.length} deduct${made.length === 1 ? "" : "s"} added (⌘Z undoes all). ${rule.label}.`);
+  }
 
   // ── the accept gate, for shapes already IN the data ─────────────────────────
   // An imported MCP takeoff arrives committed but unreviewed (origin.reviewed
@@ -5806,6 +5888,23 @@ export default function TakeoffCanvas() {
                         </g>
                       );
                     })}
+                    {/* staged rule-propagation candidates (#88): dashed danger
+                        pencil until Apply — the same review-before-ink contract
+                        as agent proposals. Non-interactive on the canvas; the
+                        banner owns Apply/Cancel (ONE decision for the batch,
+                        matching the one-command undo). */}
+                    {ruleStage && ruleStage.candidates.filter((c) => c.sheet_id === p.key).map((c, i) => {
+                      const s = tf.scale;
+                      const pts = c.verts_norm.map(([x, y]) => [x * p.img.w, y * p.img.h]);
+                      return (
+                        <g key={`rulecand-${i}`} style={{ pointerEvents: "none" }}>
+                          <title>{`Rule candidate — −${fa(c.area_sf)} deduct. ${ruleStage.rule.label}.`}</title>
+                          <polygon points={pts.map((q) => q.join(",")).join(" ")}
+                            fill="rgba(176,58,38,.10)" stroke="#b03a26" strokeOpacity={0.9}
+                            strokeWidth={2 / s} strokeDasharray={`${3.5 / s} ${3.5 / s}`} strokeLinejoin="round" />
+                        </g>
+                      );
+                    })}
                   </g>
                 );
               })}
@@ -5911,6 +6010,31 @@ export default function TakeoffCanvas() {
         {commitMsg && (
           <div style={{ position: "absolute", left: "50%", bottom: 14, transform: "translateX(-50%)", maxWidth: "70%", zIndex: 6, pointerEvents: "none", padding: "6px 12px", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", boxShadow: "var(--shadow-1)", fontSize: 12, color: isDangerMsg(commitMsg) ? "var(--c-danger)" : "var(--c-positive)" }}>
             {commitMsg}
+          </div>
+        )}
+        {/* correction-rule banner (#88): offer after a qualifying Cut Out, then
+            the staged batch's Apply/Cancel. Sits above the status line so a
+            commitMsg never hides the decision. Dismiss/Cancel are always one
+            click — a rule is never applied silently. */}
+        {(ruleOffer || ruleStage) && (
+          <div style={{ position: "absolute", left: "50%", bottom: 44, transform: "translateX(-50%)", zIndex: 7, display: "flex", alignItems: "center", gap: 10, padding: "8px 14px", background: "var(--paper-bright)", border: "1.5px dashed var(--c-danger)", boxShadow: "var(--shadow-1)", fontSize: 12.5, color: "var(--ink)", maxWidth: "82%" }}>
+            {ruleOffer ? (<>
+              <span>Make this a rule for all <b>{ruleOffer.tag}</b> rooms? Excludes enclosed regions under <b>{ruleOffer.seed.max_area_sf} SF</b>.</span>
+              <button onClick={previewRule}
+                style={{ padding: "4px 12px", background: "var(--paper-bright)", border: "1.5px solid var(--cobalt)", color: "var(--cobalt)", fontSize: 12, fontWeight: 600, cursor: "pointer", whiteSpace: "nowrap" }}>
+                Preview</button>
+              <button onClick={() => setRuleOffer(null)}
+                style={{ padding: "4px 12px", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", color: "var(--ink-muted)", fontSize: 12, cursor: "pointer" }}>
+                Dismiss</button>
+            </>) : (<>
+              <span><b>{ruleStage.candidates.length}</b> matching region{ruleStage.candidates.length === 1 ? "" : "s"} staged as dashed deducts — {ruleStage.rule.label}.</span>
+              <button onClick={applyStagedRule}
+                style={{ padding: "4px 12px", background: "var(--paper-bright)", border: "1.5px solid var(--cobalt)", color: "var(--cobalt)", fontSize: 12, fontWeight: 600, cursor: "pointer", whiteSpace: "nowrap" }}>
+                Apply {ruleStage.candidates.length}</button>
+              <button onClick={() => setRuleStage(null)}
+                style={{ padding: "4px 12px", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", color: "var(--ink-muted)", fontSize: 12, cursor: "pointer" }}>
+                Cancel</button>
+            </>)}
           </div>
         )}
         {/* live dictation chip (RFC #59 recognizer): top-center, fixed — NOT

--- a/web/test/cloudStore.test.ts
+++ b/web/test/cloudStore.test.ts
@@ -279,7 +279,7 @@ test("loadAnnotations returns the localStore default shape when absent", async (
   const drive = fakeDrive();
   const store = createCloudStore("folder1", drive as any, { local: fakeLocal() as any });
   assert.deepEqual(await store.loadAnnotations(), {
-    schema: ANN_SCHEMA, conditions: [], shapes: [], markups: [], sheets: [], sheet_group: [], last_group: [], sheet_tabs: [],
+    schema: ANN_SCHEMA, conditions: [], shapes: [], markups: [], sheets: [], sheet_group: [], last_group: [], sheet_tabs: [], rules: [],
   });
 });
 

--- a/web/test/rules.test.ts
+++ b/web/test/rules.test.ts
@@ -1,0 +1,154 @@
+// Correction-rule engine tests (#88) — pure geometry, synthetic ring/segment
+// data (no PDF, no DOM). Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildMask, type Point } from "../src/lib/oneclick.ts";
+import {
+  ringContains, ringCentroid, defaultMaxAreaSf, detectCandidateRule,
+  buildRuleFromSeed, findEnclosedRegions, applyRuleToProject,
+  SEED_MAX_SF, RULE_MIN_CAP_SF,
+  type Rule, type RuleShape,
+} from "../src/lib/rules.ts";
+
+// closed rectangle as flat boundary segments (image px)
+function rectSegs(x0: number, y0: number, x1: number, y1: number): number[] {
+  return [
+    x0, y0, x1, y0,
+    x1, y0, x1, y1,
+    x1, y1, x0, y1,
+    x0, y1, x0, y0,
+  ];
+}
+const rectRing = (x0: number, y0: number, x1: number, y1: number): Point[] =>
+  [[x0, y0], [x1, y0], [x1, y1], [x0, y1]];
+const norm = (ring: Point[], w: number, h: number): Point[] => ring.map(([x, y]) => [x / w, y / h]);
+
+// ── the synthetic sheet ──────────────────────────────────────────────────────
+// 1000×800 img px, upp 0.1 ft/px (so 40 px = 4 ft). Two rooms:
+//   A (50,50)-(450,750)  with column a  (200,300)-(240,340)
+//   B (550,50)-(950,750) with column b  (700,300)-(740,340)
+//     and an OPEN box     (800,500)-(840,540) — bottom wall missing, so its
+//     interior connects to the room field and must never be proposed.
+const IMG_W = 1000, IMG_H = 800, UPP = 0.1;
+const segs = [
+  ...rectSegs(50, 50, 450, 750),
+  ...rectSegs(200, 300, 240, 340),
+  ...rectSegs(550, 50, 950, 750),
+  ...rectSegs(700, 300, 740, 340),
+  // open box: top, left, right — no bottom
+  800, 500, 840, 500,
+  800, 500, 800, 540,
+  840, 500, 840, 540,
+];
+const mask = buildMask(segs, IMG_W, IMG_H);
+
+const roomA: RuleShape = { id: "shp-roomA", sheet_id: "S1", condition_id: "C1", measure_role: "floor_area", verts_norm: norm(rectRing(50, 50, 450, 750), IMG_W, IMG_H), computed: { area_sf: 2800 } };
+const roomB: RuleShape = { id: "shp-roomB", sheet_id: "S1", condition_id: "C1", measure_role: "floor_area", verts_norm: norm(rectRing(550, 50, 950, 750), IMG_W, IMG_H), computed: { area_sf: 2800 } };
+// the estimator's correction: a deduct hand-drawn over column a (slightly loose)
+const seedDeduct: RuleShape = { id: "shp-seed", sheet_id: "S1", condition_id: "C1", measure_role: "deduct", verts_norm: norm(rectRing(198, 298, 242, 342), IMG_W, IMG_H), computed: { area_sf: 19.4 } };
+
+const sheetData = new Map([["S1", { mask, upp: UPP, imgW: IMG_W, imgH: IMG_H }]]);
+
+test("ringContains: full containment true, overlap/outside false", () => {
+  const outer = rectRing(0, 0, 100, 100);
+  assert.equal(ringContains(outer, rectRing(20, 20, 40, 40)), true);
+  assert.equal(ringContains(outer, rectRing(80, 80, 120, 120)), false);
+  assert.equal(ringContains(outer, rectRing(200, 200, 220, 220)), false);
+});
+
+test("defaultMaxAreaSf: floors at the RFC's 25 SF, rounds bigger seeds up to 5", () => {
+  assert.equal(defaultMaxAreaSf(4), RULE_MIN_CAP_SF);
+  assert.equal(defaultMaxAreaSf(25), 25);
+  assert.equal(defaultMaxAreaSf(26), 30);
+  assert.equal(defaultMaxAreaSf(60), 60);
+  assert.equal(defaultMaxAreaSf(61), 65);
+});
+
+test("detectCandidateRule: deduct inside same-condition room on same sheet fires", () => {
+  const hit = detectCandidateRule([roomA, roomB, seedDeduct], seedDeduct);
+  assert.ok(hit);
+  assert.equal(hit.container_shape_id, "shp-roomA");
+  assert.equal(hit.max_area_sf, RULE_MIN_CAP_SF); // 19.4 SF seed → 25 SF floor
+  assert.equal(hit.seed_area_sf, 19.4);
+});
+
+test("detectCandidateRule: stays silent on the ambiguous cases", () => {
+  // different condition — not this rule's scope
+  const otherCond = { ...seedDeduct, id: "d2", condition_id: "C2" };
+  assert.equal(detectCandidateRule([roomA, otherCond], otherCond), null);
+  // different sheet
+  const otherSheet = { ...seedDeduct, id: "d3", sheet_id: "S9" };
+  assert.equal(detectCandidateRule([roomA, otherSheet], otherSheet), null);
+  // not contained (straddles the room edge)
+  const straddle = { ...seedDeduct, id: "d4", verts_norm: norm(rectRing(430, 300, 470, 340), IMG_W, IMG_H) };
+  assert.equal(detectCandidateRule([roomA, straddle], straddle), null);
+  // room-scale deduct — a boundary correction, not a column rule
+  const huge = { ...seedDeduct, id: "d5", verts_norm: norm(rectRing(100, 100, 400, 500), IMG_W, IMG_H), computed: { area_sf: SEED_MAX_SF + 1 } };
+  assert.equal(detectCandidateRule([roomA, huge], huge), null);
+  // not a deduct at all
+  assert.equal(detectCandidateRule([roomA, seedDeduct], roomA), null);
+});
+
+test("buildRuleFromSeed: traceable, plain-language, inactive nothing", () => {
+  const seed = detectCandidateRule([roomA, seedDeduct], seedDeduct)!;
+  const rule = buildRuleFromSeed(seedDeduct, seed, "CPT-1", { id: "rule-1", now: "2026-07-25T00:00:00.000Z" });
+  assert.equal(rule.seed_shape_id, "shp-seed");
+  assert.equal(rule.seed_condition_id, "C1");
+  assert.equal(rule.predicate.kind, "enclosed_subpolygon_deduct");
+  assert.equal(rule.predicate.max_area_sf, 25);
+  assert.match(rule.label, /under 25 SF/);
+  assert.match(rule.label, /CPT-1/);
+  assert.equal(rule.active, true);
+  assert.deepEqual(rule.applied_to, []);
+});
+
+test("findEnclosedRegions: finds the column island, skips the room field and the open box", () => {
+  const ringB = rectRing(550, 50, 950, 750);
+  const maxCells = Math.floor(25 / (UPP / mask.ws) ** 2); // 25 SF in mask cells
+  const found = findEnclosedRegions(mask, ringB, maxCells);
+  assert.equal(found.length, 1);
+  const c = ringCentroid(found[0]);
+  assert.ok(c[0] > 700 && c[0] < 740 && c[1] > 300 && c[1] < 340, `centroid ${c} should sit in column b`);
+});
+
+test("applyRuleToProject: propagates to the other room only, dedups the seeded one", () => {
+  const seed = detectCandidateRule([roomA, roomB, seedDeduct], seedDeduct)!;
+  const rule = buildRuleFromSeed(seedDeduct, seed, "CPT-1", { id: "rule-1", now: "2026-07-25T00:00:00.000Z" });
+  const candidates = applyRuleToProject(rule, [roomA, roomB, seedDeduct], sheetData);
+  // room A's column is already covered by the seed deduct; room B's is not
+  assert.equal(candidates.length, 1);
+  const c = candidates[0];
+  assert.equal(c.sheet_id, "S1");
+  assert.equal(c.container_shape_id, "shp-roomB");
+  assert.ok(c.area_sf > 10 && c.area_sf <= 25, `area ${c.area_sf} should be column-sized under the cap`);
+  const cen = ringCentroid(c.verts_norm.map(([nx, ny]) => [nx * IMG_W, ny * IMG_H] as Point));
+  assert.ok(cen[0] > 700 && cen[0] < 740 && cen[1] > 300 && cen[1] < 340, `centroid ${cen} should sit in column b`);
+});
+
+test("applyRuleToProject: idempotent — accepted candidates never re-propose", () => {
+  const seed = detectCandidateRule([roomA, roomB, seedDeduct], seedDeduct)!;
+  const rule = buildRuleFromSeed(seedDeduct, seed, "CPT-1", { id: "rule-1", now: "2026-07-25T00:00:00.000Z" });
+  const first = applyRuleToProject(rule, [roomA, roomB, seedDeduct], sheetData);
+  const committed: RuleShape = {
+    id: "shp-propagated", sheet_id: first[0].sheet_id, condition_id: "C1",
+    measure_role: "deduct", verts_norm: first[0].verts_norm, computed: { area_sf: first[0].area_sf },
+  };
+  const second = applyRuleToProject(rule, [roomA, roomB, seedDeduct, committed], sheetData);
+  assert.equal(second.length, 0);
+});
+
+test("applyRuleToProject: inactive rules and unknown predicate kinds do nothing", () => {
+  const seed = detectCandidateRule([roomA, roomB, seedDeduct], seedDeduct)!;
+  const rule = buildRuleFromSeed(seedDeduct, seed, "CPT-1", { id: "rule-1", now: "2026-07-25T00:00:00.000Z" });
+  assert.deepEqual(applyRuleToProject({ ...rule, active: false }, [roomA, roomB], sheetData), []);
+  const alien = { ...rule, predicate: { kind: "layer_snap", max_area_sf: 25 } } as unknown as Rule;
+  assert.deepEqual(applyRuleToProject(alien, [roomA, roomB], sheetData), []);
+});
+
+test("applyRuleToProject: sheets without data are skipped, not crashed on", () => {
+  const seed = detectCandidateRule([roomA, roomB, seedDeduct], seedDeduct)!;
+  const rule = buildRuleFromSeed(seedDeduct, seed, "CPT-1", { id: "rule-1", now: "2026-07-25T00:00:00.000Z" });
+  const elsewhere: RuleShape = { ...roomB, id: "shp-roomC", sheet_id: "S2" };
+  const candidates = applyRuleToProject(rule, [roomA, roomB, elsewhere, seedDeduct], sheetData);
+  assert.equal(candidates.length, 1);   // still just room B — S2 has no mask data
+});

--- a/web/test/shapeCommands.test.ts
+++ b/web/test/shapeCommands.test.ts
@@ -319,3 +319,32 @@ test("review: an empty or all-non-pending id set is a no-op with an empty restor
   assert.deepEqual(r.shapes, shapes);
   assert.deepEqual(r.inverse, { type: "review", restore: [] });
 });
+
+// ── ruleApply (#88) ──────────────────────────────────────────────────────────
+
+test("ruleApply: add semantics — mints ids/created_at, one noCount-delete inverse for the batch", () => {
+  const base = [manualShape()];
+  const drafts = [1, 2].map((i) => ({
+    sheet_id: "a.pdf#1", condition_id: "cnd-1", measure_role: "deduct",
+    verts_norm: [[0.1 * i, 0.1], [0.2 * i, 0.1], [0.2 * i, 0.2]],
+    computed: { area_sf: 12.5 },
+    origin: {
+      method: "rule_v1", actor: "rule", reviewed: true,
+      rule_id: "rule-1", seed_shape_id: "shp-seed",
+      proposed_ts: "2026-07-25T00:00:00.000Z", accepted_ts: "2026-07-25T00:00:01.000Z",
+    },
+  }));
+  const fwd = roundTrip(base, { type: "ruleApply", shapes: drafts.map(clone) });
+  assert.equal(fwd.shapes.length, 3);
+  const added = fwd.shapes.slice(1);
+  for (const s of added) {
+    assert.match(s.id, /^shp-/);
+    assert.match(s.created_at, ISO);
+    assert.equal(s.origin.method, "rule_v1");
+    assert.equal(s.origin.rule_id, "rule-1");                      // every propagated shape traces to its rule
+    assert.equal(s.origin.seed_shape_id, "shp-seed");              // …and to the correction that seeded it
+    assert.equal(s.origin.reviewed, true);
+  }
+  // ONE inverse deletes the whole batch, and never feeds the deletion counters
+  assert.deepEqual(fwd.inverse, { type: "delete", ids: added.map((s) => s.id), noCount: true });
+});


### PR DESCRIPTION
## Summary
Implements RFC #88's v1: the literal seed case (an estimator subtracts an enclosed cutout from a room) becomes a deterministic, re-runnable, inspectable rule — no model in the loop, nothing applied silently, every propagated shape traceable to its seed correction.

**Flow**: draw a Cut Out fully inside a same-condition `floor_area` room → banner offers *"Make this a rule for all {condition} rooms? Excludes enclosed regions under {N} SF"* → **Preview** stages matching enclosed linework islands across the project's rooms as dashed danger pencil → explicit **Apply** commits ONE command.

- **`web/src/lib/rules.ts`** (pure, 10 tests): `detectCandidateRule` (containment + size gates — a room-scale deduct is a boundary correction, not a column rule, and stays silent per the RFC's ambiguity warning), `buildRuleFromSeed`, `findEnclosedRegions` (closed linework islands inside a room ring, using One-Click's own mask raster; regions connected to the room field — door bays, alcoves — never match), `applyRuleToProject` (idempotent — anything an existing deduct covers is dropped, so re-running proposes nothing twice).
- **`shapeCommands.js`**: new `ruleApply` command type with its `PROVENANCE_POLICY` row — add semantics, one undo entry for the whole batch. Origin per shape: `method: rule_v1`, `rule_id`, `seed_shape_id`, `container_shape_id`, frozen `proposed_verts_norm`, propose/accept timestamps.
- **Persistence**: `rules: []` joins the project annotations (`emptyAnnotations`/`buildPayload`/hydrate); each rule stores its predicate, plain-language label, seed ids, and `applied_to` audit trail. Project-scoped only per the RFC's boundary — not on the MCP export or contribution wire.

## Verified live (IA2.01 sample)
Traced 2 rooms + hand-drew a seed deduct → banner fired → Preview staged **37** enclosed regions across 3 CPT-1 rooms → Apply landed all 37 as one command (totals 282.9 → 213.5 SF) → **one ⌘Z removed the whole batch**, ⇧⌘Z restored it → provenance and `rules[]` round-tripped through IndexedDB and a full reload. Detection negative cases (other condition, other sheet, straddling ring, room-scale deduct) unit-tested.

## Honest v1 caveats (for review)
- The predicate matches **every** closed sub-polygon under the cap — including room-tag label boxes and sub-1-SF fixture slivers. That's the predicate being honest; the explicit Preview→Apply gate is the safety. The real discriminator is layer-aware scoping (*"bounded by structure-layer paths"*), which the RFC itself gates on #85 — deferred. A minimum-area floor (e.g. 1 SF) is a one-line tunable if wanted before then.
- Propagation scans sheets **open in the current view** (mask data lives per open panel); the banner copy says so.
- Rule detection hooks the manual Cut Out flow; One-Click's ⌥-carve deducts don't offer a rule yet (same seam, small follow-up).
- No rule-management UI yet — rules are inspectable in the project file; delta kinds beyond enclosed-subpolygon (boundary snap class, threshold nudges) and cross-rule conflict ordering are future RFC slices.

## Checks
`typecheck` / `lint` / `build` green; 946/950 tests pass locally — the 4 failures are the known Node-25-vs-pinned-24 localStorage quirk, present on clean `main`.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)