### PR TITLE
fix(tiles): spend the base budget, cap render depth — kill the deep-zoom pixelation

### DIFF
--- a/web/src/lib/tileCompositor.ts
+++ b/web/src/lib/tileCompositor.ts
@@ -50,7 +50,7 @@
 
 import { RENDER_SCALE } from "./sheets";
 import { createTilePool } from "./tilePool";
-import { TileLRU, buildLevels, pickLevel, levelDims, visibleTiles, tileKey as rawTileKey, TILE_SIZE } from "./tiles";
+import { TileLRU, buildLevels, pickLevel, levelDims, visibleTiles, visibleTilesAtDensity, fitDensity, BASE_LEVEL, tileKey as rawTileKey, TILE_SIZE } from "./tiles";
 
 // ~450MB shared across every open sheet/panel — the old per-group ceiling
 // ("4-up ≈ 450MB" per canvasConstants.js), now a BUDGET instead of a floor
@@ -67,6 +67,12 @@ const BASE_TARGET_AREA = 28_000_000;
 // one slow/stuck tile hold the whole reveal hostage — a progressive fallback,
 // not the common case once tilePool.ts's real parallelism is in place.
 const REVEAL_GRACE_MS = 350;
+// Most tiles one detail crop may queue. A 512² tile costs roughly a full
+// page-operator replay regardless of how little of the page lands in it, so
+// crop cost scales with tile COUNT, and a crop the pool can't drain is a crop
+// the user never sees. Sized so a full-viewport crop drains in a couple of
+// passes across the pool rather than tying it up indefinitely.
+const MAX_CROP_TILES = 48;
 
 function modeKey(key: string, dark: boolean) { return `${key}:${dark ? 1 : 0}`; }
 
@@ -103,6 +109,9 @@ export function createTileCompositor() {
   const inflightReqs = new Map<string, { cancel: () => void; promise: Promise<ImageBitmap | undefined> }>();
   const levelsBySheet = new Map<string, number[]>();
   const dimsBySheet = new Map<string, { w: number; h: number }>();
+  // exact-fit density the BASE composite was painted at, per sheet — the
+  // placeholder search needs it to rank the base against the pyramid levels
+  const baseDensityBySheet = new Map<string, number>();
   const opened = new Set<string>();
   // Every tile request awaits this before hitting the worker — dataPromise
   // (an IndexedDB read) resolves well after openSheet() returns, so without
@@ -184,7 +193,14 @@ export function createTileCompositor() {
         if (myGen !== generation) { bitmap.close(); return undefined; } // superseded by resetAll
         cache.set(key, bitmap, w * h * 4);
         return bitmap;
-      } catch {
+      } catch (err) {
+        // A failed tile silently degrades to "placeholder forever" on screen,
+        // which reads as blur rather than as breakage — the #86 pixelation
+        // hunt cost a day precisely because this catch was bare. Cancellation
+        // is routine and stays quiet; a genuine render failure must not.
+        if (!(err as Error)?.message?.includes("Rendering cancelled")) {
+          console.warn(`[tiles] level ${level} tile ${tx},${ty} failed:`, err);
+        }
         return undefined;
       }
     })();
@@ -194,27 +210,14 @@ export function createTileCompositor() {
     return run;
   }
 
-  /** Densest level whose full-sheet composite still fits BASE_TARGET_AREA —
-   *  the old codebase's own raster budget, just expressed as a pyramid level
-   *  instead of a single canvas size. */
-  function baseTargetLevel(levels: number[], imgW: number, imgH: number): number {
-    let best = 0;
-    for (let i = 0; i < levels.length; i++) {
-      const { w, h } = levelDims(imgW, imgH, levels[i]);
-      if (w * h > BASE_TARGET_AREA) break; // densities only increase — first overshoot ends the search
-      best = i;
-    }
-    return best;
-  }
-
-  /** Renders the WHOLE sheet at `level` into an off-DOM buffer, then swaps it
-   *  into `canvas` atomically (same "compose off-screen, one reveal" rule as
-   *  paintDetail — a ~28MP base composite can be 100+ tiles, and painting
-   *  those onto the visible canvas one at a time would be its own wave). */
-  async function paintBaseAtLevel(canvas: HTMLCanvasElement, sheetKey: string, imgW: number, imgH: number, levels: number[], level: number, dark: boolean, myGen: number) {
-    const density = levels[level];
+  /** Renders the WHOLE sheet at `density` into an off-DOM buffer, then swaps
+   *  it into `canvas` atomically (same "compose off-screen, one reveal" rule
+   *  as paintDetail — a ~28MP base composite can be 100+ tiles, and painting
+   *  those onto the visible canvas one at a time would be its own wave).
+   *  `level` is the cache-key id only; it need not index `levels`. */
+  async function paintBaseAtLevel(canvas: HTMLCanvasElement, sheetKey: string, imgW: number, imgH: number, density: number, level: number, dark: boolean, myGen: number) {
     const { w: lw, h: lh } = levelDims(imgW, imgH, density);
-    const tiles = visibleTiles(imgW, imgH, levels, level, 0, 0, imgW, imgH);
+    const tiles = visibleTilesAtDensity(imgW, imgH, density, level, 0, 0, imgW, imgH);
     const back = document.createElement("canvas");
     back.width = lw; back.height = lh;
     const bctx = back.getContext("2d");
@@ -239,21 +242,34 @@ export function createTileCompositor() {
   async function paintBase(canvas: HTMLCanvasElement, sheetKey: string, imgW: number, imgH: number, dark: boolean) {
     const levels = levelsFor(sheetKey, imgW, imgH);
     const myGen = generation;
-    await paintBaseAtLevel(canvas, sheetKey, imgW, imgH, levels, 0, dark, myGen);
+    await paintBaseAtLevel(canvas, sheetKey, imgW, imgH, levels[0], 0, dark, myGen);
     if (myGen !== generation) return;
-    const target = baseTargetLevel(levels, imgW, imgH);
-    if (target > 0) await paintBaseAtLevel(canvas, sheetKey, imgW, imgH, levels, target, dark, myGen);
+    // Phase 2 at the EXACT budget density, not the nearest level under it —
+    // see fitDensity for the 37%-of-budget shortfall that snapping caused.
+    const bd = fitDensity(imgW, imgH, BASE_TARGET_AREA);
+    baseDensityBySheet.set(sheetKey, bd);
+    if (bd > levels[0]) await paintBaseAtLevel(canvas, sheetKey, imgW, imgH, bd, BASE_LEVEL, dark, myGen);
   }
 
-  /** Best coarser level fully cached for this region — the instant
-   *  placeholder drawn under the target level while its tiles stream in. */
-  function bestPlaceholderLevel(sheetKey: string, levels: number[], target: number, x0: number, y0: number, x1: number, y1: number, dark: boolean) {
+  /** Densest fully-cached stand-in for this region — drawn under the target
+   *  level while its tiles stream in. Considers the BASE composite alongside
+   *  the coarser pyramid levels: the base sits at the exact budget density
+   *  (~0.82 on an E-size sheet), denser than any power-of-two level under 1,
+   *  so at deep zoom it is both the best available placeholder AND the thing
+   *  the user actually stares at while the target level renders. */
+  function bestPlaceholder(sheetKey: string, levels: number[], target: number, x0: number, y0: number, x1: number, y1: number, dark: boolean): { level: number; density: number } {
     const dims = dimsBySheet.get(sheetKey)!;
-    for (let l = target - 1; l >= 0; l--) {
-      const tiles = visibleTiles(dims.w, dims.h, levels, l, x0, y0, x1, y1);
-      if (tiles.length && tiles.every((t) => cache.has(modeKey(rawTileKey(sheetKey, l, t.tx, t.ty), dark)))) return l;
-    }
-    return 0; // level 0 is always fetched by paintBase — safe fallback even if not yet cached (draws nothing, not a crash)
+    const cached = (level: number, density: number) => {
+      const tiles = visibleTilesAtDensity(dims.w, dims.h, density, level, x0, y0, x1, y1);
+      return tiles.length > 0 && tiles.every((t) => cache.has(modeKey(rawTileKey(sheetKey, level, t.tx, t.ty), dark)));
+    };
+    const baseDensity = baseDensityBySheet.get(sheetKey);
+    const candidates: { level: number; density: number }[] = [];
+    for (let l = target - 1; l >= 0; l--) candidates.push({ level: l, density: levels[l] });
+    if (baseDensity !== undefined && baseDensity < levels[target]) candidates.push({ level: BASE_LEVEL, density: baseDensity });
+    candidates.sort((a, b) => b.density - a.density); // densest stand-in first
+    for (const c of candidates) if (cached(c.level, c.density)) return c;
+    return { level: 0, density: levels[0] }; // always fetched by paintBase — safe even if not yet cached (draws nothing, not a crash)
   }
 
   /** Paints [x0,y0,x1,y1) (image px, margin already applied by the caller)
@@ -276,7 +292,13 @@ export function createTileCompositor() {
     const dims = dimsBySheet.get(sheetKey);
     const levels = levelsBySheet.get(sheetKey);
     if (!dims || !levels) return { cancel() {} };
-    const level = pickLevel(levels, density);
+    // Step down until the crop is a number of tiles the pool can actually
+    // finish. Without this the level is chosen purely from screen density, so
+    // a deep zoom on a big sheet queues a crop that never completes and the
+    // user is left on the placeholder indefinitely — blur with no recovery
+    // path, which is strictly worse than one level softer that ARRIVES.
+    let level = pickLevel(levels, density);
+    while (level > 0 && visibleTilesAtDensity(dims.w, dims.h, levels[level], level, x0, y0, x1, y1).length > MAX_CROP_TILES) level--;
     const targetDensity = levels[level];
     const bw = Math.max(1, Math.round((x1 - x0) * targetDensity));
     const bh = Math.max(1, Math.round((y1 - y0) * targetDensity));
@@ -290,9 +312,8 @@ export function createTileCompositor() {
     const bctx = back.getContext("2d");
     if (!bctx) return { cancel() {} };
 
-    const placeholderLevel = bestPlaceholderLevel(sheetKey, levels, level, x0, y0, x1, y1, dark);
-    const phDensity = levels[placeholderLevel];
-    const phTiles = visibleTiles(dims.w, dims.h, levels, placeholderLevel, x0, y0, x1, y1);
+    const { level: placeholderLevel, density: phDensity } = bestPlaceholder(sheetKey, levels, level, x0, y0, x1, y1, dark);
+    const phTiles = visibleTilesAtDensity(dims.w, dims.h, phDensity, placeholderLevel, x0, y0, x1, y1);
     for (const t of phTiles) {
       const bmp = cache.get(modeKey(rawTileKey(sheetKey, placeholderLevel, t.tx, t.ty), dark)) as ImageBitmap | undefined;
       if (!bmp) continue;

--- a/web/src/lib/tiles.ts
+++ b/web/src/lib/tiles.ts
@@ -23,7 +23,37 @@ export const TILE_SIZE = 512;
 export const MIN_LEVEL_PX = 768;
 // Reuses the old QUALITY_CEILING's intent (≈576 px/in-equivalent deep zoom)
 // as the top of the pyramid, relative to the RENDER_SCALE=2 logical baseline.
-export const MAX_DENSITY = 8;
+// That intent works out to 4, not 8: 576 px/in ÷ 72 pt/in = 8 device px per
+// POINT, and the logical space is already 2 px per point (RENDER_SCALE), so
+// the density multiplier on top of it is 8/2 = 4. Shipping 8 asked pdf.js to
+// render each tile at scale RENDER_SCALE×8 = 16 — a >100k-px viewport on an
+// E-size sheet — and quadrupled the tile count for the same crop. Measured on
+// the hosted demo at 259% zoom: not one level-8 tile ever completed (no
+// error, they simply never finished), so the detail layer sat on the base
+// placeholder upscaled 16× — the "so so pixelated" report. Deep zoom is
+// exactly where a tile must still be CHEAP, because that's where the pyramid
+// has the most tiles to produce.
+export const MAX_DENSITY = 4;
+
+/** Level id for the whole-sheet BASE composite. Deliberately outside the
+ *  pyramid's 0..n index range so its cache keys can never collide with a
+ *  real level's — the base is rendered at its own exact-fit density (see
+ *  fitDensity), not at a power-of-two level. */
+export const BASE_LEVEL = -1;
+
+/** The exact density whose full-sheet composite hits `targetArea` device px.
+ *  The pyramid is power-of-two, so snapping a budget DOWN to a level wastes
+ *  most of it: on a 7920×5280 sheet a 28MP budget admits density 0.818, but
+ *  the nearest level at-or-under is 0.5 — 10.4MP, 37% of the budget and a
+ *  1.6× LINEAR regression against the single raster this replaced. The base
+ *  layer is whatever a fast pan and any zoom past the pyramid's top actually
+ *  shows, so that shortfall is visible constantly. Never denser than 1.0:
+ *  past the RENDER_SCALE baseline there is no more detail to recover, only
+ *  supersampling a whole sheet nobody asked for. */
+export function fitDensity(imgW: number, imgH: number, targetArea: number): number {
+  const area = Math.max(1, imgW * imgH);
+  return Math.min(1, Math.sqrt(targetArea / area));
+}
 
 /** Density multiplier for each level, ascending, level index = array index.
  *  Always includes 1.0 (the native baseline) as a level boundary so pickLevel
@@ -74,7 +104,16 @@ export function visibleTiles(
   imgW: number, imgH: number, levels: number[], level: number,
   x0: number, y0: number, x1: number, y1: number,
 ): VisibleTile[] {
-  const density = levels[level];
+  return visibleTilesAtDensity(imgW, imgH, levels[level], level, x0, y0, x1, y1);
+}
+
+/** visibleTiles for a density that is NOT a pyramid level — the base layer's
+ *  exact-fit density. `level` is carried through untouched purely as the id
+ *  the caller will key the cache on (BASE_LEVEL for the base). */
+export function visibleTilesAtDensity(
+  imgW: number, imgH: number, density: number, level: number,
+  x0: number, y0: number, x1: number, y1: number,
+): VisibleTile[] {
   const { w: levelW, h: levelH } = levelDims(imgW, imgH, density);
   const lx0 = Math.max(0, Math.floor(x0 * density));
   const ly0 = Math.max(0, Math.floor(y0 * density));

--- a/web/test/tiles.test.ts
+++ b/web/test/tiles.test.ts
@@ -2,8 +2,53 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   TILE_SIZE, MAX_DENSITY, buildLevels, pickLevel, levelDims, tileGrid,
-  tileKey, tileRect, visibleTiles, requiredDensity, TileLRU,
+  tileKey, tileRect, visibleTiles, visibleTilesAtDensity, fitDensity,
+  BASE_LEVEL, requiredDensity, TileLRU,
 } from "../src/lib/tiles.ts";
+
+// The E-size sheet the 259%-zoom pixelation was measured on: 3960x2640 pt at
+// RENDER_SCALE=2. Its whole-sheet area (41.8MP) sits just above the 28MP base
+// budget, which is exactly the case power-of-two snapping handled worst.
+const E_W = 7920, E_H = 5280;
+const BASE_TARGET_AREA = 28_000_000;
+
+test("fitDensity spends the base budget instead of snapping down a level", () => {
+  const d = fitDensity(E_W, E_H, BASE_TARGET_AREA);
+  const { w, h } = levelDims(E_W, E_H, d);
+  // fills the budget (within a rounding pixel), rather than the 10.4MP that
+  // the nearest power-of-two level at-or-under the budget would have given
+  assert.ok(w * h <= BASE_TARGET_AREA * 1.001, `over budget: ${w * h}`);
+  assert.ok(w * h >= BASE_TARGET_AREA * 0.99, `under budget: ${w * h}`);
+  const snapped = buildLevels(E_W, E_H).filter((l) => {
+    const dim = levelDims(E_W, E_H, l); return dim.w * dim.h <= BASE_TARGET_AREA;
+  }).pop()!;
+  assert.ok(d > snapped, `exact fit ${d} should beat snapped level ${snapped}`);
+  assert.ok(d / snapped > 1.5, `expected a >1.5x linear gain, got ${d / snapped}`);
+});
+
+test("fitDensity never supersamples past the RENDER_SCALE baseline", () => {
+  // a small sheet whose whole page fits the budget many times over
+  assert.equal(fitDensity(1000, 800, BASE_TARGET_AREA), 1);
+});
+
+test("MAX_DENSITY keeps the deepest pdf.js render scale affordable", () => {
+  // RENDER_SCALE (2) x MAX_DENSITY is the scale a tile is rendered at; 8 put
+  // an E-size sheet's viewport past 100k px per tile and nothing completed
+  assert.ok(MAX_DENSITY <= 4, `MAX_DENSITY ${MAX_DENSITY} is too deep to render`);
+  assert.ok(Math.max(E_W, E_H) * 2 * MAX_DENSITY <= 70_000);
+});
+
+test("visibleTilesAtDensity carries a non-level id through for cache keying", () => {
+  const tiles = visibleTilesAtDensity(E_W, E_H, fitDensity(E_W, E_H, BASE_TARGET_AREA), BASE_LEVEL, 0, 0, E_W, E_H);
+  assert.ok(tiles.length > 0);
+  assert.ok(tiles.every((t) => t.level === BASE_LEVEL));
+  // and it agrees with the level-indexed path when handed a real level
+  const levels = buildLevels(E_W, E_H);
+  assert.deepEqual(
+    visibleTilesAtDensity(E_W, E_H, levels[1], 1, 0, 0, E_W, E_H),
+    visibleTiles(E_W, E_H, levels, 1, 0, 0, E_W, E_H),
+  );
+});
 
 test("buildLevels always includes native (1.0) and tops out at MAX_DENSITY", () => {
   const levels = buildLevels(5000, 3000);


### PR DESCRIPTION
Deep zoom went pixelated after #86/#107. This is the measurement and the fix.

## What was measured

Hosted demo, real foreground tab, E-size sheet (3960×2640 pt → 41.8MP at `RENDER_SCALE=2`), 259% zoom, dpr 2:

- detail layer minimum feature width: **16 device px**, unchanged after 60s idle, **zero** worker errors
- 16 = `targetDensity(8) / base density(0.5)` — the base composite upscaled 16×, permanently

The detail canvas was correctly *sized* the whole time (backing/CSS ratio tracked `density/stageScale` exactly). It was correctly sized and filled with placeholder.

## Two causes

**1. The base was spending 37% of its budget.** #107 aimed at ~28MP parity with the old single raster, then chose the densest **power-of-two** level at-or-under the budget. On this sheet: density 0.5 → 10.4MP (fits), density 1 → 41.8MP (busts). It settled for 10.4MP — a **1.6× linear regression against the raster it replaced.** `fitDensity()` renders the base at the exact density that fills the budget. This is not a margin case: the base is what a fast pan and any zoom past the pyramid's top actually show.

**2. `MAX_DENSITY` was 2× its own documented intent.** The comment defines the ceiling as ≈576 px/in-equivalent over the `RENDER_SCALE=2` baseline — that is `576/72/2 = 4`, not 8. At 8, each tile asked pdf.js for scale 16 (a >100,000-px viewport) and a crop needed ~78 tiles instead of ~21. Nothing completed. A tile that never lands degrades to "placeholder forever," which reads as blur rather than as breakage.

## Also

- `MAX_CROP_TILES` steps the detail level down until the crop is something the pool can drain. One level softer that **arrives** beats a perfect level that doesn't.
- `bestPlaceholder()` ranks the base composite against the pyramid levels instead of only searching below the target — at the exact budget density the base is denser than any power-of-two level under 1.
- `getOrFetchTile`'s bare `catch {}` now warns. That silence is why this cost a day to find.

## Verification

Real foreground tab, both sheets crisp at **305%**, with **~4× less canvas memory and ~4× fewer tiles** than `main` for visually equivalent output:

| | main (old) | this PR |
|---|---|---|
| detail density at ~300% | 8 | 4 |
| detail backing | 11.0 MP | 2.5 MP |
| tiles per crop | ~78 | ~21 |

`tiles.test.ts` 19/19 (4 new). `typecheck`, `lint`, `build` all clean. (`reportTheme.test.ts` fails identically on `main` — Node 25 vs pinned 24, pre-existing.)

**This also answers #105's open question:** canvases do **not** stop compositing above 140–160%. Verified live at 259% and 305% on a real foreground screen — that was the test rig, exactly as the author suspected.

## Honest gap

Not verified end-to-end against the specific E-size sheet the failure was measured on — that PDF exists only in a browser profile, not on disk. Every sheet available locally renders fine on `main` too, so the A/B here shows *equivalent output for a quarter of the work*, not a before/after of the failure itself. The fix targets the failing mechanism directly, but that last hop is inference. Worth one look at that sheet on the deploy preview before merging.