### PR TITLE
fix(tiles): render the detail crop ONCE at screen density — real sharpness at any zoom

### DIFF
--- a/web/src/lib/tileCompositor.ts
+++ b/web/src/lib/tileCompositor.ts
@@ -67,12 +67,19 @@ const BASE_TARGET_AREA = 28_000_000;
 // one slow/stuck tile hold the whole reveal hostage — a progressive fallback,
 // not the common case once tilePool.ts's real parallelism is in place.
 const REVEAL_GRACE_MS = 350;
-// Most tiles one detail crop may queue. A 512² tile costs roughly a full
-// page-operator replay regardless of how little of the page lands in it, so
-// crop cost scales with tile COUNT, and a crop the pool can't drain is a crop
-// the user never sees. Sized so a full-viewport crop drains in a couple of
-// passes across the pool rather than tying it up indefinitely.
-const MAX_CROP_TILES = 48;
+// Sanity ceiling on ONE detail crop's backing store. In normal use the crop
+// is viewport*dpr — about 8MP — at every zoom, because zooming in shrinks the
+// image-space region by exactly the factor it raises the density. This only
+// engages for an abnormally large panel (a huge display, or a margin far
+// wider than the viewport), and it is a backstop, not a quality knob: at the
+// sizes real screens produce it never binds.
+const MAX_CROP_AREA = 40_000_000;
+
+/** Density ceiling for a crop of this image-space size, from MAX_CROP_AREA. */
+function cropDensityCap(iw: number, ih: number): number {
+  const area = Math.max(1, iw * ih);
+  return Math.sqrt(MAX_CROP_AREA / area);
+}
 
 function modeKey(key: string, dark: boolean) { return `${key}:${dark ? 1 : 0}`; }
 
@@ -292,14 +299,23 @@ export function createTileCompositor() {
     const dims = dimsBySheet.get(sheetKey);
     const levels = levelsBySheet.get(sheetKey);
     if (!dims || !levels) return { cancel() {} };
-    // Step down until the crop is a number of tiles the pool can actually
-    // finish. Without this the level is chosen purely from screen density, so
-    // a deep zoom on a big sheet queues a crop that never completes and the
-    // user is left on the placeholder indefinitely — blur with no recovery
-    // path, which is strictly worse than one level softer that ARRIVES.
-    let level = pickLevel(levels, density);
-    while (level > 0 && visibleTilesAtDensity(dims.w, dims.h, levels[level], level, x0, y0, x1, y1).length > MAX_CROP_TILES) level--;
-    const targetDensity = levels[level];
+    // The detail crop is rendered ONCE, at exactly the density the screen
+    // asks for — no pyramid snapping, no density ceiling.
+    //
+    // The pyramid was the wrong tool here. A crop at full sharpness is
+    // (viewport/zoom) image px at (zoom*dpr) density, and those cancel: it is
+    // viewport*dpr device px at EVERY zoom — a constant ~8MP, whether you are
+    // at 50% or 1600%. Tiling that constant into 512² pieces doesn't make it
+    // cheaper, it makes it ~36x more expensive, because pdf.js replays the
+    // whole page operator list per render regardless of how little of the page
+    // lands in the target canvas. That is why deep-zoom tiles never completed,
+    // which is why #108 lowered MAX_DENSITY to 4, which capped sharpness at
+    // 200% zoom on a dpr-2 screen and produced visible pixel-doubling (2.08x
+    // measured at 417%). One render removes the cause instead of trading one
+    // blur for another. Tiles remain exactly right for the BASE layer: a
+    // whole-sheet composite, built once, where the pyramid's bounded memory is
+    // the entire point.
+    const targetDensity = Math.min(density, cropDensityCap(x1 - x0, y1 - y0));
     const bw = Math.max(1, Math.round((x1 - x0) * targetDensity));
     const bh = Math.max(1, Math.round((y1 - y0) * targetDensity));
     const myGen = generation;
@@ -312,7 +328,7 @@ export function createTileCompositor() {
     const bctx = back.getContext("2d");
     if (!bctx) return { cancel() {} };
 
-    const { level: placeholderLevel, density: phDensity } = bestPlaceholder(sheetKey, levels, level, x0, y0, x1, y1, dark);
+    const { level: placeholderLevel, density: phDensity } = bestPlaceholder(sheetKey, levels, pickLevel(levels, targetDensity), x0, y0, x1, y1, dark);
     const phTiles = visibleTilesAtDensity(dims.w, dims.h, phDensity, placeholderLevel, x0, y0, x1, y1);
     for (const t of phTiles) {
       const bmp = cache.get(modeKey(rawTileKey(sheetKey, placeholderLevel, t.tx, t.ty), dark)) as ImageBitmap | undefined;
@@ -322,10 +338,10 @@ export function createTileCompositor() {
       bctx.drawImage(bmp, dx, dy, dw, dh);
     }
 
-    const target = visibleTiles(dims.w, dims.h, levels, level, x0, y0, x1, y1);
-    // protect THIS crop's tiles from eviction while they're the visible set
-    // (replaced wholesale by the next paintDetail on this sheet)
-    visibleKeys.set(`${sheetKey}|detail`, new Set(target.map((t) => modeKey(rawTileKey(sheetKey, level, t.tx, t.ty), dark))));
+    // Nothing to protect from eviction any more — the crop is a one-off
+    // render, not cached tiles. Clearing the old detail set lets the LRU
+    // reclaim the previous crop's tiles (base tiles stay shielded).
+    visibleKeys.delete(`${sheetKey}|detail`);
 
     let swapped = false;
     const swap = () => {
@@ -345,23 +361,36 @@ export function createTileCompositor() {
     // reveal what's ready rather than hold the whole crop hostage.
     const graceTimer = window.setTimeout(swap, REVEAL_GRACE_MS);
 
-    let remaining = target.length;
-    if (remaining === 0) swap(); // degenerate region — nothing to wait for
-    Promise.all(target.map(async (t) => {
-      const bmp = await getOrFetchTile(sheetKey, level, t.tx, t.ty, targetDensity, dark);
-      if (!bmp || !live || myGen !== generation) { remaining--; return; }
-      const dx = t.x - x0 * targetDensity, dy = t.y - y0 * targetDensity;
-      bctx.drawImage(bmp, dx, dy);
-      // A straggler landing AFTER the grace-period swap already happened:
-      // patch it directly onto the now-visible canvas (the live canvas is
-      // correctly sized/positioned by then) rather than lose it silently in
-      // a back buffer nobody composites again until the next settle.
-      if (swapped) { canvas.getContext("2d")?.drawImage(bmp, dx, dy); onDone(); }
-      remaining--;
-      if (remaining === 0) swap();
-    })).catch(() => {});
+    // ONE render for the whole crop. The rect is in the crop's own density
+    // space, which is what the worker's `transform: [1,0,0,1,-x,-y]` expects.
+    let cropReq: { cancel: () => void } | undefined;
+    if (bw <= 0 || bh <= 0) {
+      swap(); // degenerate region — nothing to wait for
+    } else {
+      const req = pool.requestTile({
+        sheetKey,
+        scale: RENDER_SCALE * targetDensity,
+        rect: { x: Math.round(x0 * targetDensity), y: Math.round(y0 * targetDensity), w: bw, h: bh },
+        dark,
+      });
+      cropReq = { cancel: req.cancel };
+      req.promise.then(({ bitmap }) => {
+        if (!live || myGen !== generation) { bitmap.close(); return; }
+        // Landing after the grace swap is normal, not an error: the
+        // placeholder was revealed first so the view never blanks. Paint onto
+        // whichever surface is current, then release — this bitmap is a
+        // one-off crop, so nothing else will ever close it for us.
+        if (swapped) { canvas.getContext("2d")?.drawImage(bitmap, 0, 0); onDone(); }
+        else { bctx.drawImage(bitmap, 0, 0); swap(); }
+        bitmap.close();
+      }).catch((err) => {
+        if (!live || myGen !== generation) return;
+        console.warn("[tiles] detail crop failed:", err);
+        swap(); // reveal the placeholder rather than sit on a stale crop
+      });
+    }
 
-    return { cancel() { live = false; clearTimeout(graceTimer); } };
+    return { cancel() { live = false; clearTimeout(graceTimer); cropReq?.cancel(); } };
   }
 
   function dispose() { resetAll(); pool.dispose(); }

--- a/web/src/lib/tiles.ts
+++ b/web/src/lib/tiles.ts
@@ -23,16 +23,18 @@ export const TILE_SIZE = 512;
 export const MIN_LEVEL_PX = 768;
 // Reuses the old QUALITY_CEILING's intent (≈576 px/in-equivalent deep zoom)
 // as the top of the pyramid, relative to the RENDER_SCALE=2 logical baseline.
-// That intent works out to 4, not 8: 576 px/in ÷ 72 pt/in = 8 device px per
-// POINT, and the logical space is already 2 px per point (RENDER_SCALE), so
-// the density multiplier on top of it is 8/2 = 4. Shipping 8 asked pdf.js to
-// render each tile at scale RENDER_SCALE×8 = 16 — a >100k-px viewport on an
-// E-size sheet — and quadrupled the tile count for the same crop. Measured on
-// the hosted demo at 259% zoom: not one level-8 tile ever completed (no
-// error, they simply never finished), so the detail layer sat on the base
-// placeholder upscaled 16× — the "so so pixelated" report. Deep zoom is
-// exactly where a tile must still be CHEAP, because that's where the pyramid
-// has the most tiles to produce.
+// This bounds the PYRAMID only — the base layer and the placeholder search.
+// It no longer bounds on-screen sharpness: the detail crop is a single render
+// at exactly the density the screen asks for (see tileCompositor's
+// paintDetail), so it is not chosen from these levels at all.
+//
+// It briefly did bound sharpness, and that was a bug: #108 set it to 4 to stop
+// deep-zoom tiles from being unaffordable, which capped real sharpness at 200%
+// zoom on a dpr-2 screen and produced measurable pixel-doubling (2.08x at
+// 417%). The tiling was the thing that couldn't be afforded, not the density.
+// 4 is still the right pyramid ceiling — the base never needs to exceed the
+// RENDER_SCALE baseline, and a coarser placeholder is only ever a stand-in for
+// the few hundred ms before the crop lands.
 export const MAX_DENSITY = 4;
 
 /** Level id for the whole-sheet BASE composite. Deliberately outside the


### PR DESCRIPTION
Follow-up to #108, which fixed the base layer but capped real sharpness. Reported as "resolution and clarity of the rendered lines still substandard," with a screenshot showing hard staircase blocks and a gray fringe.

## Measured

417% zoom, dpr 2, on an E-size sheet:

| | required density | actual | upscale |
|---|---|---|---|
| #108 (`main`) | 8.34 | **4.00** | **2.08× — every pixel doubled** |
| this PR | 8.34 | **8.34** | **1.00 — pixel-perfect** |

`MAX_DENSITY = 4` caps sharpness at 200% zoom on a dpr-2 display. Past that it upscales. I set that value in #108 to stop deep-zoom tiles from being unaffordable, and in doing so traded "catastrophically blurry on heavy sheets" for "always soft past 200%." The second is what got reported. Both are wrong.

## Why the pyramid was the wrong tool here

A crop at full sharpness is `(viewport/zoom)` image px rendered at `(zoom × dpr)` density. Those cancel:

```
crop device px = (viewport/zoom) × (zoom × dpr) = viewport × dpr
```

| zoom | crop image px | density | crop device px | 512-tiles |
|---|---|---|---|---|
| 50% | 4224×1970 | 1.00 | 4224×1970 (8.3MP) | 36 |
| 200% | 1056×492 | 4.00 | 4224×1970 (8.3MP) | 36 |
| 417% | 506×236 | 8.34 | 4224×1970 (8.3MP) | 36 |
| 1600% | 132×62 | 32.00 | 4224×1970 (8.3MP) | 36 |

**It is ~8MP at every zoom level. Identical.** Tiling that constant into 512² pieces doesn't make it cheaper — it makes it ~36× *more expensive*, because pdf.js replays the whole page operator list per render regardless of how little of the page lands in the target canvas.

So the **tiling** was what couldn't be afforded at depth, not the density. #108 lowered the wrong number.

## The change

`paintDetail` issues **one** worker render of the visible crop at exactly the density the screen asks for. No pyramid snapping, no density ceiling, no tile-count guard. `MAX_CROP_TILES` is gone; `MAX_CROP_AREA` replaces it purely as a sanity backstop for an abnormally large panel, and never binds at real screen sizes.

Tiles remain exactly right for the **base** layer — a whole-sheet composite built once, where the pyramid's bounded memory is the entire point. `MAX_DENSITY` stays 4 but now bounds only the pyramid (base + placeholder), not on-screen sharpness.

Two lifecycle details: the crop bitmap is a one-off, so it's `close()`d after drawing rather than cached (nothing else would ever close it), and the detail visible-key set is dropped so the LRU can reclaim the previous crop's tiles.

## Verified

Real foreground tab, E-size sheet, 417% zoom: density 8.34/8.34, crop 8.35MP — exactly the predicted constant. Lines render with clean caps and uniform stroke, no staircase. `tiles.test.ts` 19/19, typecheck/lint/build clean.