### PR TITLE
Fix agent/search discoverability gaps (robots, sitemap, JSON-LD, well-known)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -51,7 +51,12 @@
     "estimating",
     "pdf",
     "quantity-takeoff",
-    "flooring"
+    "flooring",
+    "ai-agent",
+    "agentic-ai",
+    "preconstruction",
+    "construction-management",
+    "project-management"
   ],
   "overrides": {
     "fast-uri": "^3.1.4",

--- a/web/index.html
+++ b/web/index.html
@@ -4,20 +4,50 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="description" content="Free, open-source PDF takeoff software for flooring & construction estimating. Measure plans in your browser, organize by finish, get a materials buy list, export quantities — no account, no install. A free alternative to paid takeoff tools." />
-    <title>OpenTakeoff — free flooring & construction takeoff software</title>
+    <link rel="canonical" href="https://opentakeoff.netlify.app/" />
+    <meta name="description" content="Free, open-source construction & flooring takeoff — the first engine an AI agent can drive natively over MCP. Trace plans, get quantities, no account." />
+    <title>OpenTakeoff — free, AI-native takeoff for construction & flooring</title>
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://opentakeoff.netlify.app" />
-    <meta property="og:title" content="OpenTakeoff — free, open-source flooring & construction takeoff" />
-    <meta property="og:description" content="A free, open-source PDF takeoff canvas. Trace areas, organize by finish, export quantities — runs entirely in your browser, no account." />
+    <meta property="og:title" content="OpenTakeoff — the first takeoff canvas built for people and AI agents" />
+    <meta property="og:description" content="A free, open-source PDF takeoff canvas. Trace plans and get quantities yourself, or point an AI agent at the same engine over MCP. Runs entirely in your browser, no account." />
     <meta property="og:image" content="https://opentakeoff.netlify.app/og-card.png" />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="640" />
     <meta property="og:image:alt" content="OpenTakeoff — three patient rooms traced wall to wall in wood and a VCT room on a real floor finish plan, 743.4 SF of wood flooring counted." />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="OpenTakeoff — free, open-source flooring & construction takeoff" />
-    <meta name="twitter:description" content="A free, open-source PDF takeoff canvas. Trace areas, organize by finish, export quantities — runs entirely in your browser, no account." />
+    <meta name="twitter:title" content="OpenTakeoff — the first takeoff canvas built for people and AI agents" />
+    <meta name="twitter:description" content="A free, open-source PDF takeoff canvas. Trace plans and get quantities yourself, or point an AI agent at the same engine over MCP. Runs entirely in your browser, no account." />
     <meta name="twitter:image" content="https://opentakeoff.netlify.app/og-card.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "OpenTakeoff",
+        "applicationCategory": "BusinessApplication",
+        "applicationSubCategory": "Construction Estimating Software",
+        "operatingSystem": "Any (runs in a web browser)",
+        "url": "https://opentakeoff.netlify.app",
+        "description": "Free, open-source PDF takeoff software for construction and flooring estimating. The first takeoff engine an AI agent can drive natively over the Model Context Protocol (MCP), with the same measuring math and provenance as a human at the canvas.",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "isAccessibleForFree": true,
+        "license": "https://github.com/Kentucky-ai/opentakeoff/blob/main/LICENSE",
+        "keywords": "construction takeoff, flooring takeoff, construction estimating, quantity takeoff, quantity surveying, preconstruction, construction management, AEC software, AI agent, model context protocol, MCP, AI-native construction",
+        "creator": {
+          "@type": "Organization",
+          "name": "Kentucky AI",
+          "url": "https://kentucky-ai.com"
+        },
+        "sameAs": [
+          "https://github.com/Kentucky-ai/opentakeoff",
+          "https://www.npmjs.com/package/opentakeoff-mcp"
+        ]
+      }
+    </script>
     <meta name="theme-color" content="#f4efe0" />
     <!-- Theme-before-paint. External (not inline) so the app can ship a strict
          CSP with script-src 'self' — see public/theme-init.js and public/_headers.

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.Kentucky-ai/opentakeoff",
+  "title": "OpenTakeoff",
+  "description": "Construction takeoff for AI agents: load plans, set scale, measure, count, export with provenance.",
+  "websiteUrl": "https://opentakeoff.netlify.app",
+  "repository": {
+    "url": "https://github.com/Kentucky-ai/opentakeoff",
+    "source": "github"
+  },
+  "version": "0.8.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "opentakeoff-mcp",
+      "version": "0.8.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,0 +1,23 @@
+# OpenTakeoff is open to all crawlers — human search and AI agents alike.
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+Sitemap: https://opentakeoff.netlify.app/sitemap.xml

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://opentakeoff.netlify.app/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
robots.txt and sitemap.xml never existed, so the SPA catch-all silently
served index.html at HTTP 200 for both — looked fine, was invisible to
crawlers. Also: no JSON-LD schema, no canonical tag, no /.well-known/mcp.json,
and the meta description/title never mentioned AI agents or MCP despite that
being the flagship differentiator.

- Add real robots.txt (explicitly welcomes AI crawlers) + sitemap.xml
- Add /.well-known/mcp.json (mirrors mcp/server.json for agent discovery)
- Add canonical link + SoftwareApplication JSON-LD with AEC/MCP keywords
- Rework title/meta/og/twitter description to lead with the AI-native framing
- Add ai-agent/preconstruction/construction-management keywords to mcp/package.json
