### PR TITLE
ci: fail a PR that changes mcp/ without a version bump; refresh the stale tool list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,88 @@ jobs:
       - run: npm run smoke:dist
         working-directory: mcp
 
+  # Publishing the MCP server is fully unattended ONCE an mcp-v* tag exists —
+  # but nothing ever checked that a change to mcp/ came with a version bump, so
+  # "publish when needed" quietly depended on remembering. This is the check.
+  #
+  # It deliberately does NOT create the tag. publish-mcp.yml fires on the tag
+  # push, and a tag pushed by a workflow's GITHUB_TOKEN does not trigger other
+  # workflows — an auto-tag here would fire nothing AND consume the tag name,
+  # so the manual push that would have published is now a no-op. That trades a
+  # forgotten publish for a silently impossible one. Auto-publishing needs a
+  # PAT, which is a credential decision, not a CI one.
+  mcp-version-guard:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need the base commit to diff against
+      - name: Require a version bump when mcp/ changes
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet "$BASE" HEAD -- mcp/; then
+            echo "mcp/ untouched — nothing to check."
+            exit 0
+          fi
+          echo "mcp/ changed in this PR:"
+          git diff --name-only "$BASE" HEAD -- mcp/ | sed 's/^/  /'
+
+          PKG=$(jq -r .version mcp/package.json)
+          SRV=$(jq -r .version mcp/server.json)
+          SRVPKG=$(jq -r '.packages[0].version' mcp/server.json)
+          # Same three-way agreement publish-mcp.yml enforces at tag time.
+          # Catching it here means a mismatch fails a PR instead of a release.
+          if [ "$PKG" != "$SRV" ] || [ "$PKG" != "$SRVPKG" ]; then
+            echo "::error::version fields disagree (package.json=$PKG server.json=$SRV packages[0]=$SRVPKG) — bump them together"
+            exit 1
+          fi
+
+          BASE_PKG=$(git show "$BASE:mcp/package.json" | jq -r .version)
+          if [ "$PKG" = "$BASE_PKG" ]; then
+            echo "::error file=mcp/package.json::mcp/ changed but the version is still $PKG. Bump mcp/package.json AND mcp/server.json (.version and .packages[0].version), or the change ships to nobody: the registry only ever sees a published mcp-v* tag."
+            exit 1
+          fi
+          echo "version $BASE_PKG -> $PKG"
+          if git rev-parse -q --verify "refs/tags/mcp-v$PKG" >/dev/null; then
+            echo "::error::tag mcp-v$PKG already exists — pick an unused version"
+            exit 1
+          fi
+          echo "OK — merge, then publish with:  git tag mcp-v$PKG && git push origin mcp-v$PKG"
+
+  # Post-merge nudge: says exactly what to run, so a bumped-but-unpublished
+  # version can't sit unnoticed. Never fails the build — main is already green
+  # by here and an unpublished version is a pending action, not a defect.
+  mcp-release-reminder:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Flag an unpublished version
+        run: |
+          set -euo pipefail
+          PKG=$(jq -r .version mcp/package.json)
+          if git rev-parse -q --verify "refs/tags/mcp-v$PKG" >/dev/null; then
+            echo "mcp v$PKG is tagged — nothing pending." >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### MCP v$PKG is not published"
+              echo ""
+              echo '```'
+              echo "git tag mcp-v$PKG && git push origin mcp-v$PKG"
+              echo '```'
+              echo ""
+              echo "That tag push runs \`publish-mcp.yml\` end to end: npm (OIDC, provenance), the MCP registry entry, the GitHub release, and the MCPB bundle."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::mcp v$PKG has no mcp-v$PKG tag — not published yet"
+          fi
+
   capture:
     runs-on: ubuntu-latest
     steps:

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -32,13 +32,21 @@ which is the MCP wire. `node --import tsx` is the whole invocation.
 
 ## What the agent gets
 
-Twelve tools: `load_plan`, `sheet_info`, `set_scale`, `one_click`, `detect_rooms`,
-`measure_polygon`, `measure_line`, `takeoff_summary`, `export_takeoff`,
-`delete_shape`, `read_sheet_text`, `view_sheet` (render a sheet or crop to PNG
-with an optional calibrated measuring grid and committed-shapes overlay — the
-agent's eyes and its self-check). The full reference — including the
-coordinate contract (image px at render scale 2.0, origin top-left) and the
-scale-gate rules — is in [`mcp/README.md`](../mcp/README.md).
+Seventeen tools, in the order an agent tends to reach for them:
+
+- **Open and orient** — `load_plan`, `sheet_info`, `set_scale`, `sheet_context`
+- **Measure** — `one_click`, `detect_rooms`, `measure_polygon`, `measure_line`
+- **Revise** — `edit_shape`, `edit_materials`, `delete_shape`, `undo_last`
+- **Read the sheet** — `read_sheet_text`, `find_text`, `view_sheet` (render a
+  sheet or crop to PNG with an optional calibrated measuring grid and
+  committed-shapes overlay — the agent's eyes and its self-check)
+- **Report** — `takeoff_summary`, `export_takeoff`
+
+The full reference — including the coordinate contract (image px at render
+scale 2.0, origin top-left) and the scale-gate rules — is in
+[`mcp/README.md`](../mcp/README.md), which is the list to trust: this page is
+prose and `mcp/src/tools.ts` is the source of truth for what actually
+registers.
 
 Two rules carry over from the app unchanged:
 


### PR DESCRIPTION
`publish-mcp.yml` is genuinely unattended **once an `mcp-v*` tag exists**. Nothing ever checked that a change to `mcp/` came *with* a version bump — so "publish when needed" depended on remembering. A forgotten bump means the change ships to nobody: the registry only ever sees a published tag.

## `mcp-version-guard` (pull_request)

Fires only when `mcp/` actually changed, then requires:

- a version bump versus the base commit
- three-way agreement between `package.json` and `server.json` (`.version` and `.packages[0].version`) — the same check `publish-mcp.yml` makes at tag time, moved earlier so a mismatch fails a PR instead of a release
- an unused tag

Verified against four cases before shipping: no bump, bump to an already-tagged version, a correct three-field bump, and `package.json` bumped with `server.json` left behind. Only the third passes.

## Why it does not auto-tag

This is the interesting constraint. `publish-mcp.yml` fires on the tag push, and **a tag pushed by a workflow's `GITHUB_TOKEN` does not trigger other workflows.** An auto-tag here would fire nothing *and* consume the tag name — so the manual push that would have published becomes a no-op. That trades a forgotten publish for a silently impossible one, which is strictly worse.

Real auto-publish needs a PAT. That's a credential decision, not a CI one, and this repo currently holds **no secrets at all** — `publish-mcp` uses OIDC trusted publishing precisely so none exist. Worth keeping that property unless there's a reason not to.

## `mcp-release-reminder` (push to main)

Prints the exact command into the job summary when the current version has no tag:

```
git tag mcp-v0.9.0 && git push origin mcp-v0.9.0
```

Never fails the build — by then main is green, and an unpublished version is a pending action, not a defect.

## docs/MCP.md

Said "Twelve tools" and listed twelve. There are **seventeen** (`sheet_context`, `edit_shape`, `edit_materials`, `undo_last`, `find_text` were all missing). Rewrote it grouped by what an agent actually reaches for — open/orient, measure, revise, read, report — and pointed at `mcp/src/tools.ts` as the source of truth, so prose drifting again is merely stale rather than misleading.