### PR TITLE
feat(canvas): attach annotations to conditions — markup.condition_id

### DIFF
--- a/web/src/lib/markedset.js
+++ b/web/src/lib/markedset.js
@@ -533,9 +533,13 @@ export async function buildMarkedSetPdf({ projectName, dark, sheets, shapes, mar
       const lbl = (t) => [rlabel, t].filter((s) => s != null && s !== "").join(" ");
       // per-markup color drives the STROKE/FILL and the note text, dark-boosted for
       // the dark sheet — mirroring the canvas fallback exactly (custom color, else
-      // cobalt when linked, else amber). Legacy/uncolored markups match the canvas.
+      // the LINKED CONDITION's color, else cobalt when RFI-linked, else amber).
+      // Legacy/uncolored markups match the canvas. This precedence must stay in
+      // step with TakeoffCanvas's markup layer, or the burned set stops looking
+      // like the screen it was reviewed on — the one thing a marked set owes.
       // Linkage still prints via the RFI number prefix (lbl), independent of color.
-      const mbase = m.color || (m.rfi_id ? COBALT : "#c47a10");
+      const mCond = m.condition_id ? (conditions || []).find((c) => c.id === m.condition_id) : null;
+      const mbase = m.color || mCond?.color || (m.rfi_id ? COBALT : "#c47a10");
       const mcol = rgb(...hex(dark ? boostForDark(mbase) : mbase));
       const mdash = pdfDashFor(m.line_style || "solid");
       const mw = clampWeight(m.weight);   // stroke-width multiplier (markups only), default ×1

--- a/web/src/lib/totals.js
+++ b/web/src/lib/totals.js
@@ -423,7 +423,14 @@ export function reportJson({ projectName = "", rows = [], bySheet = [], scaleInf
     // id + rfi_id APPEND after the original four keys (the additive-only v1
     // convention — see scale_source above): a cloud with empty text was fully
     // anonymous in the export. Legacy markups: id → null, rfi_id → "".
-    markups: markups.map((m) => ({ type: m.type, sheet_id: m.sheet_id, sheet: label(m.sheet_id), text: m.text || "", id: m.id ?? null, rfi_id: m.rfi_id || "" })),
+    // condition_id + condition APPEND again, same rule. condition is the
+    // resolved finish_tag rather than only the id, so a reader of the export
+    // can see WHICH scope an annotation is about without joining two arrays;
+    // the id stays authoritative. Unattached markups: "" for both.
+    markups: markups.map((m) => {
+      const c = m.condition_id ? (rows || []).find((r) => r.id === m.condition_id) : null;
+      return { type: m.type, sheet_id: m.sheet_id, sheet: label(m.sheet_id), text: m.text || "", id: m.id ?? null, rfi_id: m.rfi_id || "", condition_id: m.condition_id || "", condition: c?.finish_tag || "" };
+    }),
     // rfis APPENDS after markups (additive-only v1 — old exports had no RFI
     // register). linked_markups/linked_sheets are DERIVED from markup.rfi_id,
     // never a second store of the link.

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -896,7 +896,7 @@ export default function TakeoffCanvas() {
     // normalize hydrated markups: legacy workspaces may hold markups with no id
     // (pre-dating the id field) — seed a stable id + default rfi_id so the new
     // select / edit / delete / move / RFI-link flows (all keyed on m.id) work on them.
-    setMarkups(Array.isArray(a.markups) ? a.markups.map((m) => ({ ...m, id: m.id || uid("mk"), rfi_id: m.rfi_id || "" })) : []);
+    setMarkups(Array.isArray(a.markups) ? a.markups.map((m) => ({ ...m, id: m.id || uid("mk"), rfi_id: m.rfi_id || "", condition_id: m.condition_id || "" })) : []);
     setRfis(Array.isArray(a.rfis) ? a.rfis : []);   // additive — old saves without rfis load as []
     // additive provenance_counters — unconditional set (the else-clear rule: a
     // snapshot load must not inherit the replaced project's deletion tallies).
@@ -3184,8 +3184,13 @@ export default function TakeoffCanvas() {
   // belongs to the panel of its FIRST click and normalizes against that panel.
   function addMarkup(m, key) {
     // created_at rides the defaults so every markup path (hand-drawn, cloud's
-    // pre-minted id, stamp instances) is stamped at this single creation gate
-    setMarkups((ms) => [...ms, { id: uid("mk"), created_at: nowIso(), sheet_id: key, rfi_id: "", ...m }]);
+    // pre-minted id, stamp instances) is stamped at this single creation gate.
+    // condition_id defaults to the ACTIVE condition: an annotation drawn while
+    // a condition is selected is almost always about that condition, and a
+    // wrong-but-editable link beats an unlinked note nobody ever goes back to
+    // attach. Explicit `...m` still wins, so a caller that means "unattached"
+    // can pass condition_id: "".
+    setMarkups((ms) => [...ms, { id: uid("mk"), created_at: nowIso(), sheet_id: key, rfi_id: "", condition_id: activeCond || "", ...m }]);
     // Drawing a markup by hand surfaces the Markups tab. But a STAMP places several
     // markups via addMarkup — don't yank the user off the Stamps tab mid-placement
     // (keep the current tab, or open Markups only if nothing's open). Highlighter
@@ -3453,6 +3458,13 @@ export default function TakeoffCanvas() {
   }
   const linkRfi = (markup, rfiId) => { if (markup && rfiId) updateMarkup(markup.id, { rfi_id: rfiId }); };
   const unlinkRfi = (markup) => { if (markup) updateMarkup(markup.id, { rfi_id: "" }); };
+  // ── markup ↔ condition. Same shape as the RFI link and deliberately so: one
+  // condition ↔ many markups, the link lives on the MARKUP, and membership is
+  // derived rather than stored on the condition. Without this an annotation is
+  // a floating note — it can't take the condition's colour, can't travel with
+  // it into an export, and can't answer "what did we say about this scope".
+  const linkCondition = (markup, condId) => { if (markup && condId) updateMarkup(markup.id, { condition_id: condId }); };
+  const unlinkCondition = (markup) => { if (markup) updateMarkup(markup.id, { condition_id: "" }); };
   // hard delete: drop the record AND clear the dangling pointer on every linked
   // markup (void is a status; delete removes — both must leave no orphan link)
   function deleteRfi(id) {
@@ -4366,6 +4378,12 @@ export default function TakeoffCanvas() {
     // would resurrect orphans
     if (owned.length) dispatchShape({ type: "delete", ids: owned.map((s) => s.id), reason: "condition-delete" }, { record: false });
     setConditions(next);
+    // Annotations are NOT owned by the condition the way shapes are — a cloud
+    // saying "verify substrate here" outlives the takeoff line it was drawn
+    // against. Clear the dangling pointer and keep the markup, same rule
+    // deleteRfi follows: leave no orphan link, but never delete someone's note
+    // as a side effect of deleting a quantity.
+    setMarkups((ms) => ms.map((m) => (m.condition_id === id ? { ...m, condition_id: "" } : m)));
     unpinFromPalette(id);   // a deleted condition can't stay pinned in the palette
     if (activeCond === id) setActiveCond(next[0]?.id || "");
     // no bulk-selection pruning needed here: the panel derives liveness from
@@ -5433,6 +5451,33 @@ export default function TakeoffCanvas() {
                          </>
                        )}
                      </div>
+                     {/* Condition link — which scope this annotation is ABOUT.
+                         Same one-to-many shape as the RFI link below it. */}
+                     {(() => {
+                       const lc = m.condition_id ? condById[m.condition_id] : null;
+                       const ctrl = { padding: "2px 7px", border: "1px solid var(--ink-faint)", background: "transparent", cursor: "pointer", fontSize: 11 };
+                       return (
+                         <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 7, flexWrap: "wrap" }}>
+                           {lc ? (
+                             <>
+                               <span title={`Annotation is about ${lc.finish_tag}`}
+                                 style={{ display: "inline-flex", alignItems: "center", gap: 5, fontFamily: "var(--f-mono)", fontSize: 11, fontWeight: 700 }}>
+                                 <span style={{ width: 9, height: 9, background: lc.color, border: "1px solid var(--ink-faint)" }} />
+                                 {lc.finish_tag}
+                               </span>
+                               <button onClick={() => { setActiveCond(lc.id); }} style={{ ...ctrl, color: "var(--cobalt)" }} title="Make this the active condition">Select</button>
+                               <button onClick={() => unlinkCondition(m)} style={{ ...ctrl, color: "var(--ink-muted)" }} title="Detach this annotation from its condition">Detach</button>
+                             </>
+                           ) : conditions.length > 0 && (
+                             <select name="link-condition" value="" onChange={(e) => { if (e.target.value) linkCondition(m, e.target.value); }}
+                               title="Attach this annotation to a condition" style={{ ...ctrl, background: "var(--paper-bright)", maxWidth: 170 }}>
+                               <option value="">Attach to condition…</option>
+                               {conditions.map((c) => <option key={c.id} value={c.id}>{c.finish_tag}</option>)}
+                             </select>
+                           )}
+                         </div>
+                       );
+                     })()}
                      {/* RFI controls — raise a fresh RFI, link an existing one, or unlink */}
                      {(() => {
                        const linked = m.rfi_id ? rfis.find((r) => r.id === m.rfi_id) : null;
@@ -5626,7 +5671,12 @@ export default function TakeoffCanvas() {
                       .slice().sort((a, b) => (a.type === "highlight" ? 0 : 1) - (b.type === "highlight" ? 0 : 1))
                       .map((m) => {
                       const z = tf.scale;
-                      const base = m.color || (m.rfi_id ? "#1f3fc7" : "#c47a10");
+                      // Colour precedence: an explicit per-markup colour always
+                      // wins (the user picked it), then the LINKED CONDITION's
+                      // colour so an annotation reads as part of that scope at a
+                      // glance, then RFI blue, then the unattached default.
+                      const mCond = m.condition_id ? condById[m.condition_id] : null;
+                      const base = m.color || mCond?.color || (m.rfi_id ? "#1f3fc7" : "#c47a10");
                       const mk = darkMode ? boostForDark(base) : base;   // literal — SVG attrs don't resolve CSS vars
                       const dash = dashArrayFor(m.line_style || "solid", z);
                       const w = clampWeight(m.weight);   // stroke-width multiplier over each element's base, default ×1

--- a/web/test/totals.test.ts
+++ b/web/test/totals.test.ts
@@ -145,9 +145,14 @@ test("reportJson: v1 key set pinned — top level, sheets[], markups[], by_sheet
   assert.equal(j.sheets[0].scale_source, "calibrated");
   assert.equal(j.sheets[0].sheet, "Sheet sh1");
   // id + rfi_id appended after the original four (additive-only v1 schema)
-  assert.deepEqual(Object.keys(j.markups[0]), ["type", "sheet_id", "sheet", "text", "id", "rfi_id"]);
+  // condition_id + condition APPEND after rfi_id (additive-only v1). `condition`
+  // is the RESOLVED finish_tag so a reader sees which scope an annotation is
+  // about without joining two arrays; condition_id stays authoritative.
+  assert.deepEqual(Object.keys(j.markups[0]), ["type", "sheet_id", "sheet", "text", "id", "rfi_id", "condition_id", "condition"]);
   assert.equal(j.markups[0].id, null);              // legacy markup: null id, empty rfi
   assert.equal(j.markups[0].rfi_id, "");
+  assert.equal(j.markups[0].condition_id, "");      // legacy markup: unattached
+  assert.equal(j.markups[0].condition, "");
   assert.equal(j.markups[1].id, "mk-2");            // an id-bearing cloud with empty text
   assert.equal(j.markups[1].rfi_id, "rfi-1");       // links to the RFI record by its id
   assert.equal(j.markups[1].text, "");
@@ -251,4 +256,30 @@ test("verticalWallSf: floor perimeters × height × multiplier; 0 without a heig
   assert.equal(verticalWallSf(shapes, "c", 9, 2), 1260);  // (40+30) × 9 × 2
   assert.equal(verticalWallSf(shapes, "c", 0, 2), 0);
   assert.equal(verticalWallSf(shapes, "c", undefined, 2), 0);
+});
+
+test("reportJson: a condition-linked markup resolves to its finish_tag; a dangling id degrades", () => {
+  const conds = [{ id: "ct", finish_tag: "CT-1", color: "#123456", waste_pct: 0 }];
+  const shapes = [{ condition_id: "ct", sheet_id: "sh1", measure_role: "floor_area", computed: { area_sf: 100, perimeter_lf: 40 } }];
+  const j = reportJson({
+    projectName: "Job 42",
+    rows: conditionTotals(conds, shapes),
+    bySheet: sheetTotals(conds, shapes),
+    markups: [
+      { type: "cloud", sheet_id: "sh1", text: "verify substrate", id: "mk-1", condition_id: "ct" },
+      { type: "text", sheet_id: "sh1", text: "general note", id: "mk-2" },                       // unattached
+      { type: "cloud", sheet_id: "sh1", text: "orphan", id: "mk-3", condition_id: "gone" },      // condition deleted
+    ],
+    sheetLabel: (id: string) => `Sheet ${id}`,
+  });
+  // linked: the id is authoritative AND the tag is resolved for the reader
+  assert.equal(j.markups[0].condition_id, "ct");
+  assert.equal(j.markups[0].condition, "CT-1");
+  // unattached stays empty on both — an annotation about the sheet, not a scope
+  assert.equal(j.markups[1].condition_id, "");
+  assert.equal(j.markups[1].condition, "");
+  // a dangling id keeps the id (so the link is diagnosable) but resolves to ""
+  // rather than inventing a tag — the export must not claim a scope that is gone
+  assert.equal(j.markups[2].condition_id, "gone");
+  assert.equal(j.markups[2].condition, "");
 });


### PR DESCRIPTION
Markups carried `rfi_id`, but **nothing tied an annotation to the scope it was about.** A cloud reading "verify substrate" was a floating note: it couldn't take the condition's colour, couldn't travel with it into an export, and couldn't answer *"what did we say about this condition?"*

`markup.condition_id` mirrors the `rfi_id` shape deliberately — one condition ↔ many markups, the link lives on the **markup**, membership derived rather than stored on the condition. One authority, no set to keep in sync.

## What lands

- **Defaults to the active condition** at creation. An annotation drawn while a condition is selected is almost always about it, and a wrong-but-editable link beats an unlinked note nobody ever returns to attach. Explicit `...m` still wins, so a caller meaning "unattached" passes `condition_id: ""`.
- **Attach / Detach / Select** in the markup panel — the same controls the RFI link already offers, sitting directly above them.
- **Colour precedence**: explicit per-markup colour → the linked condition's colour → RFI blue → unattached amber. Identical in the canvas and in `markedset.js`; they must stay in step or the burned set stops looking like the screen it was reviewed on.
- **Deleting a condition clears the pointer and keeps the markup.** Annotations aren't owned the way shapes are — a note about substrate outlives the takeoff line it was drawn against, and nobody's note should vanish as a side effect of deleting a quantity. Same rule `deleteRfi` follows: no orphan links, no collateral deletes.
- **`reportJson`** appends `condition_id` + the **resolved** `finish_tag` (additive-only v1, the rule `rfi_id` followed). The tag saves the reader a join; the id stays authoritative. A **dangling** id keeps the id — so a broken link stays diagnosable — but resolves to `""` rather than inventing a scope that no longer exists.

## Verified

The v1 key-set test failed on the new keys. That's the test doing its job, so I extended it deliberately rather than loosening it, and added a case covering linked / unattached / dangling.

In a real browser on the sample plan:

1. Drew a revision cloud with CPT-1 active → auto-attached, panel showed `■ CPT-1 · Select · Detach`, cloud drew in CPT-1 **green**
2. Detach → cloud returned to unattached **amber**, panel reverted to "Attach to condition…"
3. Re-attached via the dropdown → **green** again

963 pass. The 4 failures are the pre-existing Node-25 localStorage ones, identical on `main`.

## Not in this pass

Agent/MCP tools for reading and creating linked annotations — that's the other half of the "full interconnect" and wants its own PR against the tool surface.