### PR TITLE
feat(mcp): annotate / list_annotations / link_annotation — the agent half of #112

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -32,7 +32,7 @@ which is the MCP wire. `node --import tsx` is the whole invocation.
 
 ## What the agent gets
 
-Seventeen tools, in the order an agent tends to reach for them:
+Twenty tools, in the order an agent tends to reach for them:
 
 - **Open and orient** — `load_plan`, `sheet_info`, `set_scale`, `sheet_context`
 - **Measure** — `one_click`, `detect_rooms`, `measure_polygon`, `measure_line`
@@ -40,6 +40,10 @@ Seventeen tools, in the order an agent tends to reach for them:
 - **Read the sheet** — `read_sheet_text`, `find_text`, `view_sheet` (render a
   sheet or crop to PNG with an optional calibrated measuring grid and
   committed-shapes overlay — the agent's eyes and its self-check)
+- **Annotate** — `annotate`, `list_annotations`, `link_annotation` (notes
+  *about* the work, never measurements of it; attaching one to a finish tag is
+  what makes it part of that scope rather than a floating remark — it then
+  wears the condition's colour on the canvas and in the marked set)
 - **Report** — `takeoff_summary`, `export_takeoff`
 
 The full reference — including the coordinate contract (image px at render

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/scripts/smoke-dist.mjs
+++ b/mcp/scripts/smoke-dist.mjs
@@ -93,12 +93,15 @@ send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
 const listed = await responseFor(2);
 const names = listed.tools.map((tool) => tool.name).sort();
 assert.deepEqual(names, [
+  "annotate",
   "delete_shape",
   "detect_rooms",
   "edit_materials",
   "edit_shape",
   "export_takeoff",
   "find_text",
+  "link_annotation",
+  "list_annotations",
   "load_plan",
   "measure_line",
   "measure_polygon",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.8.0",
+  "version": "0.9.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -293,3 +293,39 @@ export const sheetContextOutput = {
   }),
   hatch: z.object({ families: z.array(hatchFamilyRow), count: z.number().int() }),
 };
+
+// ── annotations (#114) — notes ABOUT the work, never measurements of it ──────
+const annotationRow = z.object({
+  id: z.string(),
+  sheet: z.string(),
+  type: z.string(),
+  text: z.string(),
+  condition: z.string().describe("Resolved finish tag, or '' when unattached — saves joining against conditions[]"),
+  condition_id: z.string(),
+  at: z.tuple([z.number(), z.number()]).optional(),
+  target: z.tuple([z.number(), z.number()]).optional(),
+  rect: z.array(z.tuple([z.number(), z.number()]).optional()).optional(),
+});
+
+export const annotateOutput = {
+  id: z.string(),
+  sheet: z.string(),
+  type: z.string(),
+  text: z.string(),
+  condition: z.string(),
+  condition_id: z.string(),
+  note: z.string(),
+};
+
+export const listAnnotationsOutput = {
+  annotations: z.array(annotationRow),
+  count: z.number().int(),
+  unattached: z.number().int().describe("How many carry no condition — candidates for link_annotation"),
+};
+
+export const linkAnnotationOutput = {
+  id: z.string(),
+  condition: z.string(),
+  condition_id: z.string().optional(),
+  note: z.string(),
+};

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -104,6 +104,31 @@ export interface Shape {
   origin?: ShapeOrigin;
 }
 
+/** An annotation — a note ABOUT the work, never a measurement of it.
+ *
+ *  Field-identical to the canvas's markup (web/src/pages/TakeoffCanvas.jsx), so
+ *  what an agent writes here loads in the app unchanged and vice versa. Coords
+ *  are NORMALIZED 0..1 of the sheet, matching shapes' verts_norm — the tools
+ *  take image px and convert at the boundary, which is the same contract every
+ *  other tool honours.
+ *
+ *  condition_id is what makes an annotation part of a scope rather than a
+ *  floating note: it takes that condition's colour on canvas and in the marked
+ *  set, and travels with it into the report (#112). "" means unattached, which
+ *  is a legitimate state — a note about the sheet, not about a finish. */
+export interface Markup {
+  id: string;
+  sheet_id: string;
+  type: "cloud" | "text" | "callout" | "highlight";
+  text: string;
+  condition_id: string;
+  rfi_id: string;
+  at?: [number, number];
+  target?: [number, number];
+  rect?: [[number, number], [number, number]];
+  created_at?: string;
+}
+
 interface SheetState {
   key: string;
   pageNum: number;
@@ -218,6 +243,7 @@ export class Session {
   private doc: DocHandle | null = null;
   private sheets = new Map<string, SheetState>();
   conditions: Condition[] = [];
+  markups: Markup[] = [];
   shapes: Shape[] = [];
 
   /** Newest-last. Capped at UNDO_CAP; the oldest entry falls off the front. */
@@ -248,6 +274,7 @@ export class Session {
     this.sheets.clear();
     this.conditions = [];
     this.shapes = [];
+    this.markups = [];
     this.file = null;
     // the journal's entries reference shapes that no longer exist — undoing
     // across a document swap would be a lie, so the history goes with them
@@ -971,6 +998,88 @@ export class Session {
     };
   }
 
+  /** Place an annotation. A note ABOUT the work — it never measures anything
+   *  and never touches a quantity, which is why there is no review gate here:
+   *  the pencil-not-ink rule exists to stop an agent inventing GEOMETRY, and a
+   *  cloud saying "verify substrate" is not geometry.
+   *
+   *  `condition` attaches it to a scope by finish tag, minting the condition on
+   *  first touch exactly like one_click/measure_polygon — so an agent can note
+   *  something about CPT-1 before anything is traced for CPT-1. Omit it for a
+   *  note about the sheet rather than about a finish. */
+  annotate(a: { sheet: string; type: Markup["type"]; text: string; at?: Point; target?: Point; rect?: [Point, Point]; condition?: string }): Record<string, unknown> {
+    const s = this.sheet(a.sheet);
+    const n = ([x, y]: Point): [number, number] => [x / s.widthPx, y / s.heightPx];
+    if ((a.type === "cloud" || a.type === "highlight") && !a.rect) throw new UserError(`a ${a.type} needs rect: [[x0,y0],[x1,y1]] in image px`);
+    if ((a.type === "text" || a.type === "callout") && !a.at) throw new UserError(`a ${a.type} needs at: [x,y] in image px`);
+    if (a.type === "callout" && !a.target) throw new UserError("a callout needs target: [x,y] — the point the leader line aims at");
+    const cond = a.condition ? this.conditionFor(a.condition) : null;
+    const m: Markup = {
+      id: uid("mk"),
+      sheet_id: s.key,
+      type: a.type,
+      text: a.text || "",
+      condition_id: cond?.id ?? "",
+      rfi_id: "",
+      created_at: new Date().toISOString(),
+      ...(a.at ? { at: n(a.at) } : {}),
+      ...(a.target ? { target: n(a.target) } : {}),
+      ...(a.rect ? { rect: [n(a.rect[0]), n(a.rect[1])] as [[number, number], [number, number]] } : {}),
+    };
+    this.markups.push(m);
+    return {
+      id: m.id, sheet: s.key, type: m.type, text: m.text,
+      condition: cond?.finish_tag ?? "", condition_id: m.condition_id,
+      note: cond
+        ? `Attached to ${cond.finish_tag} — it wears that condition's colour on the canvas and in the marked set.`
+        : "Unattached — a note about the sheet. Pass condition to tie it to a scope.",
+    };
+  }
+
+  /** Read annotations, optionally narrowed to a sheet and/or a condition.
+   *  Resolves condition_id to its finish tag so a caller can act on the reply
+   *  without joining against the conditions array. */
+  listAnnotations(f: { sheet?: string; condition?: string } = {}): Record<string, unknown> {
+    const tagById = new Map(this.conditions.map((c) => [c.id, c.finish_tag]));
+    let rows = this.markups;
+    if (f.sheet) { const s = this.sheet(f.sheet); rows = rows.filter((m) => m.sheet_id === s.key); }
+    if (f.condition) {
+      const c = this.conditions.find((x) => x.finish_tag === f.condition);
+      if (!c) throw new UserError(`no condition "${f.condition}" — tags: ${this.conditions.map((x) => x.finish_tag).join(", ") || "(none)"}`);
+      rows = rows.filter((m) => m.condition_id === c.id);
+    }
+    const s0 = this.sheets;
+    const px = (m: Markup, p?: [number, number]): [number, number] | undefined => {
+      const sh = s0.get(m.sheet_id); if (!p || !sh) return undefined;
+      return [round1(p[0] * sh.widthPx), round1(p[1] * sh.heightPx)];
+    };
+    return {
+      annotations: rows.map((m) => ({
+        id: m.id, sheet: m.sheet_id, type: m.type, text: m.text,
+        condition: tagById.get(m.condition_id) ?? "", condition_id: m.condition_id,
+        ...(m.at ? { at: px(m, m.at) } : {}),
+        ...(m.target ? { target: px(m, m.target) } : {}),
+        ...(m.rect ? { rect: [px(m, m.rect[0]), px(m, m.rect[1])] } : {}),
+      })),
+      count: rows.length,
+      unattached: rows.filter((m) => !m.condition_id).length,
+    };
+  }
+
+  /** Attach an existing annotation to a condition, or detach it with "". The
+   *  canvas's Attach/Detach, reachable by an agent. */
+  linkAnnotation(id: string, condition: string): Record<string, unknown> {
+    const m = this.markups.find((x) => x.id === id);
+    if (!m) throw new UserError(`no annotation "${id}" — call list_annotations for real ids`);
+    if (!condition) {
+      m.condition_id = "";
+      return { id: m.id, condition: "", note: "Detached — now a note about the sheet." };
+    }
+    const c = this.conditionFor(condition);
+    m.condition_id = c.id;
+    return { id: m.id, condition: c.finish_tag, condition_id: c.id, note: `Attached to ${c.finish_tag}.` };
+  }
+
   /** The exact browser save payload (TakeoffCanvas.jsx autosave + the schema key
    * store.saveAnnotations stamps) — importable by the app. */
   exportPayload() {
@@ -982,7 +1091,7 @@ export class Session {
       sheets: [...this.sheets.values()].filter((s) => s.upp != null).map((s) => ({ sheet_id: s.key, units_per_px: s.upp })),
       conditions: this.conditions,
       shapes: this.shapes,
-      markups: [],
+      markups: this.markups,
       sheet_group: [],
       last_group: [],
       sheet_tabs: [],

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -13,6 +13,7 @@ import {
   exportTakeoffOutput, deleteShapeOutput, readSheetTextOutput,
   editShapeOutput, undoLastOutput, sheetContextOutput,
   findTextOutput, editMaterialsOutput,
+  annotateOutput, listAnnotationsOutput, linkAnnotationOutput,
 } from "./outputs.ts";
 
 // The coordinate contract, stated on every tool so any agent reading any one
@@ -242,4 +243,39 @@ export function registerTools(server: McpServer, session: Session): void {
     traceToolCall("view_sheet", a, startedAt, reply);
     return reply;
   });
+
+  // ── annotations (#114) — the agent half of markup.condition_id (#112) ──────
+  // A human could attach a note to a scope; an agent could not even SEE one
+  // (session.exportPayload hardcoded markups: []). These three close that.
+  server.registerTool("annotate", {
+    description: `Place an annotation on a sheet — a note ABOUT the work, never a measurement of it. Types: cloud and highlight take rect:[[x0,y0],[x1,y1]] (a revision cloud around an area, a highlight box over it), text takes at:[x,y], callout takes at:[x,y] plus target:[x,y] (the point its leader aims at). \n\nPass condition to attach the note to a finish tag, which is what makes it part of that SCOPE rather than a floating remark: it then wears the condition's colour on the canvas and in the marked-set PDF, and travels with it into the report. The tag is minted on first touch like one_click/measure_polygon, so you can annotate CPT-1 before anything is traced for it. Omit condition for a note about the sheet itself. \n\nNo review gate: the pencil-not-ink rule exists to stop an agent inventing geometry, and a cloud reading "verify substrate" is not geometry. It touches no quantity. ${COORDS}`,
+    inputSchema: {
+      sheet: z.string().describe("Sheet name or number, as sheet_info reports it"),
+      type: z.enum(["cloud", "text", "callout", "highlight"]).describe("cloud/highlight need rect; text/callout need at; callout also needs target"),
+      text: z.string().default("").describe("The note. A cloud with no text still reads as 'look here'"),
+      condition: z.string().optional().describe("Finish tag to attach this note to, e.g. 'CPT-1' (minted on first use). Omit for an unattached sheet note"),
+      at: pointSchema.optional().describe("Anchor point (image px) — text and callout"),
+      target: pointSchema.optional().describe("What a callout's leader line points at (image px)"),
+      rect: z.tuple([pointSchema, pointSchema]).optional().describe("Corners (image px) — cloud and highlight"),
+    },
+    outputSchema: annotateOutput,
+  }, run("annotate", (a) => session.annotate(a)));
+
+  server.registerTool("list_annotations", {
+    description: `Every annotation on the takeoff, with condition_id RESOLVED to its finish tag so you can act on the reply without joining against conditions[]. Filter by sheet, by condition, or both. Coordinates come back in image px (the same frame you passed in), not the normalized form they're stored as. \`unattached\` counts the notes carrying no condition — the candidates for link_annotation. ${COORDS}`,
+    inputSchema: {
+      sheet: z.string().optional().describe("Only annotations on this sheet"),
+      condition: z.string().optional().describe("Only annotations attached to this finish tag"),
+    },
+    outputSchema: listAnnotationsOutput,
+  }, run("list_annotations", (a) => session.listAnnotations(a)));
+
+  server.registerTool("link_annotation", {
+    description: `Attach an existing annotation to a condition, or detach it by passing an empty condition — the canvas's Attach/Detach control, reachable by an agent. Use it to tie up notes left unattached (list_annotations reports how many), or to move one to the finish it actually concerns. Attaching mints the tag on first use.`,
+    inputSchema: {
+      annotation_id: z.string().describe("Id from annotate or list_annotations"),
+      condition: z.string().describe("Finish tag to attach to; empty string detaches"),
+    },
+    outputSchema: linkAnnotationOutput,
+  }, run("link_annotation", (a) => session.linkAnnotation(a.annotation_id, a.condition)));
 }

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -48,15 +48,17 @@ async function captureStderr(fn: () => Promise<void>): Promise<string> {
 // supporting-materials config — so the coordinate contract would be noise in
 // their descriptions rather than orientation. Every other tool speaks image
 // px and says so.
-const NO_COORDS = new Set(["undo_last", "edit_materials"]);
+// link_annotation takes an id and a tag — no geometry crosses it, so the
+// coordinate contract would be noise rather than clarity.
+const NO_COORDS = new Set(["undo_last", "edit_materials", "link_annotation"]);
 
-test("tools/list: all seventeen tools, each described with the coordinate contract", async () => {
+test("tools/list: all twenty tools, each described with the coordinate contract", async () => {
   const client = await pair();
   const { tools } = await client.listTools();
   assert.deepEqual(tools.map((t) => t.name).sort(), [
-    "delete_shape", "detect_rooms", "edit_materials", "edit_shape", "export_takeoff", "find_text", "load_plan",
-    "measure_line", "measure_polygon", "one_click", "read_sheet_text", "set_scale", "sheet_context", "sheet_info",
-    "takeoff_summary", "undo_last", "view_sheet",
+    "annotate", "delete_shape", "detect_rooms", "edit_materials", "edit_shape", "export_takeoff", "find_text",
+    "link_annotation", "list_annotations", "load_plan", "measure_line", "measure_polygon", "one_click",
+    "read_sheet_text", "set_scale", "sheet_context", "sheet_info", "takeoff_summary", "undo_last", "view_sheet",
   ]);
   for (const t of tools) {
     if (NO_COORDS.has(t.name)) continue;
@@ -510,4 +512,74 @@ test("edit_materials: add/remove/patch, minted-on-touch, all-or-nothing, undo re
   const exported = await call(client, "export_takeoff", {});
   const cond = exported.data.conditions.find((c: any) => c.finish_tag === "CPT-1");
   assert.equal(cond.materials.length, 0, "undo restored the pre-add state");
+});
+
+// ── annotations (#114) — the agent half of markup.condition_id (#112) ────────
+
+test("annotate: attaches a note to a scope, resolves the tag back, and round-trips into the app payload", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+
+  const cloud = await call(client, "annotate", {
+    sheet: KEY, type: "cloud", text: "verify substrate before install",
+    rect: [[400, 900], [800, 1200]], condition: "CPT-1",
+  });
+  assert.equal(cloud.isError, false);
+  assert.equal(cloud.data.condition, "CPT-1");            // minted on first touch
+  assert.ok(cloud.data.condition_id);
+
+  // a sheet note, deliberately unattached
+  const note = await call(client, "annotate", { sheet: KEY, type: "text", text: "GC to confirm", at: [500, 500] });
+  assert.equal(note.data.condition, "");
+  assert.equal(note.data.condition_id, "");
+
+  const all = await call(client, "list_annotations", {});
+  assert.equal(all.data.count, 2);
+  assert.equal(all.data.unattached, 1);                    // the text note
+  // condition resolved for the caller — no join against conditions[] needed
+  const c = all.data.annotations.find((a: any) => a.id === cloud.data.id);
+  assert.equal(c.condition, "CPT-1");
+  // coordinates come back in the SAME image-px frame they went in as
+  assert.deepEqual(c.rect[0], [400, 900]);
+
+  // filtering by condition excludes the unattached note
+  const only = await call(client, "list_annotations", { condition: "CPT-1" });
+  assert.equal(only.data.count, 1);
+  assert.equal(only.data.annotations[0].id, cloud.data.id);
+
+  // the export the app imports carries them — markups used to be hardcoded []
+  const payload = await call(client, "export_takeoff", {});
+  assert.equal(payload.data.markups.length, 2);
+  const exported = payload.data.markups.find((m: any) => m.id === cloud.data.id);
+  assert.equal(exported.condition_id, cloud.data.condition_id);
+  assert.ok(exported.rect[0][0] > 0 && exported.rect[0][0] < 1, "stored normalized, like verts_norm");
+});
+
+test("link_annotation: attaches an orphan note, and detaches on an empty condition", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  const note = await call(client, "annotate", { sheet: KEY, type: "text", text: "chase this", at: [300, 300] });
+
+  const linked = await call(client, "link_annotation", { annotation_id: note.data.id, condition: "LVT-2" });
+  assert.equal(linked.isError, false);
+  assert.equal(linked.data.condition, "LVT-2");
+  assert.equal((await call(client, "list_annotations", {})).data.unattached, 0);
+
+  const off = await call(client, "link_annotation", { annotation_id: note.data.id, condition: "" });
+  assert.equal(off.data.condition, "");
+  assert.equal((await call(client, "list_annotations", {})).data.unattached, 1);
+
+  // a bad id is a user error, not a crash
+  const bad = await call(client, "link_annotation", { annotation_id: "mk-nope", condition: "LVT-2" });
+  assert.equal(bad.isError, true);
+});
+
+test("annotate: a shape-less type mismatch is refused before anything is written", async () => {
+  const client = await pair();
+  await call(client, "load_plan", { path: PLAN });
+  const noRect = await call(client, "annotate", { sheet: KEY, type: "cloud", text: "x" });   // cloud needs rect
+  assert.equal(noRect.isError, true);
+  const noTarget = await call(client, "annotate", { sheet: KEY, type: "callout", text: "x", at: [10, 10] });
+  assert.equal(noTarget.isError, true);
+  assert.equal((await call(client, "list_annotations", {})).data.count, 0);   // nothing written
 });


### PR DESCRIPTION
#112 let a **human** attach a note to a scope. An agent couldn't even see one — `session.exportPayload()` hardcoded `markups: []`, so the annotation layer was invisible to the MCP surface and uncreatable from it. Three tools close that.

| tool | what it does |
|---|---|
| `annotate` | place a cloud/highlight (rect), text (at), or callout (at + target), optionally attached to a finish tag |
| `list_annotations` | read them back with `condition_id` **resolved** to its finish tag, filterable by sheet and/or condition |
| `link_annotation` | attach an existing note, or detach with an empty condition — the canvas's Attach/Detach, reachable by an agent |

The tag is minted on first touch like `one_click`/`measure_polygon`, so an agent can note something about CPT-1 *before* anything is traced for CPT-1.

## No review gate, deliberately

The pencil-not-ink rule exists to stop an agent inventing **geometry**. A cloud reading "verify substrate" is not geometry and touches no quantity. Shapes stay gated; annotations don't.

## Round-trips into the app

Markups are stored normalized (0..1 of the sheet) exactly as the canvas stores them, and the tools convert at the boundary — the same contract every other tool honours. The test asserts this against `export_takeoff` rather than trusting it, including that the stored form really is normalized.

`list_annotations` returns coordinates in the **same image-px frame they went in as**, and reports `unattached` so an agent can find the orphans worth linking.

`link_annotation` joins `undo_last` and `edit_materials` in `NO_COORDS`: an id and a tag cross it, no geometry, so the coordinate contract would be noise rather than clarity.

## Dogfooding the guard

Version **0.8.0 → 0.9.0** — this is the first PR to touch `mcp/` since [#111](https://github.com/Kentucky-ai/opentakeoff/pull/111), so `mcp-version-guard` is doing exactly the job it was built for. I verified the bump, the three-way version agreement, and the unused-tag check locally before pushing.

## Verified

57 MCP tests pass — 3 new, covering attach + tag resolution + filtering + the export round-trip, link/detach including a bad id, and refusing a type/geometry mismatch **before writing anything**. `typecheck`, `build`, `smoke:dist` green. Both pinned tool lists and `docs/MCP.md` updated 17 → 20.