### PR TITLE
fix(ingest): mark wrapped images /Interpolate true so deep zoom stays smooth

### DIFF
--- a/web/src/lib/ingest.js
+++ b/web/src/lib/ingest.js
@@ -82,11 +82,40 @@ async function unzipBytes(bytes, onSkip, budget) {
   });
 }
 
+// Set /Interpolate true on the embedded image XObject so deep zoom stays SMOOTH
+// instead of snapping to hard nearest-neighbor blocks.
+//
+// pdf.js decides per-draw whether to smooth (getImageSmoothingEnabled): if the
+// image dict does NOT say /Interpolate true, it smooths only while the draw
+// transform's scale stays under dpr * 96/72 — about 2.67x on a retina display —
+// and turns smoothing OFF above that. pdf-lib's embedPng/embedJpg don't emit the
+// key, so every ingested scan or screenshot went blocky the moment you zoomed
+// past ~2.7x, which is early: a wrapped image page is sized in pixels-as-points,
+// so a 220-ppi sheet is already being magnified hard at normal working zoom.
+// Blocks are strictly worse than a soft edge when the whole job is deciding
+// where a finish boundary falls. The flag only affects MAGNIFICATION — pdf.js
+// already smooths on the way down, where the scale test passes on its own.
+//
+// Only the drawn image needs it: pdf.js reads Interpolate off the main image
+// dict and folds any SMask into that image's alpha before one composed draw, so
+// an alpha PNG's mask never carries the flag (asserted in test/ingest.test.ts).
+//
+// embedPng/embedJpg only RESERVE a ref; the XObject itself isn't in the context
+// until save() flushes it, so the dict can't be reached without forcing the
+// embed first. embed() is idempotent (it caches its own task), so the flush at
+// save time awaits the same work rather than redoing it.
+async function markInterpolated({ PDFName, PDFBool }, doc, img) {
+  await img.embed();
+  const stream = doc.context.lookup(img.ref);
+  stream?.dict?.set(PDFName.of("Interpolate"), PDFBool.True);
+}
+
 // Wrap a raster image into a single-page PDF at its native pixel size so it flows
 // through the same pdf.js path as a real plan. JPG/PNG embed directly; webp/gif/
 // bmp are decoded by the browser and re-encoded as PNG.
 async function imageToPdf(file) {
-  const { PDFDocument } = await import("pdf-lib");
+  const pdfLib = await import("pdf-lib");
+  const { PDFDocument } = pdfLib;
   const bytes = new Uint8Array(await file.arrayBuffer());
   const doc = await PDFDocument.create();
   let img, w, h;
@@ -102,6 +131,7 @@ async function imageToPdf(file) {
     const blob = await new Promise((res) => canvas.toBlob(res, "image/png"));
     img = await doc.embedPng(new Uint8Array(await blob.arrayBuffer())); w = bmp.width; h = bmp.height;
   }
+  await markInterpolated(pdfLib, doc, img);
   doc.addPage([w, h]).drawImage(img, { x: 0, y: 0, width: w, height: h });
   const name = baseName(file.name).replace(IMAGE_EXT, "") + ".pdf";
   return new File([await doc.save()], name, { type: "application/pdf" });

--- a/web/test/ingest.test.ts
+++ b/web/test/ingest.test.ts
@@ -1,17 +1,45 @@
-// Ingest guardrails — the zip-bomb / nested-archive caps in lib/ingest.js.
-// Real archives are built with fflate's zipSync so the caps run against genuine
-// zip headers (originalSize, nesting) rather than mocks. The image→PDF path is
-// browser-only (createImageBitmap/canvas) and deliberately untouched here; every
-// case uses PDF entries so the test stays DOM-free and node-runnable.
+// Ingest guardrails — the zip-bomb / nested-archive caps in lib/ingest.js, plus
+// the image→PDF wrap. Real archives are built with fflate's zipSync so the caps
+// run against genuine zip headers (originalSize, nesting) rather than mocks, and
+// the image cases use real PNG bytes through pdf-lib's embedPng. Only the
+// webp/gif/bmp branch is browser-only (createImageBitmap/canvas) and untested
+// here; everything below stays DOM-free and node-runnable.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { zipSync } from "fflate";
+import { PDFDocument, PDFName } from "pdf-lib";
 import { ingestFiles } from "../src/lib/ingest.js";
 
 const enc = new TextEncoder();
 const pdfBytes = (n = 1) => enc.encode("%PDF-1.4\n" + "x".repeat(n));
 const zipFile = (name: string, tree: Record<string, Uint8Array>) =>
   new File([zipSync(tree)], name, { type: "application/zip" });
+
+// 2x2 checkerboards, hand-encoded so no fixture file is needed: one opaque
+// (color type 2, the shape a plan scan takes) and one with alpha (color type 6,
+// what a screenshot takes) — the alpha case makes pdf-lib emit a second /Image
+// XObject as the SMask.
+const OPAQUE_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAE0lEQVR4nGNgYGD4//8/GDMwAAAp5AX71ZPZmwAAAABJRU5ErkJggg==";
+const ALPHA_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAF0lEQVR4nGNgYGBo+P///38GMMHA0AAAT0oI+QstIkIAAAAASUVORK5CYII=";
+const pngFile = (b64: string, name: string) =>
+  new File([Buffer.from(b64, "base64")], name, { type: "image/png" });
+
+/** Every /Image XObject in a saved PDF, as [ColorSpace, Interpolate] pairs. */
+async function imageXObjects(file: File) {
+  const doc = await PDFDocument.load(new Uint8Array(await file.arrayBuffer()));
+  const out: { cs: string; interpolate: string | undefined }[] = [];
+  for (const [, obj] of doc.context.enumerateIndirectObjects()) {
+    const dict = (obj as { dict?: { get(k: unknown): { toString(): string } | undefined } }).dict;
+    if (!dict || dict.get(PDFName.of("Subtype"))?.toString() !== "/Image") continue;
+    out.push({
+      cs: dict.get(PDFName.of("ColorSpace"))?.toString() ?? "",
+      interpolate: dict.get(PDFName.of("Interpolate"))?.toString(),
+    });
+  }
+  return out;
+}
 
 test("a plain zip of PDFs extracts them all", async () => {
   const zip = zipFile("plans.zip", { "A1.pdf": pdfBytes(), "A2.pdf": pdfBytes() });
@@ -64,4 +92,31 @@ test("the byte budget is shared across sibling entries in one ingest", async () 
   const { pdfs, skipped } = await ingestFiles([zip], { maxTotalBytes: 120 });
   assert.equal(pdfs.length, 1);
   assert.ok(skipped.some((s) => s.reason === "archive too large"));
+});
+
+test("an ingested image becomes a .pdf sized in pixels-as-points", async () => {
+  const { pdfs, skipped } = await ingestFiles([pngFile(OPAQUE_PNG, "finishplan-17.png")]);
+  assert.equal(skipped.length, 0);
+  assert.equal(pdfs[0].name, "finishplan-17.pdf");
+  const doc = await PDFDocument.load(new Uint8Array(await pdfs[0].arrayBuffer()));
+  assert.deepEqual(doc.getPage(0).getSize(), { width: 2, height: 2 });
+});
+
+test("an ingested image carries /Interpolate true so deep zoom stays smooth", async () => {
+  // Without the flag pdf.js turns image smoothing OFF once the draw transform's
+  // scale passes dpr * 96/72 (~2.67x on retina), so a wrapped scan snaps to hard
+  // nearest-neighbor blocks exactly where an estimator is deciding a boundary.
+  const { pdfs } = await ingestFiles([pngFile(OPAQUE_PNG, "scan.png")]);
+  assert.deepEqual(await imageXObjects(pdfs[0]), [{ cs: "/DeviceRGB", interpolate: "true" }]);
+});
+
+test("only the drawn image needs the flag — an alpha PNG's SMask is not drawn on its own", async () => {
+  // pdf.js reads Interpolate off the MAIN image dict and folds the SMask into
+  // that image's alpha before one composed draw, so the mask never carries it.
+  // Asserted rather than assumed: it's the reason this doesn't walk /SMask.
+  const { pdfs } = await ingestFiles([pngFile(ALPHA_PNG, "shot.png")]);
+  assert.deepEqual(await imageXObjects(pdfs[0]), [
+    { cs: "/DeviceRGB", interpolate: "true" },
+    { cs: "/DeviceGray", interpolate: undefined },
+  ]);
 });


### PR DESCRIPTION
## The bug

Drop a scan, a screenshot, or a sheet exported as PNG into OpenTakeoff and `ingestFiles` wraps it into a one-page PDF at native pixel size. pdf-lib's `embedPng`/`embedJpg` emit no `/Interpolate` key, and pdf.js reads that key to decide whether to smooth:

```js
function getImageSmoothingEnabled(transform, interpolate) {
  if (interpolate) return true;
  const scale = Util.singularValueDecompose2dScale(transform);
  ...
  return scale[0] <= actualScale && scale[1] <= actualScale;  // actualScale = dpr * 96/72
}
```

So smoothing is on only while the draw scale stays under ~2.67x on a retina display, and **off** above it. A wrapped image page is sized in pixels-as-points, so a 220-ppi sheet crosses that threshold at ordinary working zoom — and every line snaps to hard nearest-neighbor blocks.

Found on a real 36x24 sheet exported at 220 ppi (7920x5280).

## The fix

Set `/Interpolate true` on the embedded image XObject, handing the decision back to the browser's bilinear path.

Two things worth knowing, both documented at the call site:

- `embedPng`/`embedJpg` only **reserve a ref** — the XObject isn't in the context until `save()` flushes it, so the dict can't be reached without forcing the embed first. `img.embed()` caches its own task, so the flush at save time awaits the same work rather than redoing it.
- Only the **drawn** image needs the flag. pdf.js reads `Interpolate` off the main image dict and folds any SMask into that image's alpha before one composed draw, so an alpha PNG's mask never carries it. Asserted in the tests rather than assumed — it's the reason this doesn't walk `/SMask`.

This only affects **magnification**; pdf.js already smooths on the way down. And it can't recover detail the source never had — a raster sheet stays a raster sheet. It stops a soft edge being drawn as a staircase, which matters when the edge *is* the finish boundary someone is tracing.

## Verification

Same sheet, same 445% zoom, same display — deployed build vs. this branch:

| before (deployed) | after (this branch) |
|---|---|
| hard nearest-neighbor staircase | smooth |

Also covers the image→PDF path in `test/ingest.test.ts` for the first time — it's node-runnable for PNG/JPEG (only the webp/gif/bmp branch needs the DOM). The two `/Interpolate` assertions fail without the fix; verified by reverting the call and re-running.

`npm run check` green on the pinned Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)