### PR TITLE
feat(mcp): declare @napi-rs/canvas as optionalDependency so npx installs eyes

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -168,9 +168,10 @@ set becomes browsable natively (`resources/list` re-announces itself via
 Page numbers — not file-derived sheet keys — address resources, so URIs stay
 clean regardless of the PDF's name; the human-facing key (`plan.pdf#2`) and
 title-block number (`A-101`) ride along as the resource name and title.
-Rendering uses `@napi-rs/canvas` (pdf.js's own optional dependency): on a
-platform without a prebuilt binary every non-raster capability still works and
-the image read explains exactly what's missing.
+Rendering uses `@napi-rs/canvas`, declared as this package's own optional
+dependency so a plain `npx opentakeoff-mcp` installs the prebuilt binary and
+arrives with eyes; on a platform without a prebuilt binary every non-raster
+capability still works and the image read explains exactly what's missing.
 
 The intended agent loop: read `takeoff://sheets` → look at
 `takeoff://sheet/{page}/image` → pick click targets → measure with the tools.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.8.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -24,6 +24,9 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.100"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",
@@ -22,6 +22,9 @@
     "@modelcontextprotocol/sdk": "^1.12.0",
     "pdfjs-dist": "^4.10.38",
     "zod": "^3.24.1"
+  },
+  "optionalDependencies": {
+    "@napi-rs/canvas": "^0.1.100"
   },
   "devDependencies": {
     "@types/node": "^22.19.21",


### PR DESCRIPTION
A bare `npx opentakeoff-mcp` has no eyes: `view_sheet` and the `takeoff://sheet/{page}/image` resources error cleanly because `@napi-rs/canvas` never installs — npm drops pdf.js's transitive optional dependency in that flow. Every geometry tool works; the agent just can't see.

**Fix:** declare `@napi-rs/canvas` directly in `optionalDependencies` (`^0.1.100`, intersecting pdfjs-dist's own `^0.1.65` range so npm keeps one copy). Prebuilt darwin/linux/win binaries exist, and optional dependencies fail soft — a platform without a prebuilt binary installs fine and keeps the existing clean `view_sheet` error. Version bumped 0.9.0 → 0.9.1 for the release gate.

**Verified:** `npm run typecheck` clean, 57/57 tests pass, `npm run build` + `npm run smoke:dist` green on Node 24; `createCanvas → toBuffer('image/png')` round-trips against the freshly installed optional dep.