### PR TITLE
fix(mcp): bump server.json with package.json — 0.9.2

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.0",
+  "version": "0.9.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.0",
+      "version": "0.9.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
The `mcp-v0.9.1` tag failed the publish workflow's version-consistency gate: #122 bumped `package.json` but not `server.json` (`.version` and `.packages[0].version` both still 0.9.0). The gate fired before any publish step, so nothing reached npm or the registry — 0.9.1 is skipped, its tag deleted, and 0.9.2 becomes the release that ships the `@napi-rs/canvas` optionalDependency.

All three version fields now agree at 0.9.2; lockfile synced.