### PR TITLE
fix(import): replace path keeps the operator's open view

### DIFF
--- a/web/src/lib/importTakeoff.js
+++ b/web/src/lib/importTakeoff.js
@@ -75,8 +75,19 @@ export function mergeTakeoffImport(current, imported, knownFiles = null) {
   // don't block the clean-replace path (a pre-traced calibration would be rare
   // enough here that predictability wins over preserving it).
   if (!arr(cur.shapes).length && !arr(cur.markups).length) {
+    // …except the VIEW. An MCP export typically carries empty tab/group
+    // state (the session has no such concept), and adopting an empty list
+    // would close the operator's open sheet and bounce them to the gallery
+    // mid-import — the shapes land on a sheet they're no longer looking at.
+    // Empty carries no intent; a NON-empty imported view is real state and wins.
+    const payload = {
+      ...imported,
+      ...(arr(imported.sheet_tabs).length ? {} : { sheet_tabs: arr(cur.sheet_tabs) }),
+      ...(arr(imported.sheet_group).length ? {} : { sheet_group: arr(cur.sheet_group) }),
+      ...(arr(imported.last_group).length ? {} : { last_group: arr(cur.last_group) }),
+    };
     return {
-      payload: imported,
+      payload,
       note: { replaced: true, shapes_added: impShapes.length, shapes_pending: pendingCount(impShapes), conditions_merged: 0, conditions_added: impConds.length, scales_adopted: arr(imported.sheets).length, unknown_files: unknownFiles(impShapes) },
     };
   }

--- a/web/test/importTakeoff.test.ts
+++ b/web/test/importTakeoff.test.ts
@@ -35,6 +35,19 @@ test("empty project: import replaces wholesale (seeded conditions are not work)"
   assert.equal(note.shapes_pending, 1);   // reviewed:false counts as pending
 });
 
+test("replace keeps the operator's open view when the export carries none", () => {
+  // An MCP export has empty sheet_tabs/groups — adopting them would bounce
+  // the operator from their open sheet to the gallery mid-import.
+  const current = { shapes: [], markups: [], conditions: [], sheets: [], sheet_tabs: ["va.pdf"], sheet_group: ["va.pdf", "va.pdf#2"], last_group: ["va.pdf", "va.pdf#2"] };
+  const { payload, note } = mergeTakeoffImport(current, doc({ sheet_tabs: [], sheet_group: [], last_group: [] }));
+  assert.equal(note.replaced, true);
+  assert.deepEqual(payload.sheet_tabs, ["va.pdf"]);
+  assert.deepEqual(payload.sheet_group, ["va.pdf", "va.pdf#2"]);
+  // …but a NON-empty imported view is real state and wins on replace
+  const explicit = mergeTakeoffImport(current, doc({ sheet_tabs: ["va.pdf#3"] }));
+  assert.deepEqual(explicit.payload.sheet_tabs, ["va.pdf#3"]);
+});
+
 test("merge: same finish tag joins the operator's condition — no duplicate, shapes remapped", () => {
   const current = {
     conditions: [{ id: "mine", finish_tag: " cpt-1 " }],   // tag match is case/space-insensitive


### PR DESCRIPTION
An MCP export carries empty sheet_tabs/groups (the session has no tab
concept); adopting them on the clean-replace path closed the open sheet
and bounced the operator to the gallery mid-import — the shapes landed on
a sheet they were no longer looking at. Empty view state carries no
intent, so the operator's tabs/groups survive; a non-empty imported view
is real state and still wins. Caught live on the VA-plan acceptance run.
