### PR TITLE
Landing: open-source credit line linking kentucky-ai.com

### DIFF
--- a/web/src/components/PlanNavigator.jsx
+++ b/web/src/components/PlanNavigator.jsx
@@ -563,6 +563,10 @@ export default function PlanNavigator({
                   A real medical-center <strong style={{ color: "var(--ink)" }}>floor finish plan</strong> — the scale auto-detects;
                   pick a finish and trace a flooring takeoff in seconds.
                 </div>
+                <div style={{ marginTop: 30, fontFamily: "var(--f-mono)", fontSize: 10.5, letterSpacing: "0.1em", color: "var(--text-faint)" }}>
+                  Apache-2.0 open source · an open project by{" "}
+                  <a href="https://kentucky-ai.com" target="_blank" rel="noopener" style={{ color: "var(--ink-muted)" }}>Kentucky&nbsp;AI</a>
+                </div>
               </div>
             ) : enumerated ? (
               <>


### PR DESCRIPTION
Adds a one-line credit under the sample-plan block on the empty plan-set state: "Apache-2.0 open source · an open project by Kentucky AI", linking kentucky-ai.com. Empty state only — zero chrome on the canvas.

Verified rendering on localhost:5173 (headless DOM dump shows the anchor); `npm run check` green on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)