### PR TITLE
Cut Outs subtract as real holes — compose per parent, never double-deduct

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
+        "@turf/boolean-contains": "^7.3.5",
+        "@turf/boolean-overlap": "^7.3.5",
+        "@turf/difference": "^7.3.5",
+        "@turf/helpers": "^7.3.5",
         "fflate": "^0.8.3",
         "pdf-lib": "^1.17.1",
         "pdfjs-dist": "^4.10.38",
@@ -2306,6 +2310,387 @@
         "win32"
       ]
     },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.5.tgz",
+      "integrity": "sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.5.tgz",
+      "integrity": "sha512-P4JUAHgvJkD+8ybQ6d1OHp9TBsGsjJxF5lWeXJgp0k4+Hd/D0CVy4/mhLkZdNa6QdljVdwNcfU0CTqy1WsSQig==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/boolean-point-in-polygon": "7.3.5",
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-split": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.3.5.tgz",
+      "integrity": "sha512-DUeiPVqFSTjW79erPbo780pRcKCRad59NcscVsTYkZD/92peF/4rQvHbvAUpUDPZaQCxe+mvfeDHfUFmfVKCGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-overlap": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-overlap/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.5.tgz",
+      "integrity": "sha512-ba7+B0wzaS9GtERZOoXUZ6oW8IcIJHNQZf3c+tiD9ESjcsPO1Q/4qIJGTKl92nBLhhracHJxMWBM/U6hAVkaRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-TuWfrAT63W43BDzgYc94UzQ5/PjF1aTnh4AIzmQwez1YnimShYcOTwo8OIHzDaB6gbbvFsfxYMuOA5JOp942Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.5.tgz",
+      "integrity": "sha512-iDyWYCvgS3vgB8W1ai2cvfJaTq9bOt1QghiVkCNIyccF97CgtYJzenREVVUlp8qU9lJlbQ/ameyKvXPA1uOAlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.5.tgz",
+      "integrity": "sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.5.tgz",
+      "integrity": "sha512-30/hQqc+ErnlcavvDdxGfgm8VtsJDEzSYpf3mPqYxOyI976l49T6+1jCQD5xKswml6o8zZAaTSe6ZcSKF+SCNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.5.tgz",
+      "integrity": "sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.5.tgz",
+      "integrity": "sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.5.tgz",
+      "integrity": "sha512-2Cl4oPsjaDdfIwz/5IRDdG2fNdfp3W6atICm81vnzl/GwURoVP+CLjXJ64QWWzpzIbgX2XprJQTmamByDt5MDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.3.5.tgz",
+      "integrity": "sha512-7lZMWYHuzM6EMlL5pIIi/Nh7GLsM7ilW8/jVyHP1yGfQ0c0YAUoJd/Xy3J2+9v8OkYiZW/t2LdwVoTmCEJLWxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "fast-deep-equal": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-overlap/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.5.tgz",
+      "integrity": "sha512-TM1aCu7utM6fllAEHO8PNqBJZ/uoFJVNp2A0YI7FyWN928hPbacsvNtLeVz/Kq1ZbeqQ1ZIKRxo9FdVjaj8hGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.5.tgz",
+      "integrity": "sha512-GEuy+LdbbaqtYjHk/i1G8sK51wfCdPqTO8uH0dJZ6WlcIcZQfRcKKI4ksFm7NkVyfmw8gXWbpMJD8lO380GFBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.5",
+        "@turf/geojson-rbush": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/line-intersect": "7.3.5",
+        "@turf/line-segment": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@turf/nearest-point-on-line": "7.3.5",
+        "@turf/truncate": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.5.tgz",
+      "integrity": "sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.5.tgz",
+      "integrity": "sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.5",
+        "@turf/helpers": "7.3.5",
+        "@turf/invariant": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.5.tgz",
+      "integrity": "sha512-Qx2iv3KIqKuDAUduMfaJ5fFegEWBeRve5zePalRevS16bMUqEX+jnKPK9fWGyUuPqT61qP1Kybz0PTWPbUbljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.5",
+        "@turf/meta": "7.3.5",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2356,6 +2741,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2513,6 +2904,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/boolean": {
@@ -3041,7 +3441,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3162,6 +3561,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geojson-equality-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
+      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.14"
       }
     },
     "node_modules/glob-parent": {
@@ -3775,6 +4183,25 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
       "license": "MIT"
     },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
@@ -3845,6 +4272,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
       }
     },
     "node_modules/react": {
@@ -3930,6 +4372,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.62.0",
@@ -4116,6 +4564,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -4148,6 +4602,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4164,6 +4627,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "node_modules/tslib": {
       "version": "1.14.1",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "description": "OpenTakeoff \u2014 a free, open-source PDF takeoff canvas for flooring contractors.",
+  "description": "OpenTakeoff — a free, open-source PDF takeoff canvas for flooring contractors.",
   "license": "Apache-2.0",
   "scripts": {
     "dev": "vite",
@@ -19,6 +19,10 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
+    "@turf/boolean-contains": "^7.3.5",
+    "@turf/boolean-overlap": "^7.3.5",
+    "@turf/difference": "^7.3.5",
+    "@turf/helpers": "^7.3.5",
     "fflate": "^0.8.3",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^4.10.38",

--- a/web/src/components/TakeoffsPanel.jsx
+++ b/web/src/components/TakeoffsPanel.jsx
@@ -425,7 +425,7 @@ export function ConditionAppearanceEditor({ cond: c, onUpdateCond, onSetCondPara
 
 function TakeoffsPanel({
   open, width, multiSheet, units = "imperial",
-  conditions, activeCond, visRowById, conditionColumns, shapeLabels = [], templates, palette = [],
+  conditions, activeCond, visRowById, projRowById = new Map(), conditionColumns, shapeLabels = [], templates, palette = [],
   matLib, matLibById, linkedCountById,
   panelPrefs, onPanelPrefs, reassigning, epoch, clearSelectionRef,
   onActivate, onSetActive, onLocate,
@@ -586,6 +586,14 @@ function TakeoffsPanel({
     const mult = c.multiplier || 1;
     const sf = row?.floor_sf || 0, lf = row?.lf || 0, ea = row?.ea || 0, wsf = row?.wall_sf || 0;
     const shapeCount = row?.shape_count || 0;
+    // whole-project Σ suffix (#137): shown ONLY when the project holds more
+    // than the open sheets, so the common everything-on-this-sheet case stays
+    // one number. A condition entirely on closed sheets reads "Σ 412 SF"
+    // instead of a dead "—".
+    const qtys = (o) => [o.sf ? fa(o.sf) : "", o.wsf ? `${fa(o.wsf)} wall` : "", o.lf ? fl(o.lf) : "", o.ea ? `${num(o.ea, 0)} EA` : ""].filter(Boolean).join(" · ");
+    const pr = projRowById.get(c.id);
+    const prQ = pr ? { sf: pr.floor_sf || 0, wsf: pr.wall_sf || 0, lf: pr.lf || 0, ea: pr.ea || 0 } : null;
+    const projDiff = prQ && (Math.abs(prQ.sf - sf) > 0.005 || Math.abs(prQ.wsf - wsf) > 0.005 || Math.abs(prQ.lf - lf) > 0.005 || Math.abs(prQ.ea - ea) > 0.005);
     const on = c.id === activeCond;
     const matOn = on && panelMatOpen;
     const checked = checkedConds.has(c.id);
@@ -613,7 +621,12 @@ function TakeoffsPanel({
           <div style={{ minWidth: 0, flex: 1 }}>
             <div style={{ fontWeight: on ? 700 : 600, color: "var(--ink)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{c.finish_tag}{mult > 1 ? <span style={{ color: "var(--ink-muted)", fontWeight: 500 }}> ×{mult}</span> : null}</div>
             <div style={{ fontFamily: "var(--f-mono,monospace)", fontSize: 11, color: "var(--ink-muted)" }}>
-              {sf ? fa(sf) : ""}{wsf ? `${sf ? " · " : ""}${fa(wsf)} wall` : ""}{lf ? `${sf || wsf ? " · " : ""}${fl(lf)}` : ""}{ea ? `${sf || wsf || lf ? " · " : ""}${num(ea, 0)} EA` : ""}{!sf && !wsf && !lf && !ea ? "—" : ""}
+              {qtys({ sf, wsf, lf, ea })}{!sf && !wsf && !lf && !ea && !projDiff ? "—" : ""}
+              {projDiff ? (
+                <span title="Σ = whole project, every sheet. The leading numbers count the open sheets only." style={{ color: "var(--ink-faint)" }}>
+                  {(sf || wsf || lf || ea) ? " · " : ""}Σ {qtys(prQ) || "0"}
+                </span>
+              ) : null}
             </div>
           </div>
           <span style={{ fontFamily: "var(--f-mono,monospace)", fontSize: 10.5, color: "var(--ink-muted)", flexShrink: 0 }}>{shapeCount}▦</span>

--- a/web/src/lib/cutout.js
+++ b/web/src/lib/cutout.js
@@ -1,0 +1,148 @@
+// Real polygon boolean subtraction for the Eraser/deduct tool — #137.
+//
+// Before this, a cutout committed as a second, independent shape
+// (measure_role: "deduct") sitting on top of its condition's polygon; totals
+// did plain arithmetic (sum floor_area, subtract deduct's area_sf), and the
+// canvas painted a red hatch decal over the condition instead of an actual
+// hole. No multi-ring polygon ever existed anywhere in the data model, so
+// perimeter/LF never shrank around the cut and a deduct that touched the
+// condition's edge didn't clip correctly.
+//
+// This module runs the real boolean subtract (turf `difference`) between a
+// parent floor_area shape's own ring and the deduct's ring, and hands back
+// the result as an outer ring + hole ring(s) — TakeoffCanvas.commitPoly
+// stores that on the parent as `verts_norm_holes` (see lib/shapeCommands.js's
+// `cutout` command) instead of minting a second overlapping shape.
+//
+// Coordinate convention: pixel-space in, pixel-space out — the SAME
+// panel-relative px used everywhere else in this file (closedMetrics,
+// commitPoly). Turf's boolean ops (difference/booleanContains/booleanOverlap)
+// are purely topological — ray-casting and winding, not spherical trig — so
+// running them on plain image px instead of lon/lat is safe. Only turf's
+// MEASUREMENT functions (area/length/distance/bearing) assume a sphere; this
+// module never calls those. Area/perimeter come from closedMetrics via
+// polyWithHolesMetrics, exactly like every other shape on this canvas.
+//
+// Scope (see #137 and its follow-up issue for the fuller story): this
+// resolves a deduct against a SINGLE, unambiguous parent floor_area shape on
+// the same sheet — including a parent that ALREADY carries reconciled
+// cutout(s): the new ring subtracts against (outer + existing holes), so N
+// deducts compose into N holes and the overlap between two deducts is never
+// double-subtracted (set subtraction). A deduct that touches/overlaps more
+// than one floor_area shape is intentionally left AMBIGUOUS here — the
+// caller (TakeoffCanvas.resolveCutout) treats a null return as "fall back to
+// the legacy independent-shape behavior," which stays exactly as safe as it
+// was before this file existed. Feeding the real hole geometry to export
+// (JobHub/DXF) is follow-up work.
+import { polygon as turfPolygon, featureCollection } from "@turf/helpers";
+import turfDifference from "@turf/difference";
+import booleanOverlap from "@turf/boolean-overlap";
+import booleanContains from "@turf/boolean-contains";
+import { polyWithHolesMetrics } from "./geometry.js";
+
+// GeoJSON rings are CLOSED (first === last); this canvas's rings are OPEN
+// (verts_norm never repeats the closing vertex — see closedMetrics). These
+// two convert at the turf boundary only; nothing outside this file should
+// ever see a closed ring.
+const closeRing = (pts) => {
+  if (!pts.length) return pts;
+  const [x0, y0] = pts[0], [xn, yn] = pts[pts.length - 1];
+  return (x0 === xn && y0 === yn) ? pts : [...pts, [x0, y0]];
+};
+const openRing = (pts) => {
+  if (pts.length > 1) {
+    const [x0, y0] = pts[0], [xn, yn] = pts[pts.length - 1];
+    if (x0 === xn && y0 === yn) return pts.slice(0, -1);
+  }
+  return pts;
+};
+
+// True when `ringA` (the deduct) meaningfully touches `ringB` (a candidate
+// parent's outer ring) — fully contained OR a partial/edge overlap (the
+// "hole touches the edge" case). booleanOverlap alone misses full
+// containment by its own definition (true only when NEITHER fully contains
+// the other), so both checks are needed. Malformed rings (self-intersecting,
+// <3 points) fail closed (not a match) rather than throwing.
+function touches(ringA, ringB) {
+  if (ringA.length < 3 || ringB.length < 3) return false;
+  try {
+    const a = turfPolygon([closeRing(ringA)]);
+    const b = turfPolygon([closeRing(ringB)]);
+    return booleanContains(b, a) || booleanOverlap(a, b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Finds the ONE candidate this deduct ring resolves against.
+ * @param {Array<{id: string, ringPx: number[][]}>} candidates floor_area
+ *   shapes on the SAME sheet as the deduct, outer ring already denormalized
+ *   to the panel's px space. Containment tests run against the OUTER ring
+ *   only — a deduct landing inside an existing hole still resolves to that
+ *   parent (and subtracts nothing new, which is the correct net).
+ * @param {number[][]} deductRingPx the deduct's own ring, same px space.
+ * @returns {string|null} the unique parent's id, or null (zero or 2+ hits —
+ *   ambiguous, caller falls back to the legacy independent-shape path).
+ */
+export function findCutoutParent(candidates, deductRingPx) {
+  const hits = candidates.filter(({ ringPx }) => touches(deductRingPx, ringPx));
+  return hits.length === 1 ? hits[0].id : null;
+}
+
+/**
+ * Runs the real boolean subtract: (parent outer ring + its existing holes)
+ * minus the deduct ring. Returns null — never a guess — when the op fails or
+ * degenerates: the deduct erases the parent outright (turf hands back null),
+ * or splits it into disjoint pieces (a MultiPolygon result) — both are
+ * genuinely harder cases than "cut a hole in this shape" and stay on the
+ * legacy path rather than silently picking one piece.
+ * @param {number[][]} outerRingPx parent's own outer ring, px space.
+ * @param {number[][][]} holeRingsPx parent's EXISTING holes, px space (empty
+ *   for the common single-cutout case).
+ * @param {number[][]} deductRingPx the new deduct's ring, px space.
+ * @returns {{outer: number[][], holes: number[][][], area: number, perim: number}|null}
+ *   outer/holes are OPEN rings (this canvas's convention); area/perim are the
+ *   same pixel-space units closedMetrics returns (caller scales by upp/upp²).
+ */
+export function subtractCutout(outerRingPx, holeRingsPx, deductRingPx) {
+  let result;
+  try {
+    const parentPoly = turfPolygon([closeRing(outerRingPx), ...holeRingsPx.map(closeRing)]);
+    const deductPoly = turfPolygon([closeRing(deductRingPx)]);
+    result = turfDifference(featureCollection([parentPoly, deductPoly]));
+  } catch {
+    return null;
+  }
+  if (!result || result.geometry?.type !== "Polygon") return null;
+  const [outer, ...holes] = result.geometry.coordinates.map(openRing);
+  if (outer.length < 3) return null;
+  const metrics = polyWithHolesMetrics(outer, holes);
+  return { outer, holes, area: metrics.area, perim: metrics.perim };
+}
+
+/**
+ * Re-derives a parent's geometry after ONE cutout in a multi-cut chain is
+ * deleted: starts from a pristine base (the chain's EARLIEST frozen
+ * parent_prev snapshot) and re-subtracts every SURVIVING deduct ring in
+ * order. Set subtraction is order-insensitive, but commit order keeps each
+ * intermediate step identical to how it first resolved. Zero surviving rings
+ * → the base itself with fresh metrics.
+ * @param {number[][]} baseOuterPx pristine outer ring, px space.
+ * @param {number[][][]} baseHolesPx pristine holes (usually empty), px space.
+ * @param {number[][][]} deductRingsPx surviving deduct rings, commit order.
+ * @returns {{outer: number[][], holes: number[][][], area: number, perim: number}|null}
+ *   null when any re-subtract degenerates — the caller must NOT restore the
+ *   pristine base over surviving cuts; it falls back to a plain delete that
+ *   leaves the doomed cut baked in (the pre-existing multi-delete limitation).
+ */
+export function recomposeCutouts(baseOuterPx, baseHolesPx, deductRingsPx) {
+  let outer = baseOuterPx, holes = baseHolesPx;
+  for (const ring of deductRingsPx) {
+    const r = subtractCutout(outer, holes, ring);
+    if (!r) return null;
+    outer = r.outer; holes = r.holes;
+  }
+  const metrics = polyWithHolesMetrics(outer, holes);
+  return { outer, holes, area: metrics.area, perim: metrics.perim };
+}

--- a/web/src/lib/geometry.js
+++ b/web/src/lib/geometry.js
@@ -177,6 +177,23 @@ export function closedMetrics(pts) {
   return { area: Math.abs(area) / 2, perim };
 }
 export function openLen(pts) { let L = 0; for (let i = 1; i < pts.length; i++) L += Math.hypot(pts[i][0] - pts[i - 1][0], pts[i][1] - pts[i - 1][1]); return L; }
+// #137 — a polygon that carries real holes (verts_norm_holes: a Cut Out that
+// was reconciled into the parent's own geometry via a real boolean subtract,
+// see lib/cutout.js): outer ring's area LESS every hole's, perimeter PLUS
+// every hole's boundary — a hole is a real wall, it gets walked same as the
+// outer ring, not zeroed out. Same pixel-space-in/pixel-space-out convention
+// as closedMetrics (caller scales by upp/upp²). Floors at 0 so a degenerate
+// hole set (shouldn't happen off a real turf.difference result, but a stale
+// hand-edited project file could carry one) can't hand back negative SF.
+export function polyWithHolesMetrics(outerPts, holesPts = []) {
+  const outer = closedMetrics(outerPts);
+  let area = outer.area, perim = outer.perim;
+  for (const h of holesPts) {
+    const hm = closedMetrics(h);
+    area -= hm.area; perim += hm.perim;
+  }
+  return { area: Math.max(0, area), perim };
+}
 export function pointInPoly(x, y, pts) {
   let inside = false;
   for (let i = 0, j = pts.length - 1; i < pts.length; j = i++) {
@@ -192,12 +209,22 @@ export function distToSeg(px, py, ax, ay, bx, by) {
 }
 
 // does (x,y) image-px hit this shape (within thr px)?
+// #137 — hole-aware: a shape carrying verts_norm_holes (a real Cut Out) does
+// NOT hit-test true for a point strictly inside one of its holes — clicking
+// into the cut should reach whatever's underneath (or nothing), not the
+// condition it was cut out of. The hole's own boundary still counts as an
+// edge hit, exactly like the outer ring's. No-op (byte-identical to before)
+// when the shape carries no holes.
 export function hitShape(shape, x, y, w, h, thr) {
   const pts = shape.verts_norm.map(([nx, ny]) => [nx * w, ny * h]);
   if (shape.measure_role === "count") return Math.hypot(pts[0][0] - x, pts[0][1] - y) < thr * 2;
   if (shape.measure_role === "linear" || shape.measure_role === "surface_area") { for (let i = 1; i < pts.length; i++) if (distToSeg(x, y, pts[i - 1][0], pts[i - 1][1], pts[i][0], pts[i][1]) < thr) return true; return false; }
-  if (pointInPoly(x, y, pts)) return true;
+  const holes = (shape.verts_norm_holes || []).map((ring) => ring.map(([nx, ny]) => [nx * w, ny * h]));
+  if (pointInPoly(x, y, pts) && !holes.some((hpts) => pointInPoly(x, y, hpts))) return true;
   for (let i = 0; i < pts.length; i++) { const j = (i + 1) % pts.length; if (distToSeg(x, y, pts[i][0], pts[i][1], pts[j][0], pts[j][1]) < thr) return true; }
+  for (const hpts of holes) {
+    for (let i = 0; i < hpts.length; i++) { const j = (i + 1) % hpts.length; if (distToSeg(x, y, hpts[i][0], hpts[i][1], hpts[j][0], hpts[j][1]) < thr) return true; }
+  }
   return false;
 }
 

--- a/web/src/lib/shapeCommands.js
+++ b/web/src/lib/shapeCommands.js
@@ -55,6 +55,14 @@
 //             an edit; post-accept edits grade through geom/stampEdit as
 //             usual). Shapes not pending are untouched. `restore` puts the
 //             prior origin back verbatim — undo of an accept is un-accepting.
+//   cutout    #137 — mints the deduct shape (add semantics: id + created_at)
+//             AND patches its PARENT's verts_norm/verts_norm_holes/computed
+//             together as ONE undo entry (a real polygon boolean subtract,
+//             not a second independent overlay). The parent patch stamps
+//             NOTHING — the reconciliation is derived from the deduct
+//             gesture, not a parent edit — and nothing counts. `restore`
+//             (undo of a draw, or an explicit delete of the reconciled
+//             deduct) unmints the deduct and puts the parent back verbatim.
 // ─────────────────────────────────────────────────────────────────────────────
 import { mintUuid, nowIso, stampEdit } from "./provenance.js";
 import { assignShapeLabel } from "./shapeLabels.js";
@@ -68,6 +76,7 @@ export const PROVENANCE_POLICY = {
   replace: "no stamp, no counted, no undo entry (whole-array non-edit)",
   review: "origin.reviewed → true + accepted_ts per still-pending shape; restore puts the prior origin back verbatim",
   ruleApply: "add semantics (created_at + id mint per shape, ONE undo entry per batch); caller-built rule_v1 origin carries rule_id + seed_shape_id",
+  cutout: "#137 — mints the deduct (id + created_at) AND patches its parent's verts_norm/verts_norm_holes/computed as ONE undo entry; parent patch stamps nothing, nothing counts; restore unmints the deduct and reverts the parent verbatim",
 };
 
 // Undo depth — one bounded gesture history, not an archive (revisions are).
@@ -114,6 +123,22 @@ const withGeomFields = (s, snap) => {
   if ("computed" in snap) out.computed = snap.computed; else delete out.computed;
   if ("updated_at" in snap) out.updated_at = snap.updated_at; else delete out.updated_at;
   if ("origin" in snap) out.origin = snap.origin; else delete out.origin;
+  return out;
+};
+
+// #137 — the PARENT-shape half of a cutout: verts_norm always set (the outer
+// ring), verts_norm_holes and computed presence-aware — a parent that has
+// never carried a hole must come back from undo with no verts_norm_holes key
+// at all, matching every other presence-aware snapshot in this file.
+const cutoutSnapshot = (s) => ({
+  verts_norm: s.verts_norm.map((v) => [...v]),
+  ...("verts_norm_holes" in s ? { verts_norm_holes: s.verts_norm_holes.map((r) => r.map((v) => [...v])) } : {}),
+  ...("computed" in s ? { computed: s.computed } : {}),
+});
+const withCutout = (s, patch) => {
+  const out = { ...s, verts_norm: patch.verts_norm };
+  if ("verts_norm_holes" in patch) out.verts_norm_holes = patch.verts_norm_holes; else delete out.verts_norm_holes;
+  if ("computed" in patch) out.computed = patch.computed; else delete out.computed;
   return out;
 };
 
@@ -263,6 +288,35 @@ export function applyShapeCommand(shapes, cmd) {
       // canvas clears both stacks alongside (a restored timeline starts fresh,
       // and a rescale invalidates every recorded `computed`).
       return { shapes: Array.isArray(cmd.shapes) ? cmd.shapes : [], inverse: null };
+    case "cutout": {
+      // restore (undo of a draw, or an explicit delete of the reconciled
+      // deduct — see TakeoffCanvas.deleteSelected): drop the deduct shape,
+      // put the parent back exactly as the caller says (the pre-cut snapshot,
+      // or a multi-cut rebuild — see cutout.recomposeCutouts).
+      if (cmd.restore) {
+        const removed = shapes.find((s) => s.id === cmd.deductId);
+        if (!removed) return { shapes, inverse: null };
+        let redoParentNext = null;
+        const next = shapes.filter((s) => s.id !== cmd.deductId).map((s) => {
+          if (s.id !== cmd.parentId) return s;
+          redoParentNext = cutoutSnapshot(s);
+          return withCutout(s, cmd.parentPrev);
+        });
+        if (!redoParentNext) return { shapes, inverse: null };   // parent vanished — refuse rather than orphan the patch
+        return { shapes: next, inverse: { type: "cutout", shape: removed, parentId: cmd.parentId, parentNext: redoParentNext } };
+      }
+      // forward: mint the deduct shape (add semantics), patch the parent in place.
+      const minted = cmd.shape.id ? cmd.shape : { id: `shp-${mintUuid()}`, created_at: nowIso(), ...cmd.shape };
+      let parentPrev = null;
+      const next = shapes.map((s) => {
+        if (s.id !== cmd.parentId) return s;
+        parentPrev = cutoutSnapshot(s);
+        return withCutout(s, cmd.parentNext);
+      });
+      if (!parentPrev) return { shapes, inverse: null };   // parent vanished mid-gesture — refuse rather than mint an orphaned deduct
+      next.push(minted);
+      return { shapes: next, inverse: { type: "cutout", restore: true, deductId: minted.id, parentId: cmd.parentId, parentPrev } };
+    }
     case "review": {
       if (cmd.restore) {
         // restore rows put the recorded origin back verbatim; the inverse is

--- a/web/src/lib/shapeMetrics.js
+++ b/web/src/lib/shapeMetrics.js
@@ -1,0 +1,61 @@
+// The ONE role-aware shape-quantity computer — extracted from
+// TakeoffCanvas.recomputeShape so callers that have no mounted panel can
+// price a shape too: the load-time heal (a shape that ARRIVES without
+// `computed` — an import that carried geometry only — draws fine but reads
+// as 0 SF in every summer and silently zeroes its condition's totals), and
+// node tests. recomputeShape stays the canvas-side wrapper (panel dims +
+// scale + cond lookup); the math lives here, once.
+//
+// `dims` is the sheet's logical image size — pdf.js viewport at
+// RENDER_SCALE, the same frame verts_norm normalizes against. `upp` is that
+// sheet's units-per-px at the SAME baseline. `cond` is the shape's condition
+// record (surface height / linear thickness defaults).
+import { closedMetrics, openLen, polyWithHolesMetrics } from "./geometry.js";
+import { flattenCurve } from "./curve.js";
+
+export function computeShapeMetrics(s, dims, upp, cond) {
+  const pts = (s.verts_norm || []).map(([nx, ny]) => [nx * dims.w, ny * dims.h]);
+  const u = upp || 0;
+  if (s.measure_role === "count") return { count: 1 };
+  if (s.measure_role === "surface_area") {
+    // the wall keeps the height it was DRAWN at; the condition H is only the
+    // default for new traces (and the fallback for legacy shapes without one).
+    // An explicit override wins outright — even 0 — so a zeroed wall can't
+    // silently recompute at the condition height.
+    const h = s.height_override === true
+      ? Number(s.height_ft) || 0
+      : Number(s.height_ft) || Number(cond?.height_ft) || 0;
+    const LF = openLen(pts) * u;
+    return { area_sf: +(LF * h).toFixed(2), perimeter_lf: +LF.toFixed(2) };
+  }
+  if (s.measure_role === "linear") {
+    const LF = openLen(s.curved ? flattenCurve(pts) : pts) * u;
+    const tIn = Number(cond?.thickness_in) || 0;
+    return { perimeter_lf: +LF.toFixed(2), area_sf: tIn > 0 ? +((LF * tIn) / 12).toFixed(2) : 0 };
+  }
+  // #137 — a shape carrying verts_norm_holes (a reconciled Cut Out) nets its
+  // hole(s) out of area and adds their boundary into perimeter, so a later
+  // rescale/flip/drag still prices the ACTUAL clipped geometry rather than
+  // silently reverting to the un-holed outer ring. No-op for every shape
+  // that has never had a cutout reconciled into it.
+  const holesPx = (s.verts_norm_holes || []).map((ring) => ring.map(([nx, ny]) => [nx * dims.w, ny * dims.h]));
+  const met = holesPx.length ? polyWithHolesMetrics(pts, holesPx) : closedMetrics(pts);
+  return { area_sf: +(met.area * u * u).toFixed(2), perimeter_lf: +(met.perim * u).toFixed(2) };
+}
+
+// True when the shape is missing the number its role feeds the summers —
+// null/absent ONLY, never 0 (an explicit 0 is a value someone computed, not
+// a gap), and only when it carries enough vertices to price honestly (a
+// malformed ring stays unpriced rather than guessed).
+export function needsMetrics(s) {
+  const c = s.computed || {};
+  const n = s.verts_norm?.length || 0;
+  switch (s.measure_role) {
+    case "count": return c.count == null;
+    case "floor_area":
+    case "deduct": return c.area_sf == null && n >= 3;
+    case "surface_area": return c.area_sf == null && n >= 2;
+    case "linear": return c.perimeter_lf == null && n >= 2;
+    default: return false;
+  }
+}

--- a/web/src/lib/totals.js
+++ b/web/src/lib/totals.js
@@ -38,7 +38,13 @@ export { round2 } from "./num.js";
 function accumulateRole(acc, s) {
   const cp = s.computed || {};
   switch (s.measure_role) {
-    case "deduct": acc.floor -= cp.area_sf || 0; break;
+    // #137 — a deduct carrying cuts_shape_id was reconciled at commit time
+    // into a REAL polygon boolean subtract against its parent (lib/cutout.js):
+    // the parent's own computed.area_sf already nets the hole out, so
+    // counting the deduct's own area again here would double-subtract the
+    // same cut. Its area_sf stays at face value on the shape (hover label);
+    // this is the ONE place that decides whether it counts toward aggregates.
+    case "deduct": if (!s.cuts_shape_id) acc.floor -= cp.area_sf || 0; break;
     case "floor_area": acc.floor += cp.area_sf || 0; break;
     case "surface_area": acc.wall += cp.area_sf || 0; break;
     case "linear": acc.lf += cp.perimeter_lf || 0; acc.border += cp.area_sf || 0; break;

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -103,6 +103,8 @@ import { requiredDensity as tileRequiredDensity } from "../lib/tiles";
 // nowIso stays imported for the non-shape records (markups, RFIs, conditions).
 import { nowIso, mintUuid } from "../lib/provenance.js";
 import { applyShapeCommand, geomSnapshot, vertsEqual, recordCommand } from "../lib/shapeCommands.js";
+import { findCutoutParent, subtractCutout, recomposeCutouts } from "../lib/cutout.js";
+import { computeShapeMetrics, needsMetrics } from "../lib/shapeMetrics.js";
 import { fmtCheckLen, parseLenInput, checkVerdict, M_PER_FT, areaVal, areaUnit, lenVal, lenUnit, calInputToFeet, heightVal, heightUnit, heightInputToFeet, heightStep, dimInputStr } from "../lib/units";
 import * as panelGeom from "../lib/panelGeometry.js";
 
@@ -1801,7 +1803,9 @@ export default function TakeoffCanvas() {
         else if (ocSel && proposal) { deleteSelectedOcVertex(); }
         else if (proposal?.regions.length) { setProposal((pr) => { const rg = pr.regions.slice(0, -1); return rg.length ? { ...pr, regions: rg } : null; }); }
         else if (selVert != null && selectedId) { deleteSelectedShapeVertex(); }
-        else if (selectedId) { dispatchShape({ type: "delete", ids: [selectedId] }); setSelectedId(null); }
+        // route through deleteSelected — a reconciled Cut Out (#137) must
+        // revert its hole out of the parent, keyboard and menu alike
+        else if (selectedId) { deleteSelected(); }
         else if (selectedMarkupId && showMarkups) { deleteMarkup(selectedMarkupId); setSelectedMarkupId(null); }
         // pop ONLY the armed tool's pending points — calibrate and check both
         // keep two-click state (calib points even render while another tool is
@@ -2132,29 +2136,13 @@ export default function TakeoffCanvas() {
   // scale. This is what makes cross-sheet paste and group-mode edits honest.
   // uppOverride: pass the NEW effective upp when re-pricing right after a
   // setScales — `scales` in this render's closure is still the old map.
+  // Canvas-side wrapper over the ONE quantity computer (lib/shapeMetrics.js):
+  // panel dims + scale + condition lookup here, the role-aware math there —
+  // shared with the load-time heal, which prices shapes on CLOSED sheets too.
+  // Hole-aware since #137: a parent carrying verts_norm_holes prices the
+  // clipped geometry, not the outer ring.
   function recomputeShape(s, uppOverride) {
-    const sp = panelByKey(s.sheet_id);
-    const pts = s.verts_norm.map(([nx, ny]) => [nx * sp.img.w, ny * sp.img.h]);
-    const u = uppOverride ?? (uppFor(s.sheet_id) || 0);
-    if (s.measure_role === "count") return { count: 1 };
-    if (s.measure_role === "surface_area") {
-      // the wall keeps the height it was DRAWN at; the condition H is only the
-      // default for new traces (and the fallback for legacy shapes without one).
-      // An explicit override wins outright — even 0 (a zero-height wall is a
-      // deliberate statement, not an invitation to fall back to the condition).
-      const h = s.height_override === true
-        ? Number(s.height_ft) || 0
-        : Number(s.height_ft) || Number(condById[s.condition_id]?.height_ft) || 0;
-      const LF = openLen(pts) * u;
-      return { area_sf: +(LF * h).toFixed(2), perimeter_lf: +LF.toFixed(2) };
-    }
-    if (s.measure_role === "linear") {
-      const LF = openLen(s.curved ? flattenCurve(pts) : pts) * u;
-      const tIn = Number(condById[s.condition_id]?.thickness_in) || 0;
-      return { perimeter_lf: +LF.toFixed(2), area_sf: tIn > 0 ? +((LF * tIn) / 12).toFixed(2) : 0 };
-    }
-    const met = closedMetrics(pts);
-    return { area_sf: +(met.area * u * u).toFixed(2), perimeter_lf: +(met.perim * u).toFixed(2) };
+    return computeShapeMetrics(s, panelByKey(s.sheet_id).img, uppOverride ?? (uppFor(s.sheet_id) || 0), condById[s.condition_id]);
   }
   function moveCrosshair(e) {
     if (editingRef.current) return;   // inline editor open — no aim crosshair (ref check, never per-mousemove state)
@@ -2651,6 +2639,59 @@ export default function TakeoffCanvas() {
 
   // A shape belongs to the panel of its FIRST point — verts normalize against
   // that panel's dims, quantities use that sheet's scale.
+  // #137 — try to resolve a freshly-drawn deduct into a REAL hole in a parent
+  // floor_area shape (turf boolean subtract, lib/cutout.js) instead of it
+  // landing as a second independent overlay. Returns null (caller keeps the
+  // legacy path) whenever the resolution is anything but unambiguous:
+  //   - zero or 2+ floor_area shapes on this sheet touch the deduct's ring
+  //     (ambiguous parent, or it spans more than one condition's shape);
+  //   - the boolean op itself degenerates (deduct erases the parent, or
+  //     splits it into disjoint pieces — subtractCutout refuses both).
+  // A parent that already carries reconciled cutout(s) is a normal target:
+  // the new ring subtracts against (outer + existing holes), so N deducts
+  // compose into N holes and overlap between cuts never double-deducts.
+  function resolveCutout(tp, deductPointsPx, deductShape) {
+    // deductPointsPx is ABSOLUTE stage space (commitPoly's `points`, xOffset
+    // baked in — same convention as verts_norm's own encode below); candidate
+    // rings must land in that SAME frame or containment/overlap comes out
+    // wrong the moment more than one sheet is open side by side (group view).
+    const candidates = shapes
+      .filter((s) => s.sheet_id === tp.key && s.measure_role === "floor_area")
+      .map((s) => ({ id: s.id, ringPx: s.verts_norm.map(([x, y]) => [x * tp.img.w + tp.xOffset, y * tp.img.h]) }));
+    if (!candidates.length) return null;
+    const parentId = findCutoutParent(candidates, deductPointsPx);
+    if (!parentId) return null;
+    const parent = shapes.find((s) => s.id === parentId);
+    const parentRingPx = candidates.find((c) => c.id === parentId).ringPx;
+    const parentHolesPx = (parent.verts_norm_holes || []).map((ring) => ring.map(([nx, ny]) => [nx * tp.img.w + tp.xOffset, ny * tp.img.h]));
+    const result = subtractCutout(parentRingPx, parentHolesPx, deductPointsPx);
+    if (!result) return null;
+    const norm = (ring) => ring.map(([x, y]) => [(x - tp.xOffset) / tp.img.w, y / tp.img.h]);
+    const upp = uppFor(tp.key);
+    const parentNext = {
+      verts_norm: norm(result.outer),
+      verts_norm_holes: result.holes.map(norm),
+      computed: { area_sf: +(result.area * upp * upp).toFixed(2), perimeter_lf: +(result.perim * upp).toFixed(2) },
+    };
+    // Frozen pre-cut snapshot of the PARENT, durable on the deduct's own
+    // origin (not just the ephemeral undo stack) — deleteSelected reads this
+    // to revert the parent's geometry when this specific cutout is deleted
+    // later, possibly in a different session after the undo stack is long gone.
+    const parentPrev = {
+      verts_norm: parent.verts_norm.map((v) => [...v]),
+      ...("verts_norm_holes" in parent ? { verts_norm_holes: parent.verts_norm_holes.map((r) => r.map((v) => [...v])) } : {}),
+      ...("computed" in parent ? { computed: parent.computed } : {}),
+    };
+    return {
+      parentId,
+      parentNext,
+      deductShape: {
+        ...deductShape,
+        cuts_shape_id: parentId,
+        origin: { method: "cutout_v1", cuts_shape_id: parentId, parent_prev: parentPrev },
+      },
+    };
+  }
   function commitPoly(points, asDeduct) {
     if (points.length < 3) return;
     const tp = panelAt(points[0][0]);
@@ -2659,14 +2700,26 @@ export default function TakeoffCanvas() {
     if (!activeCond) { setCommitMsg("Pick or add a condition first."); return; }
     const met = closedMetrics(points);
     // id + created_at are minted by the add command — the ONE creation gate
-    const res = dispatchShape({ type: "add", shapes: [{
+    const shape = {
       sheet_id: tp.key, condition_id: activeCond,
       measure_role: asDeduct ? "deduct" : "floor_area",
       verts_norm: points.map(([x, y]) => [(x - tp.xOffset) / tp.img.w, y / tp.img.h]),
       computed: { area_sf: +(met.area * upp * upp).toFixed(2), perimeter_lf: +(met.perim * upp).toFixed(2) },
       ...(activeLabel ? { label: activeLabel } : {}),
       origin: { method: "manual" },
-    }] });
+    };
+    // #137 — a deduct tries the real-hole path first; anything ambiguous
+    // (see resolveCutout) falls straight back to the independent-overlay
+    // commit below, unchanged.
+    if (asDeduct) {
+      const cut = resolveCutout(tp, points, shape);
+      if (cut) {
+        const res = dispatchShape({ type: "cutout", shape: cut.deductShape, parentId: cut.parentId, parentNext: cut.parentNext });
+        maybeOfferRule(res.shapes[res.shapes.length - 1], res.shapes);
+        return;
+      }
+    }
+    const res = dispatchShape({ type: "add", shapes: [shape] });
     // A Cut Out fully inside a same-condition room reads as a correction —
     // offer to make it a rule (#88). Detection only; nothing applies here.
     if (asDeduct) maybeOfferRule(res.shapes[res.shapes.length - 1], res.shapes);
@@ -3584,7 +3637,55 @@ export default function TakeoffCanvas() {
     }
     if (tool === "surface") commitSurface(poly); else if (tool === "linear") commitLinear(poly); else if (tool === "curve") commitLinear(poly, true); else commitPoly(poly, tool === "deduct"); setPoly([]);
   }
-  function deleteSelected() { if (selectedId) { dispatchShape({ type: "delete", ids: [selectedId] }); setSelectedId(null); } }
+  // #137 — the parent state deleting a reconciled deduct should restore. The
+  // deduct's own frozen origin.parent_prev is only correct when it is the
+  // parent's SOLE cut: with several reconciled cutouts on one parent, that
+  // snapshot predates the OTHER cuts, so restoring it would wipe their holes
+  // while their deduct shapes live on. Instead: take the chain's EARLIEST
+  // snapshot (the most pristine geometry on record) and re-subtract every
+  // surviving deduct's ring in commit order (lib/cutout.recomposeCutouts).
+  // Null when the rebuild can't be trusted (panel not mounted, scale unset,
+  // or a re-subtract degenerates) — the caller then falls back to a plain
+  // delete that leaves the cut baked in, never reverts over survivors.
+  function cutoutParentPrevSans(doomed) {
+    const chain = shapes.filter((s) => s.cuts_shape_id === doomed.cuts_shape_id && s.origin?.parent_prev);
+    const rest = chain.filter((s) => s.id !== doomed.id);
+    if (!rest.length) return doomed.origin.parent_prev;
+    const parent = shapes.find((s) => s.id === doomed.cuts_shape_id);
+    const tp = panelByKey(parent.sheet_id);
+    const upp = uppFor(parent.sheet_id);
+    if (!tp?.img?.w || !upp) return null;
+    const px = (ring) => ring.map(([nx, ny]) => [nx * tp.img.w, ny * tp.img.h]);
+    const base = chain[0].origin.parent_prev;
+    const r = recomposeCutouts(px(base.verts_norm), (base.verts_norm_holes || []).map(px), rest.map((s) => px(s.verts_norm)));
+    if (!r) return null;
+    const norm = (ring) => ring.map(([x, y]) => [x / tp.img.w, y / tp.img.h]);
+    return {
+      verts_norm: norm(r.outer),
+      ...(r.holes.length ? { verts_norm_holes: r.holes.map(norm) } : {}),
+      computed: { area_sf: +(r.area * upp * upp).toFixed(2), perimeter_lf: +(r.perim * upp).toFixed(2) },
+    };
+  }
+  // #137 — deleting a reconciled deduct reverts its cut out of the parent
+  // too: the sole cut restores the frozen origin.parent_prev snapshot
+  // (durable — works after a reload, not just within the same undo stack);
+  // one of SEVERAL cuts rebuilds the parent from the chain's earliest
+  // snapshot minus the survivors (cutoutParentPrevSans). A rebuild that
+  // degenerates falls through to the plain delete — the shape goes, its cut
+  // stays baked in.
+  function deleteSelected() {
+    if (!selectedId) return;
+    const only = shapes.find((s) => s.id === selectedId);
+    if (only?.cuts_shape_id && only.origin?.parent_prev && shapes.some((s) => s.id === only.cuts_shape_id)) {
+      const parentPrev = cutoutParentPrevSans(only);
+      if (parentPrev) {
+        dispatchShape({ type: "cutout", restore: true, deductId: only.id, parentId: only.cuts_shape_id, parentPrev });
+        setSelectedId(null);
+        return;
+      }
+    }
+    dispatchShape({ type: "delete", ids: [selectedId] }); setSelectedId(null);
+  }
   function reassignSelected(condId) { if (selectedId) dispatchShape({ type: "reassign", ids: [selectedId], condition_id: condId }); }
   function reassignSelectedLabel(value) { if (selectedId) dispatchShape({ type: "label", ids: [selectedId], value }); }   // Select-tool single-shape re-label (#111) — value "" / null clears it; label commands never stamp
 
@@ -4559,6 +4660,54 @@ export default function TakeoffCanvas() {
   // memoized panel, so its identity must only change when the totals can.
   const visRows = useMemo(() => conditionTotals(conditions, visibleShapes), [conditions, visibleShapes]);
   const visRowById = useMemo(() => new Map(visRows.map((r) => [r.id, r])), [visRows]);
+  // Whole-project per-condition totals — the number the bid is built on. The
+  // panel's rows lead with the visible-sheet slice (what you're looking at);
+  // this map feeds the dim Σ suffix whenever the project holds MORE than the
+  // open sheets show, so a condition whose takeoffs live on closed sheets
+  // reads "Σ 412 SF" instead of a dead "—" (the whole-project number used to
+  // exist only in the Report/exports). Same conditionTotals rules, no filter.
+  const projRows = useMemo(() => conditionTotals(conditions, shapes), [conditions, shapes]);
+  const projRowById = useMemo(() => new Map(projRows.map((r) => [r.id, r])), [projRows]);
+  // ── load-time quantity heal (#137) ─────────────────────────────────────────
+  // A shape can ARRIVE without the numbers its role requires (an import that
+  // carried geometry only). Such a shape draws fine but reads as 0 SF in
+  // every summer and silently zeroes its condition's totals. Heal once per
+  // load: recompute from the SAME deterministic dims the render pipeline uses
+  // (pdf.js viewport at RENDER_SCALE — page metadata only, no raster, so
+  // shapes on CLOSED sheets heal too), and only where the sheet's scale is
+  // known — no scale, no honest number; those stay unpriced rather than
+  // guessed. Commits like the rescale repair (replace + reset — not an edit,
+  // no undo entry); the next autosave banks it. The seq guard kills an
+  // in-flight heal the moment shapes/scales change — the rerun starts over
+  // against the fresh state (docFor caches, so the redo is cheap), and once
+  // nothing needsMetrics this is a pure no-op.
+  const healSeqRef = useRef(0);
+  useEffect(() => {
+    if (status !== "ready") return;
+    const missing = shapes.filter((s) => needsMetrics(s) && uppFor(s.sheet_id));
+    if (!missing.length) return;
+    const seq = ++healSeqRef.current;
+    (async () => {
+      const dimsBy = new Map();
+      for (const key of new Set(missing.map((s) => s.sheet_id))) {
+        try {
+          const { file, page: pn } = parseSheetKey(key);
+          const pdf = await docFor(file);
+          const pageObj = await pdf.getPage(Math.min(Math.max(1, pn), pdf.numPages || 1));
+          const vp = pageObj.getViewport({ scale: RENDER_SCALE });
+          dimsBy.set(key, { w: Math.ceil(vp.width), h: Math.ceil(vp.height) });
+        } catch { /* orphaned sheet (source gone) — its shapes stay unpriced */ }
+      }
+      if (seq !== healSeqRef.current) return;   // stale — a newer load/edit owns the heal now
+      const healed = new Map(missing
+        .filter((s) => dimsBy.has(s.sheet_id))
+        .map((s) => [s.id, computeShapeMetrics(s, dimsBy.get(s.sheet_id), uppFor(s.sheet_id) || 0, condById[s.condition_id])]));
+      if (!healed.size) return;
+      dispatchShape({ type: "replace", shapes: shapes.map((s) => (healed.has(s.id) ? { ...s, computed: healed.get(s.id) } : s)) }, { reset: true });
+      setCommitMsg(`Repriced ${healed.size} takeoff${healed.size === 1 ? "" : "s"} that loaded without quantities.`);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reruns on load/shape/scale change; docFor/uppFor/condById read from the same render
+  }, [status, shapes, scales, conditions]);
   // Zone check: the SAME conditionTotals rules on the shapes whose center point
   // sits inside the traced zone (lib/zone.js) — third scope of the one role math.
   const zoneShapes = useMemo(() => (zoneCheck ? shapesInZone(shapes, zoneCheck) : null), [shapes, zoneCheck]);
@@ -5681,6 +5830,23 @@ export default function TakeoffCanvas() {
                         return <polyline key={s.id} points={lpts.map((q) => q.join(",")).join(" ")} fill="none" stroke={sel ? "#1f3fc7" : col} strokeOpacity={pending ? 0.85 : undefined} strokeWidth={(sel ? 4 : 3) / z} strokeDasharray={pending ? pDash : dashArrayFor(cond?.line_style || "solid", z)} strokeLinecap="round" strokeLinejoin="round" />;
                       }
                       const ded = s.measure_role === "deduct";
+                      // #137 — a RECONCILED deduct (cuts_shape_id) renders as a
+                      // dashed outline only: its geometry is already excised
+                      // from its parent's fill below (fill-rule evenodd), so a
+                      // solid overlay here would reintroduce the exact
+                      // "decal on top" bug the real subtract fixes.
+                      if (ded && s.cuts_shape_id) {
+                        return <polygon key={s.id} points={pts.map((q) => q.join(",")).join(" ")} fill="none" stroke={sel ? "#1f3fc7" : "#b03a26"} strokeWidth={(sel ? 3 : 1.5) / z} strokeDasharray={`${5 / z} ${3 / z}`} />;
+                      }
+                      // #137 — a parent carrying real hole ring(s): ONE compound
+                      // path, outer ring + every hole ring, fill-rule evenodd so
+                      // the hole is an actual excision from the fill rather than
+                      // a shape sitting on top of it.
+                      if (!ded && s.verts_norm_holes?.length) {
+                        const ringD = (ring) => `M${dn(ring).map((q) => q.join(",")).join("L")}Z`;
+                        const d = ringD(s.verts_norm) + s.verts_norm_holes.map(ringD).join("");
+                        return <path key={s.id} d={d} fillRule="evenodd" fill={pending ? col + "14" : shapeFill(cond)} stroke={sel ? "#1f3fc7" : col} strokeOpacity={pending ? 0.9 : undefined} strokeWidth={sw} strokeDasharray={pending ? pDash : dashArrayFor(cond?.line_style || "solid", z)} />;
+                      }
                       // deduct keeps its danger-red dashing (a safety signal, wins over line_style); positive floor_area follows the condition's line_style
                       return <polygon key={s.id} points={pts.map((q) => q.join(",")).join(" ")}
                         fill={ded ? (pending ? "rgba(176,58,38,.10)" : "rgba(176,58,38,.28)") : pending ? col + "14" : shapeFill(cond)}
@@ -6356,7 +6522,7 @@ export default function TakeoffCanvas() {
           units={units}
           conditions={conditions}
           activeCond={activeCond}
-          visRowById={visRowById}
+          visRowById={visRowById} projRowById={projRowById}
           conditionColumns={conditionColumns}
           shapeLabels={shapeLabels}
           templates={templates}

--- a/web/test/cutout.test.ts
+++ b/web/test/cutout.test.ts
@@ -1,0 +1,106 @@
+// Real polygon boolean subtraction behind the Cut Out tool (#137) —
+// lib/cutout.js. Boundary-math cases: a square room with a square hole (the
+// core case), a hole that touches the room's edge (a notch, not an interior
+// ring), compose against an already-holed parent, overlap that must never
+// double-deduct, the delete-one-of-several rebuild (recomposeCutouts), and
+// the ambiguous/degenerate cases that must fall back to the legacy
+// independent-shape path rather than guess. No browser, no pdf.js.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { findCutoutParent, subtractCutout, recomposeCutouts } from "../src/lib/cutout.js";
+import { polyWithHolesMetrics, closedMetrics } from "../src/lib/geometry.js";
+
+const approx = (a: number, b: number, tol = 1e-6) => Math.abs(a - b) <= tol;
+
+// 100×100 square, [0,0]..[100,100] — open ring (no repeated closing vertex).
+const SQUARE = [[0, 0], [100, 0], [100, 100], [0, 100]];
+const FAR_SQUARE = [[500, 500], [600, 500], [600, 600], [500, 600]];
+
+test("subtractCutout: square hole fully inside — area nets, perimeter ADDS the hole boundary", () => {
+  const hole = [[40, 40], [60, 40], [60, 60], [40, 60]];   // 20×20 = 400
+  const r = subtractCutout(SQUARE, [], hole);
+  assert.ok(r);
+  assert.ok(approx(r.area, 10000 - 400), `area ${r.area}`);
+  assert.ok(approx(r.perim, 400 + 80), `perim ${r.perim}`);
+  assert.equal(r.holes.length, 1);
+  const outerAlone = closedMetrics(r.outer);
+  assert.ok(approx(outerAlone.area, 10000) && approx(outerAlone.perim, 400), "outer ring untouched by an interior hole");
+});
+
+test("subtractCutout: edge-touching cut bites the OUTER ring — only the overlap is removed", () => {
+  const hole = [[90, 40], [110, 40], [110, 60], [90, 60]];   // half inside
+  const r = subtractCutout(SQUARE, [], hole);
+  assert.ok(r);
+  assert.ok(approx(r.area, 10000 - 200), `only the overlapping 10×20 sliver removed, got ${r.area}`);
+  assert.equal(r.holes.length, 0, "a notch, not a floating interior ring");
+  assert.ok(r.outer.length > SQUARE.length, "outer ring gained vertices for the notch");
+});
+
+test("subtractCutout: degenerate results bail to null (caller falls back to the legacy path)", () => {
+  const covers = [[-10, -10], [110, -10], [110, 110], [-10, 110]];
+  assert.equal(subtractCutout(SQUARE, [], covers), null, "erasing the whole parent");
+  const bisects = [[-10, 45], [110, 45], [110, 55], [-10, 55]];
+  assert.equal(subtractCutout(SQUARE, [], bisects), null, "splitting the parent (MultiPolygon)");
+});
+
+test("subtractCutout: composes against a parent that already carries a hole", () => {
+  const first = subtractCutout(SQUARE, [], [[10, 10], [20, 10], [20, 20], [10, 20]]);
+  assert.ok(first);
+  const second = subtractCutout(first.outer, first.holes, [[70, 70], [80, 70], [80, 80], [70, 80]]);
+  assert.ok(second);
+  assert.equal(second.holes.length, 2, "both holes present");
+  assert.ok(approx(second.area, 10000 - 100 - 100), "both cuts net out");
+});
+
+test("subtractCutout: overlapping second cut never double-deducts the shared area", () => {
+  const first = subtractCutout(SQUARE, [], [[40, 40], [60, 40], [60, 60], [40, 60]]);   // 400 out
+  assert.ok(first);
+  // overlaps the first hole's right half: 400 gross, 200 already inside hole #1
+  const second = subtractCutout(first.outer, first.holes, [[50, 40], [70, 40], [70, 60], [50, 60]]);
+  assert.ok(second);
+  assert.ok(approx(second.area, 10000 - 400 - 200), `union (600) not sum (800), got ${second.area}`);
+  assert.equal(second.holes.length, 1, "overlapping cuts merged into ONE hole ring");
+  // a cut fully INSIDE an existing hole is a no-op on the parent, not a failure
+  const inside = subtractCutout(second.outer, second.holes, [[45, 45], [55, 45], [55, 55], [45, 55]]);
+  assert.ok(inside && approx(inside.area, second.area), "swallowed cut resolves with zero net change");
+});
+
+test("findCutoutParent: unique / none / ambiguous", () => {
+  const hole = [[40, 40], [60, 40], [60, 60], [40, 60]];
+  assert.equal(findCutoutParent([{ id: "p1", ringPx: SQUARE }], hole), "p1");
+  assert.equal(findCutoutParent([{ id: "far", ringPx: FAR_SQUARE }], hole), null);
+  assert.equal(findCutoutParent([], hole), null);
+  assert.equal(findCutoutParent([{ id: "p1", ringPx: SQUARE }, { id: "p2", ringPx: SQUARE }], hole), null,
+    "two touching candidates → ambiguous, caller keeps the independent-shape path");
+  const edgeHole = [[90, 40], [110, 40], [110, 60], [90, 60]];
+  assert.equal(findCutoutParent([{ id: "p1", ringPx: SQUARE }], edgeHole), "p1", "partial edge overlap still resolves");
+});
+
+test("polyWithHolesMetrics: matches subtractCutout's math; no holes = closedMetrics", () => {
+  const hole = [[40, 40], [60, 40], [60, 60], [40, 60]];
+  const m = polyWithHolesMetrics(SQUARE, [hole]);
+  assert.ok(approx(m.area, 9600) && approx(m.perim, 480));
+  const none = polyWithHolesMetrics(SQUARE, []);
+  assert.ok(approx(none.area, 10000) && approx(none.perim, 400));
+});
+
+test("recomposeCutouts: rebuilding a parent after one cut in a chain is deleted", () => {
+  const h1 = [[10, 10], [20, 10], [20, 20], [10, 20]];   // 100
+  const h2 = [[70, 70], [80, 70], [80, 80], [70, 80]];   // 100
+  // delete cut #1: pristine base minus the SURVIVING h2 only
+  const r = recomposeCutouts(SQUARE, [], [h2]);
+  assert.ok(r);
+  assert.ok(approx(r.area, 10000 - 100), `only the surviving cut nets out, got ${r.area}`);
+  assert.equal(r.holes.length, 1);
+  // deleting the LAST cut of the chain: zero surviving rings → the base itself
+  const none = recomposeCutouts(SQUARE, [], []);
+  assert.ok(none && approx(none.area, 10000) && none.holes.length === 0);
+  // three-cut chain, middle one deleted — both survivors re-subtract in order
+  const h3 = [[40, 40], [50, 40], [50, 50], [40, 50]];   // 100
+  const r3 = recomposeCutouts(SQUARE, [], [h1, h3]);
+  assert.ok(r3 && approx(r3.area, 10000 - 200) && r3.holes.length === 2);
+  // a surviving cut that bisects the base degenerates → null (caller falls
+  // back to a plain delete; NEVER restores the pristine base over survivors)
+  const bisects = [[-10, 45], [110, 45], [110, 55], [-10, 55]];
+  assert.equal(recomposeCutouts(SQUARE, [], [bisects]), null);
+});

--- a/web/test/shapeCommands.test.ts
+++ b/web/test/shapeCommands.test.ts
@@ -57,11 +57,69 @@ function roundTrip(shapes: any[], cmd: any) {
 // ── policy completeness ──────────────────────────────────────────────────────
 
 test("every applied command type has a PROVENANCE_POLICY row; unknown types throw", () => {
-  for (const t of ["add", "geom", "reassign", "label", "delete", "replace"]) {
+  for (const t of ["add", "geom", "reassign", "label", "delete", "replace", "cutout"]) {
     assert.ok(t in PROVENANCE_POLICY, `policy row missing for ${t}`);
   }
   assert.throws(() => applyShapeCommand([], { type: "resize" } as any), /PROVENANCE_POLICY/);
   assert.throws(() => applyShapeCommand([], null as any), /PROVENANCE_POLICY/);
+});
+
+// ── cutout (#137 — mint the deduct + patch its parent as ONE command) ────────
+
+test("cutout: mints the deduct, patches the parent, ONE symmetric undo entry", () => {
+  const parent = {
+    id: "shp-parent", created_at: "2026-01-01T00:00:00Z", sheet_id: "a.pdf#1",
+    condition_id: "cnd-1", measure_role: "floor_area",
+    verts_norm: [[0, 0], [1, 0], [1, 1], [0, 1]] as number[][],
+    computed: { area_sf: 100, perimeter_lf: 40 },
+    origin: { method: "manual" },
+  };
+  const before = [clone(parent)];
+  const cmd = {
+    type: "cutout",
+    parentId: "shp-parent",
+    parentNext: {
+      verts_norm: [[0, 0], [1, 0], [1, 1], [0, 1]],
+      verts_norm_holes: [[[0.4, 0.4], [0.6, 0.4], [0.6, 0.6], [0.4, 0.6]]],
+      computed: { area_sf: 96, perimeter_lf: 48 },
+    },
+    shape: {
+      sheet_id: "a.pdf#1", condition_id: "cnd-1", measure_role: "deduct",
+      verts_norm: [[0.4, 0.4], [0.6, 0.4], [0.6, 0.6], [0.4, 0.6]],
+      computed: { area_sf: 4, perimeter_lf: 8 },
+      cuts_shape_id: "shp-parent",
+      origin: { method: "cutout_v1", cuts_shape_id: "shp-parent", parent_prev: { verts_norm: parent.verts_norm, computed: parent.computed } },
+    },
+  };
+  const res = applyShapeCommand(before, cmd as any);
+  assert.equal(res.shapes.length, 2, "ONE new shape lands — no orphan second overlay");
+  const patched = res.shapes.find((s: any) => s.id === "shp-parent");
+  assert.equal(patched.verts_norm_holes.length, 1, "parent gained the real hole ring");
+  assert.equal(patched.computed.area_sf, 96, "parent's own computed nets the hole out");
+  const minted = res.shapes.find((s: any) => s.measure_role === "deduct");
+  assert.ok(minted.id.startsWith("shp-") && minted.created_at, "deduct minted with id + created_at");
+  assert.equal(minted.cuts_shape_id, "shp-parent", "linked back to its parent");
+  assert.equal(res.counted, undefined, "nothing counts");
+  // undo: drop the deduct, parent back verbatim — hole KEY absent, not []
+  const undone = applyShapeCommand(res.shapes, res.inverse);
+  assert.equal(undone.shapes.length, 1);
+  assert.ok(!("verts_norm_holes" in undone.shapes[0]), "undo restores holeless = key absent");
+  assert.deepEqual(undone.shapes, before, "undo restores deep-equal");
+  // redo-of-undo re-applies verbatim (same deduct id, same parent patch)
+  const redone = applyShapeCommand(undone.shapes, undone.inverse);
+  assert.deepEqual(redone.shapes, res.shapes, "redo restores the cut state verbatim");
+});
+
+test("cutout: parent missing → refuses (inverse null, nothing minted); restore of a gone deduct refuses too", () => {
+  const res = applyShapeCommand([], {
+    type: "cutout", parentId: "shp-gone",
+    parentNext: { verts_norm: [[0, 0], [1, 0], [1, 1]], computed: { area_sf: 1, perimeter_lf: 4 } },
+    shape: { sheet_id: "a.pdf#1", condition_id: "c", measure_role: "deduct", verts_norm: [[0, 0], [1, 0], [1, 1]] },
+  } as any);
+  assert.equal(res.shapes.length, 0, "nothing minted");
+  assert.equal(res.inverse, null);
+  const res2 = applyShapeCommand([], { type: "cutout", restore: true, deductId: "shp-gone", parentId: "p", parentPrev: { verts_norm: [] } } as any);
+  assert.equal(res2.inverse, null);
 });
 
 // ── add ──────────────────────────────────────────────────────────────────────

--- a/web/test/shapeMetrics.test.ts
+++ b/web/test/shapeMetrics.test.ts
@@ -1,0 +1,69 @@
+// lib/shapeMetrics.js — the ONE role-aware shape-quantity computer (extracted
+// from TakeoffCanvas.recomputeShape) and needsMetrics, the load-time heal's
+// "is this shape missing its numbers" gate (#137). The heal exists because
+// shapes can ARRIVE geometry-only (an import without computed) and every
+// summer reads computed?.x || 0 — the gap must be detected and priced, never
+// guessed.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeShapeMetrics, needsMetrics } from "../src/lib/shapeMetrics.js";
+
+const approx = (a: number, b: number, tol = 1e-6) => Math.abs(a - b) <= tol;
+const DIMS = { w: 1000, h: 800 };
+const UPP = 0.05;   // 20 px per foot
+
+test("floor_area: closed metrics at scale", () => {
+  // 200×160 px = 10×8 ft = 80 SF, 36 LF perimeter
+  const s = { measure_role: "floor_area", verts_norm: [[0.1, 0.1], [0.3, 0.1], [0.3, 0.3], [0.1, 0.3]] };
+  const m = computeShapeMetrics(s, DIMS, UPP, undefined);
+  assert.ok(approx(m.area_sf!, 80), String(m.area_sf));
+  assert.ok(approx(m.perimeter_lf!, 36), String(m.perimeter_lf));
+});
+
+test("floor_area with holes: nets the cutout, hole boundary ADDS to perimeter", () => {
+  const s = {
+    measure_role: "floor_area",
+    verts_norm: [[0.1, 0.1], [0.3, 0.1], [0.3, 0.3], [0.1, 0.3]],
+    verts_norm_holes: [[[0.15, 0.15], [0.2, 0.15], [0.2, 0.2], [0.15, 0.2]]],   // 50×40 px = 5 SF
+  };
+  const m = computeShapeMetrics(s, DIMS, UPP, undefined);
+  assert.ok(approx(m.area_sf!, 75), String(m.area_sf));
+  assert.ok(m.perimeter_lf! > 36);
+});
+
+test("linear: LF always; border SF only with a condition thickness", () => {
+  const s = { measure_role: "linear", verts_norm: [[0.1, 0.1], [0.3, 0.1]] };   // 200 px = 10 LF
+  const plain = computeShapeMetrics(s, DIMS, UPP, undefined);
+  assert.ok(approx(plain.perimeter_lf!, 10) && plain.area_sf === 0);
+  const trimmed = computeShapeMetrics(s, DIMS, UPP, { thickness_in: 6 });
+  assert.ok(approx(trimmed.area_sf!, 5), String(trimmed.area_sf));
+});
+
+test("surface_area: condition-height fallback vs drawn height vs explicit 0 override", () => {
+  const s = { measure_role: "surface_area", verts_norm: [[0.1, 0.1], [0.3, 0.1]] };
+  assert.ok(approx(computeShapeMetrics(s, DIMS, UPP, { height_ft: 8 }).area_sf!, 80));
+  assert.ok(approx(computeShapeMetrics({ ...s, height_ft: 9 }, DIMS, UPP, { height_ft: 8 }).area_sf!, 90));
+  assert.ok(approx(computeShapeMetrics({ ...s, height_override: true, height_ft: 0 }, DIMS, UPP, { height_ft: 8 }).area_sf!, 0),
+    "explicit override 0 stays 0 — never silently re-heights");
+});
+
+test("count: always {count: 1}, dims/scale irrelevant", () => {
+  assert.equal(computeShapeMetrics({ measure_role: "count", verts_norm: [[0.5, 0.5]] }, DIMS, 0, undefined).count, 1);
+});
+
+test("needsMetrics: missing-only detection, role-aware, never on 0", () => {
+  const tri = [[0, 0], [0.1, 0], [0.1, 0.1]];
+  assert.ok(needsMetrics({ measure_role: "floor_area", verts_norm: tri }));
+  assert.ok(needsMetrics({ measure_role: "floor_area", verts_norm: tri, computed: {} }));
+  assert.ok(!needsMetrics({ measure_role: "floor_area", verts_norm: tri, computed: { area_sf: 0 } }),
+    "explicit 0 is a VALUE, not a gap");
+  assert.ok(!needsMetrics({ measure_role: "floor_area", verts_norm: [[0, 0], [0.1, 0]] }),
+    "2-vertex 'polygon' stays unpriced (malformed, never guess)");
+  assert.ok(needsMetrics({ measure_role: "deduct", verts_norm: tri }));
+  assert.ok(needsMetrics({ measure_role: "linear", verts_norm: [[0, 0], [0.1, 0]] }));
+  assert.ok(!needsMetrics({ measure_role: "linear", verts_norm: [[0, 0], [0.1, 0]], computed: { perimeter_lf: 12 } }));
+  assert.ok(needsMetrics({ measure_role: "surface_area", verts_norm: [[0, 0], [0.1, 0]] }));
+  assert.ok(needsMetrics({ measure_role: "count", verts_norm: [[0.5, 0.5]] }));
+  assert.ok(!needsMetrics({ measure_role: "count", verts_norm: [[0.5, 0.5]], computed: { count: 1 } }));
+  assert.ok(!needsMetrics({ measure_role: "zone", verts_norm: tri }), "unknown role never heals");
+});

--- a/web/test/totals.test.ts
+++ b/web/test/totals.test.ts
@@ -283,3 +283,17 @@ test("reportJson: a condition-linked markup resolves to its finish_tag; a dangli
   assert.equal(j.markups[2].condition_id, "gone");
   assert.equal(j.markups[2].condition, "");
 });
+
+// #137 — a RECONCILED deduct (cuts_shape_id set) was boolean-subtracted into
+// its parent at commit time: the parent's own area_sf already nets the hole
+// out, so the summer must NOT subtract the deduct's area again. A legacy
+// independent deduct (no cuts_shape_id) still subtracts.
+test("conditionTotals: reconciled deduct never double-subtracts; legacy deduct still does", () => {
+  const conds = [{ id: "c1", finish_tag: "CPT-1" }];
+  const rows = conditionTotals(conds as any, [
+    { id: "p", condition_id: "c1", measure_role: "floor_area", verts_norm: [], computed: { area_sf: 90 } },   // 100 gross − 10 hole, already netted
+    { id: "d1", condition_id: "c1", measure_role: "deduct", cuts_shape_id: "p", verts_norm: [], computed: { area_sf: 10 } },
+    { id: "d2", condition_id: "c1", measure_role: "deduct", verts_norm: [], computed: { area_sf: 5 } },
+  ] as any);
+  assert.equal(rows[0].floor_sf, 85, "90 − 5 (legacy only); a double-deduct would read 75");
+});


### PR DESCRIPTION
Closes #137.

A Cut Out committed as a second independent overlay and totals subtracted each deduct's full ring blind — overlapping cuts double-deducted, edge-crossing cuts over-deducted, and no real hole existed anywhere in the data model.

**What changes**

- **`lib/cutout.js` (new):** real polygon boolean subtraction (turf `difference`). A deduct that unambiguously targets one room subtracts into it as hole ring(s) — outer + holes, composing with existing holes: N cuts = N holes, overlap nets once (set subtraction), a cut swallowed by an existing hole is zero-net. Ambiguous or degenerate cases (touches two rooms, erases/bisects the parent) fall back to the legacy overlay unchanged.
- **`shapeCommands.js`:** new `cutout` command — mints the deduct AND patches the parent as ONE undo entry; symmetric restore. Policy row documents what stamps (nothing on the parent).
- **Delete semantics:** deleting one cut of several rebuilds the parent from the chain's earliest frozen `parent_prev` snapshot minus the survivors (`recomposeCutouts`) — never wipes sibling cuts. The Delete key now routes through `deleteSelected` so keyboard and Edit menu agree.
- **Renderer:** the parent draws as one `evenodd` compound path — the cut is an actual excision, not a decal; a reconciled deduct is a dashed outline only. `hitShape` reads through holes (clicking a cut reaches what's underneath).
- **Totals:** `accumulateRole` skips reconciled deducts — their hole already nets in the parent's `computed`, so counting them again would double-subtract. Report, panel, and marked-set legend all inherit the fix.
- **`lib/shapeMetrics.js` (new) + load-time heal:** a shape that arrives geometry-only (an import without `computed`) reprices automatically from pdf.js page metadata (closed sheets included, scale required) instead of silently reading 0 SF.
- **Conditions panel:** dim `Σ` whole-project per-condition total whenever the project holds more than the open sheets show.

**Verification:** live headless at dpr 1 on the sample plan — room + two cuts + delete-the-first, 10 assertions green (two real holes on one parent, overlap never double-deducts, rebuild math exact). New `cutout.test.ts` + `shapeMetrics.test.ts`, `shapeCommands`/`totals` suites extended. `npm run check` green on Node 24.

**Known follow-up (tracked in #137):** the marked-set PDF still paints the deduct decal rather than a true hole in the export drawing itself (legend numbers are correct); hole geometry on the shapes-export wire is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)