### PR TITLE
feat(mcp): export_report takes project_name — closes the last gap in the report.v1 contract (#132)

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.2",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.2",
+      "version": "0.9.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.3",
+  "version": "0.9.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -1151,11 +1151,11 @@ export class Session {
    * the contract a pricing consumer reads (#130) — export_takeoff carries
    * materials as CONFIG rows and takeoff_summary strips them; only this
    * document carries the computed order quantities. */
-  exportReport() {
+  exportReport(projectName = "") {
     if (!this.doc) throw new UserError("No plan loaded — call load_plan first.");
     const rows = (conditionTotals(this.conditions, this.shapes) as Record<string, unknown>[]).filter((r) => (r.shape_count as number) > 0);
     return reportJson({
-      projectName: "",
+      projectName,
       rows,
       bySheet: sheetTotals(this.conditions, this.shapes),
       scaleInfo: [...this.sheets.values()].filter((s) => s.upp != null).map((s) => ({ sheet_id: s.key, scale_source: s.scaleSource ?? "unknown" })),

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -139,10 +139,13 @@ export function registerTools(server: McpServer, session: Session): void {
 
   server.registerTool("export_report", {
     description: `The computed Report document — "opentakeoff.report.v1", the same schema the canvas Report's JSON export writes. Everything a pricing consumer needs without re-implementing the app's math: per-condition quantities with waste and multiplier applied (gross and *_net), the computed materials BUY LIST per condition (order quantity = basis ÷ coverage rate, rounded up to whole purchase units) plus the project-wide roll-up summed by (name, unit), per-sheet BASE subtotals, scale provenance per sheet, and annotations. Contrast: export_takeoff is the raw canvas payload (materials as CONFIG rows, no computed quantities) and takeoff_summary strips materials for a compact reply — when the numbers are leaving for pricing, consume this. Returned inline; pass path to also write it to disk as JSON.`,
-    inputSchema: { path: z.string().optional().describe("File path to write the document to") },
+    inputSchema: {
+      path: z.string().optional().describe("File path to write the document to"),
+      project_name: z.string().optional().describe("Label for the document's project_name field (a headless session has no project of its own; omitted → null)"),
+    },
     outputSchema: exportReportOutput,
-  }, run("export_report", async ({ path: outPath }) => {
-    const doc = session.exportReport();
+  }, run("export_report", async ({ path: outPath, project_name: projectName }) => {
+    const doc = session.exportReport(projectName);
     if (outPath) {
       const { writeFile } = await import("node:fs/promises");
       await writeFile(outPath, JSON.stringify(doc));

--- a/mcp/test/conformance.test.ts
+++ b/mcp/test/conformance.test.ts
@@ -227,6 +227,9 @@ test("every tool: canonical valid call → schema-valid structuredContent mirror
   assert.deepEqual(report.materials, [{ name: "Adhesive", unit: "gal", qty: mLine.qty }], "project-wide roll-up sums by (name, unit)");
   assert.ok(["standard", "upp", "calibrated", "detected"].includes(report.sheets[0].scale_source), "scale provenance rides the report");
   assert.ok(report.totals.total_sf_net > report.totals.total_sf, "grand totals carry waste");
+  assert.equal(report.project_name, null, "a headless session has no project of its own — null, never ''");
+  const labeled = await callOk(client, "export_report", { project_name: "Summit Phase 2" });
+  assert.equal(labeled.project_name, "Summit Phase 2", "a consumer can label the document it prices from");
   await callOk(client, "edit_condition", { condition: "CPT-1", waste_pct: 0 });   // leave the session as the later tests expect
 
   const del = await callOk(client, "delete_shape", { shape_id: clicked.shape_id });


### PR DESCRIPTION
#132 asked for a first-class, versioned computed-report export. #133 shipped it — \`export_report\` emits \`opentakeoff.report.v1\`: per-condition totals with waste/multiplier (gross and \`*_net\`), the computed materials buy list per condition plus the project-wide roll-up, per-sheet BASE subtotals, and scale provenance, all under the same \`reportJson\` the canvas Report writes, with the key set pinned in \`web/test/totals.test.ts\` and both-directions conformance in \`mcp/test/conformance.test.ts\`.

One gap remained: a headless session has no project, so \`project_name\` was hardcoded to \`null\` and every pricing consumer had to re-attach the label by hand after ingest. \`export_report\` now takes an optional \`project_name\` that rides into the document — omitted stays \`null\`, never \`""\`.

- Conformance covers both directions: default null, and a passed label landing verbatim.
- 0.9.3 → 0.9.4.

Closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)