### PR TITLE
feat(canvas): roll goods — figure the seams, draw the cuts (#136)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.4",
+  "version": "0.9.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -286,6 +286,7 @@ export const exportReportOutput = {
   by_label: z.array(z.record(z.unknown())),
   units: z.string(),
   display_units: z.string(),
+  roll_goods: z.array(z.record(z.unknown())).describe("Roll-goods order rows (#136) — order_lf / rolls / order_qty per roll-goods condition, ×N applied; empty when no condition carries a roll_setup (always the case for a headless session today)"),
 };
 
 export const editConditionOutput = {

--- a/mcp/test/conformance.test.ts
+++ b/mcp/test/conformance.test.ts
@@ -228,6 +228,7 @@ test("every tool: canonical valid call → schema-valid structuredContent mirror
   assert.ok(["standard", "upp", "calibrated", "detected"].includes(report.sheets[0].scale_source), "scale provenance rides the report");
   assert.ok(report.totals.total_sf_net > report.totals.total_sf, "grand totals carry waste");
   assert.equal(report.project_name, null, "a headless session has no project of its own — null, never ''");
+  assert.deepEqual(report.roll_goods, [], "roll_goods (#136) always emitted — empty until a condition carries a roll_setup");
   const labeled = await callOk(client, "export_report", { project_name: "Summit Phase 2" });
   assert.equal(labeled.project_name, "Summit Phase 2", "a consumer can label the document it prices from");
   await callOk(client, "edit_condition", { condition: "CPT-1", waste_pct: 0 });   // leave the session as the later tests expect

--- a/web/src/brand/icons.jsx
+++ b/web/src/brand/icons.jsx
@@ -14,6 +14,7 @@ export const icons = {
   document: (s) => <I size={s}><path d="M6 3 H 16 L 19 6 V 21 H 6 Z" /><path d="M16 3 V 6 H 19" /><line x1="9" y1="12" x2="16" y2="12" /><line x1="9" y1="16" x2="16" y2="16" /></I>,
   product: (s) => <I size={s}><rect x="3" y="7" width="18" height="13" /><path d="M3 7 L 12 3 L 21 7" /><line x1="12" y1="3" x2="12" y2="20" /></I>,
   takeoff: (s) => <I size={s}><rect x="3" y="3" width="18" height="18" /><line x1="3" y1="9" x2="21" y2="9" /><line x1="9" y1="3" x2="9" y2="21" /><circle cx="15" cy="15" r="1.2" fill="currentColor" /></I>,
+  roll: (s) => <I size={s}><circle cx="7.5" cy="9" r="4.8" /><circle cx="7.5" cy="9" r="1.1" fill="currentColor" stroke="none" /><path d="M12.3 9 H 21 V 19 H 3" /></I>,
   plus: (s) => <I size={s}><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></I>,
 
   // ── takeoff canvas set — drafting monoline, vertex-dot motif on measure tools ──

--- a/web/src/components/ReportPanel.jsx
+++ b/web/src/components/ReportPanel.jsx
@@ -6,7 +6,8 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "../brand/icons.jsx";
 import ToolMenu from "./ToolMenu.jsx";
 import { conditionTotals, grandTotals, sheetTotals, sheetGroupedRows, labelGroupedRows, round2, totalsToCsv, downloadText, materialsSummary, reportJson, hasMultipliers, BY_SHEET_BASE_NOTE } from "../lib/totals.js";
-import { TABLE_PROFILE, CSV_PROFILE, colGetter, customColProfile, specColProfile, laborColProfile, partitionRowsBy, forceIncludeGroupCol, loadColPrefs, saveColPrefs, loadGroupBy, saveGroupBy, visibleCols, floorPerimeterLf, applyUnits } from "../lib/reportColumns.js";
+import { TABLE_PROFILE, CSV_PROFILE, colGetter, customColProfile, specColProfile, laborColProfile, rollColProfile, partitionRowsBy, forceIncludeGroupCol, loadColPrefs, saveColPrefs, loadGroupBy, saveGroupBy, visibleCols, floorPerimeterLf, applyUnits } from "../lib/reportColumns.js";
+import { rollReportRows } from "../lib/rollTakeoff.js";
 import { areaVal, areaUnit, lenVal, lenUnit } from "../lib/units";
 import { columnLabel } from "../lib/conditionColumns.js";
 import { shapeLabelValue } from "../lib/shapeLabels.js";
@@ -44,7 +45,7 @@ const sheetNum = (v, d = 1) => {
   return num(r, d);
 };
 
-export default function ReportPanel({ projectName, onProjectName, conditions, shapes, sheetLabel, onMarkedSet, markedSetDark, onClose, markups = [], rfis = [], scaleInfo = [], provenanceCounters = null, clientInfo = {}, onClientInfo, conditionColumns = [], shapeLabels = [], units = "imperial" }) {
+export default function ReportPanel({ projectName, onProjectName, conditions, shapes, sheetLabel, onMarkedSet, markedSetDark, onClose, markups = [], rfis = [], scaleInfo = [], provenanceCounters = null, clientInfo = {}, onClientInfo, conditionColumns = [], shapeLabels = [], units = "imperial", rollByCond = null }) {
   // memoized on the source arrays: project-name/client-info keystrokes re-render
   // the panel without touching conditions/shapes, so the totaling passes skip
   // imported report theme → { vars, name, warnings }. vars are spread onto this
@@ -129,6 +130,11 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
   // opt-ins → custom → spec → labor), present only when at least one
   // condition carries a laborType/subfloorType value.
   const laborCols = laborColProfile(conditions);
+  // roll-goods columns (#136) — the figured order (Roll Order LF / Rolls)
+  // beside the measured quantities, appended after labor (frozen 13 →
+  // built-in opt-ins → custom → spec → labor → roll), present only when at
+  // least one condition figures a roll layout.
+  const rollCols = rollColProfile(rollByCond);
   // metric display converts AT THE DESCRIPTOR (applyUnits): headers swap to
   // m²/m, the SY column retires, and every dimensioned getter/foot wraps in
   // the converter — renderCell and the tfoot below need no unit awareness.
@@ -136,7 +142,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
   // inside totalsToCsv/reportWorkbook so each output has ONE conversion site.
   const M = units === "metric";
   const AU = areaUnit(units), LU = lenUnit(units);
-  const tableCols = applyUnits(visibleCols([...TABLE_PROFILE, ...customCols, ...specCols, ...laborCols], colPrefs), units);
+  const tableCols = applyUnits(visibleCols([...TABLE_PROFILE, ...customCols, ...specCols, ...laborCols, ...rollCols], colPrefs), units);
   // group-by choice: "" (none) | "sheet" | a custom column id; normalized
   // ONCE per render and used everywhere (select value AND partitioning) — a
   // stale colId must fall back to None, never reach the select or the
@@ -149,7 +155,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
   const groupBy = groupByRaw === "sheet" || (groupByRaw === "label" && shapeLabels.length > 0) || conditionColumns.some((cc) => cc.id === groupByRaw) ? groupByRaw : "";
   // grouping force-includes its column in the CSV/XLSX even when hidden in
   // the picker (D7) — a grouped report's export always carries its grouping
-  const csvCols = forceIncludeGroupCol(visibleCols([...CSV_PROFILE, ...customCols, ...specCols, ...laborCols], colPrefs), customCols, groupBy);
+  const csvCols = forceIncludeGroupCol(visibleCols([...CSV_PROFILE, ...customCols, ...specCols, ...laborCols, ...rollCols], colPrefs), customCols, groupBy);
   const perimByCond = useMemo(() => floorPerimeterLf(shapes), [shapes]);
   // custom-column values reach the getters through ctx, never as row fields
   // (conditionTotals rows are spread into the contribution payload)
@@ -158,7 +164,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
   const specByCond = useMemo(() => new Map(conditions.map((c) => [c.id, c.spec])), [conditions]);
   // labor columns read the hand-typed labor/subfloor type off the same ctx seam
   const laborByCond = useMemo(() => new Map(conditions.map((c) => [c.id, { laborType: c.laborType, subfloorType: c.subfloorType }])), [conditions]);
-  const ctx = { perimByCond, attrsByCond, specByCond, laborByCond };
+  const ctx = { perimByCond, attrsByCond, specByCond, laborByCond, rollByCond };
   // grouped view. Custom-column mode partitions the already-computed rows
   // (no recompute); sheet mode re-runs conditionTotals per sheet's shapes —
   // ORDERED quantities per slice (waste + ×N applied), each group carrying
@@ -296,7 +302,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
   const baseName = (projectName || "takeoff").replace(/[^\w.-]+/g, "_");
   const exportCsv = () => downloadText(`${baseName}.csv`, totalsToCsv(rows, projectName, bySheet, sheetLabel, csvCols, ctx, byLabelExport.length ? byLabelExport : null, brand.brandName, units), "text/csv");
   const exportJson = () => downloadText(`${baseName}.json`,
-    JSON.stringify(reportJson({ projectName, rows, bySheet, scaleInfo, markups, rfis, sheetLabel, conditionColumns, attrsByCond, shapeLabels, byLabel: byLabelExport, displayUnits: units }), null, 2),
+    JSON.stringify(reportJson({ projectName, rows, bySheet, scaleInfo, markups, rfis, sheetLabel, conditionColumns, attrsByCond, shapeLabels, byLabel: byLabelExport, displayUnits: units, rollGoods: rollReportRows(rollByCond, rows) }), null, 2),
     "application/json");
   const exportRfisCsv = () => downloadText(`${baseName}_rfis.csv`, rfisToCsv(rfis, markups, projectName, sheetLabel, brand.brandName), "text/csv");
   const exportRfisJson = () => downloadText(`${baseName}_rfis.json`,

--- a/web/src/components/RollPanel.jsx
+++ b/web/src/components/RollPanel.jsx
@@ -1,0 +1,176 @@
+// Roll panel (#136) — the docked right-rail surface for roll goods: every
+// roll-goods condition's cuts laid out ON THE ROLL, to scale, numbered in
+// cutting order, with per-cut dimensions and the figured order line. The
+// diagram is also the reorder desk: drag a cut to a new spot and the whole
+// roll RE-PACKS through the engine's skyline nesting (a manual order can
+// never produce an overlapped roll), or Reset order to hand sequencing back
+// to the packer. The overlay/edit toggles live here too — this panel is the
+// roll-goods HQ; the canvas just draws what it says.
+//
+// Layout state lives on the SHAPES (roll_layout, via the rollcut command), so
+// everything here is a pure view over the layouts prop the canvas computes.
+import { useRef, useState } from "react";
+import { Icon } from "../brand/icons.jsx";
+import { ftIn } from "../lib/units";
+import { rollColorForType } from "../lib/rollgoods.js";
+import { HatchSwatch } from "./hatches.jsx";
+
+const PXFT = 9; // diagram scale, px per foot — a 12-ft roll draws 108px wide
+
+// One roll's diagram: the roll drawn VERTICALLY (width across, length down),
+// cuts at their packed (cutY across, cutX down) positions, numbered when they
+// have the room, over-roll cuts in danger red, physical roll boundaries as
+// dashed rules when a max roll length is set. Drag (when editable) previews
+// locally and hands the full new order up on release — the re-pack happens in
+// the engine, never here.
+function RollDiagram({ ri, editable, onReorder }) {
+  const [drag, setDrag] = useState(null); // { id, dx, dy } — local preview only
+  const svgRef = useRef(null);
+  const W = ri.config.rollWidthFt * PXFT;
+  const lenFt = Math.max(ri.orderFt, 1);
+  const H = lenFt * PXFT;
+  const pad = 14;
+
+  const startDrag = (e, strip) => {
+    if (!editable) return;
+    e.preventDefault(); e.stopPropagation();
+    const sx = e.clientX, sy = e.clientY;
+    const move = (ev) => setDrag({ id: strip.id, dx: (ev.clientX - sx) / PXFT, dy: (ev.clientY - sy) / PXFT });
+    const up = (ev) => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      const dx = (ev.clientX - sx) / PXFT, dy = (ev.clientY - sy) / PXFT;
+      setDrag(null);
+      if (Math.abs(dx) < 0.1 && Math.abs(dy) < 0.1) return; // a click is not a reorder
+      // effective positions: the dragged cut at its preview spot, the rest at
+      // their packed spots — sorted into the new cutting order (down the roll,
+      // then across), which the canvas turns into seq overrides + a re-pack
+      const eff = ri.strips.map((s) => ({
+        id: s.id,
+        x: (s.cutX || 0) + (s.id === strip.id ? dy : 0),   // down the roll = screen y
+        y: (s.cutY || 0) + (s.id === strip.id ? dx : 0),   // across = screen x
+      })).sort((a, b) => (Math.abs(a.x - b.x) > 1e-6 ? a.x - b.x : a.y - b.y));
+      onReorder(eff.map((s) => s.id));
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  };
+
+  const rollFill = rollColorForType(ri.material);
+  const nRolls = ri.config.rollLengthFt > 0 ? Math.ceil(lenFt / ri.config.rollLengthFt - 1e-9) : 0;
+  return (
+    <svg ref={svgRef} width={W + pad * 2 + 46} height={H + pad * 2}
+      style={{ display: "block", maxWidth: "100%", touchAction: "none" }}>
+      {/* the roll itself */}
+      <rect x={pad} y={pad} width={W} height={H} fill={rollFill + "22"} stroke="var(--ink-faint)" />
+      {/* physical roll boundaries when a max length is set */}
+      {nRolls > 1 && Array.from({ length: nRolls - 1 }, (_, k) => {
+        const y = pad + (k + 1) * ri.config.rollLengthFt * PXFT;
+        return <g key={k}>
+          <line x1={pad} y1={y} x2={pad + W} y2={y} stroke="var(--ink-muted)" strokeDasharray="5 4" />
+          <text x={pad + W + 4} y={y - 3} fontSize={9} fill="var(--ink-muted)" fontFamily="var(--f-mono)">roll {k + 2}</text>
+        </g>;
+      })}
+      {/* cuts — cutY across the width (screen x), cutX down the length (screen y) */}
+      {ri.strips.map((s) => {
+        const lw = Math.max(0, s.laneMax - s.laneMin), ln = Math.max(0, s.runMax - s.runMin);
+        const isDrag = drag && drag.id === s.id;
+        const cx = (s.cutY || 0) + (isDrag ? drag.dx : 0);
+        const cy = (s.cutX || 0) + (isDrag ? drag.dy : 0);
+        const x = pad + cx * PXFT, y = pad + cy * PXFT, w = lw * PXFT, h = ln * PXFT;
+        const n = ri.nums.get(s.id) || 0;
+        return (
+          <g key={s.id} onPointerDown={(e) => startDrag(e, s)}
+            style={editable ? { cursor: "grab" } : undefined}>
+            <title>{`Cut ${n}${s.label ? ` — ${s.label}` : ""}: ${ftIn(ln)} × ${ftIn(lw)}${s.overRoll ? " — LONGER THAN ONE ROLL (needs a cross-seam)" : ""}`}</title>
+            <rect x={x} y={y} width={w} height={h}
+              fill={rollFill + (isDrag ? "88" : "66")}
+              stroke={s.overRoll ? "var(--c-danger)" : "var(--ink)"} strokeWidth={s.overRoll ? 1.6 : 0.8} />
+            {w > 15 && h > 15 && (
+              <g>
+                <circle cx={x + 10} cy={y + 10} r={7} fill="var(--ink)" />
+                <text x={x + 10} y={y + 13} fontSize={9.5} fontWeight={700} fill="var(--paper-bright)" textAnchor="middle" fontFamily="var(--f-mono)">{n}</text>
+              </g>
+            )}
+            {/* leader dimension in the right margin */}
+            {h > 10 && <text x={pad + W + 4} y={y + h / 2 + 3} fontSize={8.5} fill="var(--ink-muted)" fontFamily="var(--f-mono)">{ftIn(ln)}</text>}
+          </g>
+        );
+      })}
+      {/* width dimension under the roll */}
+      <text x={pad + W / 2} y={pad + H + 11} fontSize={9} fill="var(--ink-muted)" textAnchor="middle" fontFamily="var(--f-mono)">{ftIn(ri.config.rollWidthFt)} roll</text>
+    </svg>
+  );
+}
+
+export default function RollPanel({
+  layouts, // [{ condId, tag, color, fill, hatch, multiplier, ri }] — ri = computeRollTakeoff summary
+  show, onShow, edit, onEdit,
+  onReorder, onResetOrder, onClose,
+}) {
+  const ctl = (on) => ({ padding: "2px 8px", border: `1px solid ${on ? "var(--cobalt)" : "var(--ink-faint)"}`, background: on ? "var(--cobalt)" : "transparent", color: on ? "var(--paper-bright)" : "var(--ink-muted)", cursor: "pointer", fontSize: 10.5, fontFamily: "var(--f-mono)", lineHeight: 1.5 });
+  return (
+    <div style={{ width: 320, flexShrink: 0, display: "flex", flexDirection: "column", borderLeft: "1px solid var(--ink-faint)", background: "var(--paper-bright)", overflow: "hidden", minHeight: 0 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "9px 12px", background: "var(--ink)", color: "var(--paper-cream)" }}>
+        <Icon name="roll" size={15} />
+        <strong style={{ flex: 1, fontSize: 12.5 }}>Roll goods</strong>
+        <button onClick={() => onShow(!show)} title="Draw the figured cuts over the plan" style={ctl(show)}>cuts</button>
+        <button onClick={() => onEdit(!edit)} title="Edit cuts on the plan — drag a cut along its lane, pull its ends to resize; double-click resets a cut to the figured layout" style={ctl(edit)}>edit</button>
+        <button onClick={onClose} title="Close panel" style={{ border: "none", background: "transparent", color: "var(--paper-cream)", fontSize: 16, cursor: "pointer", padding: "0 2px" }}>×</button>
+      </div>
+      <div style={{ flex: 1, overflow: "auto", fontSize: 12 }}>
+        {layouts.length === 0 && (
+          <div style={{ padding: 14, color: "var(--ink-muted)", lineHeight: 1.6 }}>
+            No roll-goods conditions yet. Open a condition's properties in the Takeoffs
+            panel and add a roll setup (carpet, sheet vinyl, rubber) — its floor areas
+            get figured into cuts here.
+          </div>
+        )}
+        {layouts.map(({ condId, tag, color, fill, hatch, multiplier, ri }) => {
+          return (
+            <div key={condId} style={{ borderBottom: "2px solid var(--ink-faint)", padding: "10px 12px" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 2 }}>
+                <span style={{ borderRadius: 4, overflow: "hidden", lineHeight: 0, flexShrink: 0 }}><HatchSwatch type={hatch || "solid"} line={color} fill={fill} /></span>
+                <b style={{ fontFamily: "var(--f-mono)", fontSize: 12 }}>{tag}</b>
+                {multiplier > 1 && <span style={{ color: "var(--ink-muted)", fontSize: 11 }} title="The condition's ×N applies to the ORDER — the diagram shows one unit's cuts">×{multiplier}</span>}
+                <span style={{ marginLeft: "auto", color: "var(--ink-muted)", fontSize: 10.5, fontFamily: "var(--f-mono)" }}>{ri.direction === "ns" ? "run N–S" : "run E–W"}</span>
+              </div>
+              <div style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--ink)", marginBottom: 6 }}>
+                order {ftIn(ri.orderFt)} · {Math.round(ri.qty * 100) / 100} {ri.unit.toUpperCase()} · {ri.cutCount} cut{ri.cutCount === 1 ? "" : "s"}
+                {ri.config.rollLengthFt > 0 ? ` · ${ri.rollCount} roll${ri.rollCount === 1 ? "" : "s"} @ ${ftIn(ri.config.rollLengthFt)}` : ""}
+              </div>
+              {ri.oversize && (
+                <div style={{ margin: "0 0 6px", padding: "5px 8px", border: "1px solid var(--c-danger)", color: "var(--c-danger)", fontSize: 11, lineHeight: 1.45 }}>
+                  A cut is longer than one whole roll — it needs a cross-seam the math can't place. Split the run on the plan (edit mode) or raise the max roll length.
+                </div>
+              )}
+              <div style={{ overflowX: "auto" }}>
+                <RollDiagram ri={ri} editable onReorder={(ids) => onReorder(condId, ids)} />
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 2 }}>
+                <span style={{ fontSize: 10.5, color: "var(--ink-muted)" }}>Drag a cut on the roll to change the cutting order — the roll re-packs.</span>
+                <button onClick={() => onResetOrder(condId)} title="Clear the manual cutting order — the packer sequences widest-then-longest again"
+                  style={{ marginLeft: "auto", flexShrink: 0, padding: "2px 8px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink-muted)", cursor: "pointer", fontSize: 10.5 }}>reset order</button>
+              </div>
+              {/* the cut list — numbered in cutting order, with the piece and the room extent */}
+              <div style={{ marginTop: 6 }}>
+                {ri.strips.slice().sort((a, b) => (ri.nums.get(a.id) || 0) - (ri.nums.get(b.id) || 0)).map((s) => {
+                  const n = ri.nums.get(s.id) || 0;
+                  const lw = Math.max(0, s.laneMax - s.laneMin), ln = Math.max(0, s.runMax - s.runMin);
+                  const cw = Math.max(0, s.coverMax - s.coverMin), cn = Math.max(0, (s.runMax - s.maxOverageFt) - (s.runMin + s.minOverageFt));
+                  return (
+                    <div key={s.id} style={{ display: "flex", gap: 7, alignItems: "baseline", fontSize: 10.5, fontFamily: "var(--f-mono)", color: "var(--ink-secondary)", padding: "1px 0" }}>
+                      <span style={{ color: s.overRoll ? "var(--c-danger)" : "var(--ink)", fontWeight: 700, width: 18, flexShrink: 0 }}>{n}</span>
+                      <span>cut {ftIn(ln)} × {ftIn(lw)}</span>
+                      <span style={{ color: "var(--ink-muted)" }}>· covers {ftIn(cn)} × {ftIn(cw)}{s.label ? ` · ${s.label}` : ""}{s.laneCount > 1 ? ` · lane ${s.laneIndex + 1}/${s.laneCount}` : ""}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/TakeoffsPanel.jsx
+++ b/web/src/components/TakeoffsPanel.jsx
@@ -34,6 +34,9 @@ import { HATCHES, PALETTE, NO_FILL, HatchSwatch } from "./hatches.jsx";
 import { LINE_STYLES, LINE_STYLE_IDS } from "../lib/lineStyles.js";
 import { materialKind, MATERIAL_PRESETS, GROUT_DEFAULTS, groutDerivedFields, showsGroutCalc, showsGroutDeriveAffordance } from "../lib/coverage.js";
 import { draftCommitValue, blurCommitValue, blurCommitNonNegative } from "../lib/draftInput.js";
+import { ROLL_FLOORING_TYPES } from "../lib/rollgoods.js";
+import { hasRollSetup, mintRollSetup } from "../lib/rollTakeoff.js";
+import { ftIn } from "../lib/units";
 
 export const PANEL_MIN_W = 240;
 export const PANEL_MAX_W = 560;
@@ -316,7 +319,7 @@ function AddValueInput({ onAdd }) {
 // the docked panel AND the restored top-bar band render the SAME editor (one
 // source of truth, like the app's single activateCondition path). Owns only its
 // hatch-popover open state; everything else flows through the passed handlers.
-export function ConditionAppearanceEditor({ cond: c, onUpdateCond, onSetCondParam, onAssignAttr, conditionColumns = [], layout = "stack", units = "imperial" }) {
+export function ConditionAppearanceEditor({ cond: c, onUpdateCond, onSetCondParam, onAssignAttr, conditionColumns = [], layout = "stack", units = "imperial", rollInfo = null }) {
   const [hatchOpen, setHatchOpen] = useState(false);
   const activeColor = c.color || "#c96442";
   // Two layouts, one editor. "stack" (docked panel, narrow) stacks the groups
@@ -405,6 +408,97 @@ export function ConditionAppearanceEditor({ cond: c, onUpdateCond, onSetCondPara
           spec.color — NOT the condition's line `color`. Guard that spec is a plain
           object first: a corrupted payload (spec an array/string) would otherwise
           render and let an edit spread it into a garbage shape ({0:"f",1:"o",…}). */}
+      {/* Roll goods (#136) — OPT-IN per condition: conditions are trade-agnostic
+          (no flooring-type field exists), so a roll_setup object PRESENT on the
+          condition is what makes it roll goods. Docked ("stack") layout only,
+          like spec. The engine (lib/rollgoods.js) figures seams/cuts/order
+          footage from the condition's floor areas; the readout below comes back
+          from the canvas via rollInfo. All lengths stored in feet (the lib/units
+          contract); seam/wall allowances are inch-native like the engine. */}
+      {!isRow && !hasRollSetup(c) && (
+        <div style={{ display: "flex", alignItems: "center", gap: 6, paddingTop: 6, marginTop: 1, borderTop: "1px solid var(--ink-faint)" }}>
+          <select name="condition-roll-optin" value=""
+            title="Make this condition a roll-goods material — its floor areas get figured into roll cuts (seams, order footage, a cut diagram)"
+            onChange={(e) => { if (e.target.value) onUpdateCond({ roll_setup: mintRollSetup(e.target.value) }); }}
+            style={{ padding: "3px 6px", borderRadius: 0, border: "1px dashed var(--ink-faint)", background: "transparent", color: "var(--ink-muted)", fontSize: 11.5, cursor: "pointer" }}>
+            <option value="">+ roll goods…</option>
+            <option value="carpet">Broadloom carpet</option>
+            <option value="sheet_vinyl">Sheet vinyl</option>
+            <option value="rubber">Sheet rubber</option>
+          </select>
+        </div>
+      )}
+      {!isRow && hasRollSetup(c) && (() => {
+        const rs = c.roll_setup;
+        const patch = (p) => onUpdateCond({ roll_setup: { ...rs, ...p } });
+        const wFt = Math.floor(Number(rs.roll_width_ft) || 0);
+        const wIn = Math.round(((Number(rs.roll_width_ft) || 0) - wFt) * 12);
+        const setW = (ft, inch) => patch({ roll_width_ft: Math.max(0.5, (Number(ft) || 0) + (Number(inch) || 0) / 12) });
+        const numIp = { width: 46, padding: "3px 5px", borderRadius: 0, border: "1px solid var(--ink-faint)", fontSize: 12 };
+        const sel = { padding: "2px 4px", borderRadius: 0, border: "1px solid var(--ink-faint)", background: "var(--paper-bright)", fontSize: 11.5 };
+        return (
+          <div style={{ display: "flex", flexDirection: "column", gap: 5, paddingTop: 6, marginTop: 1, borderTop: "1px solid var(--ink-faint)" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <span style={{ color: "var(--ink-muted)", fontSize: 10, letterSpacing: 0.4, textTransform: "uppercase" }}
+                title="Roll-goods setup — the engine figures seams, cuts, and order footage from this condition's floor areas">Roll goods</span>
+              <select name="condition-roll-material" value={rs.material || "carpet"} onChange={(e) => patch({ material: e.target.value })} style={sel}
+                title="Material class — sets the cut overlay's material-true color">
+                {ROLL_FLOORING_TYPES.map((ft) => <option key={ft} value={ft}>{ft === "carpet" ? "carpet" : ft === "sheet_vinyl" ? "sheet vinyl" : "rubber"}</option>)}
+              </select>
+              <button onClick={() => onUpdateCond({ roll_setup: undefined })} title="Remove the roll-goods setup (cuts and order footage stop being figured; manual cut edits on shapes are kept but inert)"
+                style={{ marginLeft: "auto", padding: "1px 6px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--c-danger)", cursor: "pointer", fontSize: 11 }}>✕</button>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 5, flexWrap: "wrap" }}>
+              <span style={{ color: "var(--ink-muted)" }}>Roll</span>
+              {rs.material === "carpet" ? (
+                <select name="condition-roll-width" value={String(rs.roll_width_ft)} onChange={(e) => patch({ roll_width_ft: parseFloat(e.target.value) || 12 })} style={sel}
+                  title="Roll width — broadloom comes 12′ or 15′">
+                  <option value="12">12′</option>
+                  <option value="15">15′</option>
+                </select>
+              ) : (
+                <span style={{ display: "inline-flex", alignItems: "center", gap: 3 }} title="Roll width — resilient sheet widths vary by product (6′, 6′6″, 12′…)">
+                  <input name="condition-roll-width-ft" type="number" min="0" step="1" value={wFt} onChange={(e) => setW(e.target.value, wIn)} style={numIp} /><span style={{ color: "var(--ink-muted)" }}>′</span>
+                  <input name="condition-roll-width-in" type="number" min="0" max="11" step="1" value={wIn} onChange={(e) => setW(wFt, e.target.value)} style={numIp} /><span style={{ color: "var(--ink-muted)" }}>″</span>
+                </span>
+              )}
+              <span style={{ color: "var(--ink-muted)" }} title="Max usable length of one physical roll — 0 = continuous (cut off one roll). When set, cuts pack across rolls and the diagram marks the roll breaks.">max</span>
+              <input name="condition-roll-length" type="number" min="0" step="5" value={rs.roll_length_ft || 0}
+                onChange={(e) => patch({ roll_length_ft: Math.max(0, parseFloat(e.target.value) || 0) })} style={numIp} />
+              <span style={{ color: "var(--ink-muted)" }}>′</span>
+              <select name="condition-roll-direction" value={rs.direction || "auto"} onChange={(e) => patch({ direction: e.target.value })} style={sel}
+                title="Run direction — auto picks whichever needs less footage; force it when the pattern or the light dictates">
+                <option value="auto">auto</option>
+                <option value="ns">N–S</option>
+                <option value="ew">E–W</option>
+              </select>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 5, flexWrap: "wrap" }}>
+              <span style={{ color: "var(--ink-muted)" }} title="Seam allowance — extra width where two cuts meet, per seamed edge">Seam</span>
+              <input name="condition-roll-seam" type="number" min="0" step="0.5" value={rs.seam_allowance_in ?? 2}
+                onChange={(e) => patch({ seam_allowance_in: Math.max(0, parseFloat(e.target.value) || 0) })} style={numIp} />
+              <span style={{ color: "var(--ink-muted)" }}>″ · wall</span>
+              <input name="condition-roll-wall" type="number" min="0" step="0.5" value={rs.wall_overage_in ?? 3}
+                onChange={(e) => patch({ wall_overage_in: Math.max(0, parseFloat(e.target.value) || 0) })} style={numIp} />
+              <span style={{ color: "var(--ink-muted)" }}>″ · sells by</span>
+              <select name="condition-roll-unit" value={rs.price_unit || "sf"} onChange={(e) => patch({ price_unit: e.target.value })} style={sel}
+                title="The unit this material sells in — a unit, never a dollar (the takeoff stays quantities-only)">
+                <option value="sy">SY</option>
+                <option value="sf">SF</option>
+                <option value="lf">LF</option>
+              </select>
+            </div>
+            {rollInfo && (
+              <div style={{ fontFamily: "var(--f-mono,monospace)", fontSize: 11, color: "var(--ink)" }}
+                title="The figured order — how far down the roll the cuts reach (side-by-side cuts share length), rounded up to the inch. The Roll panel has the cut diagram.">
+                Figured: order {ftIn(rollInfo.orderFt)} · {rollInfo.qty} {rollInfo.unit.toUpperCase()}
+                {rollInfo.config.rollLengthFt > 0 ? ` · ${rollInfo.rollCount} roll${rollInfo.rollCount === 1 ? "" : "s"}` : ""}
+                {rollInfo.oversize && <span style={{ color: "var(--c-danger)" }}> · a cut exceeds one roll</span>}
+              </div>
+            )}
+          </div>
+        );
+      })()}
       {!isRow && c.spec && typeof c.spec === "object" && !Array.isArray(c.spec) && (
         <div style={{ display: "flex", flexDirection: "column", gap: 4, paddingTop: 6, marginTop: 1, borderTop: "1px solid var(--ink-faint)" }}>
           <span style={{ color: "var(--ink-muted)", fontSize: 10, letterSpacing: 0.4, textTransform: "uppercase" }}
@@ -425,7 +519,7 @@ export function ConditionAppearanceEditor({ cond: c, onUpdateCond, onSetCondPara
 
 function TakeoffsPanel({
   open, width, multiSheet, units = "imperial",
-  conditions, activeCond, visRowById, projRowById = new Map(), conditionColumns, shapeLabels = [], templates, palette = [],
+  conditions, activeCond, visRowById, projRowById = new Map(), conditionColumns, shapeLabels = [], templates, palette = [], rollByCond = null,
   matLib, matLibById, linkedCountById,
   panelPrefs, onPanelPrefs, reassigning, epoch, clearSelectionRef,
   onActivate, onSetActive, onLocate,
@@ -649,7 +743,7 @@ function TakeoffsPanel({
             used to live in its own toolbar row above the canvas. Extracted to
             ConditionAppearanceEditor so the docked panel AND the top-bar band
             render the same editor from one source of truth. */}
-        {on && <ConditionAppearanceEditor cond={c} onUpdateCond={onUpdateCond} onSetCondParam={onSetCondParam} onAssignAttr={onAssignAttr} conditionColumns={conditionColumns} units={units} />}
+        {on && <ConditionAppearanceEditor cond={c} onUpdateCond={onUpdateCond} onSetCondParam={onSetCondParam} onAssignAttr={onAssignAttr} conditionColumns={conditionColumns} units={units} rollInfo={rollByCond?.get(c.id) || null} />}
         {matOn && (
           <div style={{ padding: "8px 12px 10px", background: "var(--paper-cream)", borderTop: "1px solid var(--ink-faint)", fontSize: 11.5 }}>
             <div style={{ marginBottom: 6, color: "var(--ink-muted)" }}>Supporting Materials — order qty = measured ÷ coverage, rounded up.</div>

--- a/web/src/lib/canvasUtil.js
+++ b/web/src/lib/canvasUtil.js
@@ -63,6 +63,7 @@ export const instantiateTemplate = (t) => ({
   ...(t.thickness_in != null ? { thickness_in: t.thickness_in } : {}),
   ...(t.laborType != null ? { laborType: t.laborType } : {}),
   ...(t.subfloorType != null ? { subfloorType: t.subfloorType } : {}),
+  ...(t.roll_setup ? { roll_setup: { ...t.roll_setup } } : {}),   // #136 — deep-copied like grout: a template's roll spec must never be shared by reference
   // instantiateMaterial (lib/materials.js) deep-copies the nested grout
   // geometry — a shallow spread here aliased the CT-1 seed's one grout object
   // into every fresh-workspace condition across every project in the session

--- a/web/src/lib/reportColumns.js
+++ b/web/src/lib/reportColumns.js
@@ -95,6 +95,7 @@ const COL_DIM = {
   floor_sf: "area", wall_sf: "area", border_sf: "area", total_sf: "area",
   total_sf_net: "area", waste_sf: "area",
   lf: "len", lf_net: "len", waste_lf: "len", perimeter_ref: "len",
+  "roll:order_lf": "len",
 };
 export const METRIC_LABELS = { area: "m²", len: "m" };        // on-screen table
 export const METRIC_CSV_LABELS = { area: "m2", len: "m" };    // CSV/XLSX (ASCII, matches the legend PDF)
@@ -214,6 +215,34 @@ export function laborColProfile(conditions) {
     defaultVisible: true,
     labor: true,
     get: (r, ctx) => laborValue(ctx?.laborByCond?.get(r.id), f.field),
+  }));
+}
+
+// ── Roll goods (#136) ───────────────────────────────────────────────────────
+// The figured order beside the measured quantities: order footage down the
+// roll (side-by-side cuts share length — NOT a sum of cut lengths) and the
+// physical roll count. Values arrive via ctx.rollByCond (Map(condition_id →
+// computeRollTakeoff summary)), the spec/labor seam — never as row fields.
+// Emitted only when at least one condition actually figures a roll layout, so
+// a project without roll goods is byte-identical (frozen 13 → built-in
+// opt-ins → custom → spec → labor → roll). ×N applies like every quantity —
+// N identical units are N cuttings of the same layout.
+export const ROLL_FIELDS = [
+  { key: "roll:order_lf", header: "Roll Order LF", get: (ri, mult) => round2(ri.orderFt * mult) },
+  { key: "roll:rolls", header: "Rolls", get: (ri, mult) => ri.rollCount * mult },
+];
+
+export function rollColProfile(rollByCond) {
+  if (!(rollByCond instanceof Map) || !rollByCond.size) return [];
+  return ROLL_FIELDS.map((f) => ({
+    key: f.key,
+    header: f.header,
+    defaultVisible: true,
+    roll: true,
+    get: (r, ctx) => {
+      const ri = ctx?.rollByCond?.get(r.id);
+      return ri ? f.get(ri, r.multiplier || 1) : "";
+    },
   }));
 }
 

--- a/web/src/lib/rollTakeoff.js
+++ b/web/src/lib/rollTakeoff.js
@@ -1,0 +1,174 @@
+// Roll-goods takeoff wiring (#136) — the pure bridge between the canvas's
+// shape/condition model and lib/rollgoods.js (the packing engine). The engine
+// speaks polygon rings in FEET; the app stores verts normalized to a sheet's
+// bitmap. This module owns that conversion plus everything derivable without
+// React or the DOM: per-condition layouts, the per-sheet cut rectangles the
+// overlay draws, the per-shape override plumbing, and the report rows the
+// Report table / CSV / opentakeoff.report.v1 consume. Keep it pure — the same
+// math must serve the canvas and any headless consumer.
+//
+// Opt-in contract (the engine's own header states it): OpenTakeoff conditions
+// are trade-agnostic, so roll goods is a `roll_setup` object ON the condition
+// — presence is the opt-in — carrying `material` (carpet | sheet_vinyl |
+// rubber) for color/defaults plus the engine's spec fields. Manual per-cut
+// edits live on the SHAPE as `roll_layout: { laneCount, lanes: { [laneIndex]:
+// { runMin, runMax, seq? } } }` — keyed by lane so a reshaped room (lane count
+// changed) drops its stale overrides via the engine's own laneCount guard.
+import {
+  isRollType, defaultRollSetup, computeRollLayout, rollLayoutOrderLengthFt,
+  rollLayoutRollCount, rollCutNumbers, rollQtyForUnit, roundUpToInch,
+} from "./rollgoods.js";
+import { round2 } from "./num.js";
+
+// A condition is roll goods iff it carries a usable roll_setup. Corrupt
+// payloads (roll_setup an array/string, width missing) read as opted OUT —
+// the same defensive posture as spec/attrs sanitizing, without a hydrate pass.
+export function hasRollSetup(c) {
+  const rs = c?.roll_setup;
+  return !!rs && typeof rs === "object" && !Array.isArray(rs) && Number(rs.roll_width_ft) > 0;
+}
+
+// Fresh setup for the opt-in select — the engine's defaults plus the material
+// class the overlay colors by.
+export function mintRollSetup(material) {
+  const ft = isRollType(material) ? material : "carpet";
+  return { material: ft, ...defaultRollSetup(ft) };
+}
+
+// roll_setup → the engine's config object, every field coerced. doorway
+// overage rides along for forward-compat but stays inert until door edges
+// exist on shapes (hasDoorAtEdge is never supplied — deliberately no UI knob
+// for a field that would silently do nothing).
+export function rollConfig(rs) {
+  return {
+    rollWidthFt: Math.max(0.5, Number(rs.roll_width_ft) || 12),
+    rollLengthFt: Math.max(0, Number(rs.roll_length_ft) || 0),
+    seamAllowanceIn: Math.max(0, Number(rs.seam_allowance_in) || 0),
+    wallOverageIn: Math.max(0, Number(rs.wall_overage_in) || 0),
+    doorwayOverageIn: Math.max(0, Number(rs.doorway_overage_in) || 0),
+    direction: rs.direction === "ns" || rs.direction === "ew" ? rs.direction : "auto",
+  };
+}
+
+// Manual per-cut overrides, flattened off every shape into the engine's
+// { "<shapeId>:<laneIndex>": { runMin, runMax, seq, laneCount } } map. The
+// laneCount guard is applied by the ENGINE (applyStripOverrides /
+// seqFromOverrides) — this just collects.
+export function collectRollOverrides(shapes) {
+  const out = {};
+  for (const s of shapes) {
+    const rl = s.roll_layout;
+    if (!rl || typeof rl !== "object" || !rl.lanes || typeof rl.lanes !== "object") continue;
+    for (const [li, o] of Object.entries(rl.lanes)) {
+      if (!o || typeof o !== "object") continue;
+      out[`${s.id}:${li}`] = { ...o, laneCount: rl.laneCount };
+    }
+  }
+  return out;
+}
+
+// The length/width of one strip's physical cut piece, in feet.
+export const stripLenFt = (s) => Math.max(0, s.runMax - s.runMin);
+export const stripWidthFt = (s) => Math.max(0, s.laneMax - s.laneMin);
+
+// One strip's floor rectangle in SHEET PX — the overlay's frame. laneAxis "x"
+// (direction ns) tiles lanes across x and runs along y; "ew" the reverse.
+export function stripSheetRect(strip, upp) {
+  if (!(upp > 0)) return null;
+  const lane0 = strip.laneMin / upp, lane1 = strip.laneMax / upp;
+  const run0 = strip.runMin / upp, run1 = strip.runMax / upp;
+  return strip.laneAxis === "x"
+    ? { x: lane0, y: run0, w: lane1 - lane0, h: run1 - run0 }
+    : { x: run0, y: lane0, w: run1 - run0, h: lane1 - lane0 };
+}
+
+// ── the whole takeoff, figured ──────────────────────────────────────────────
+// computeRollTakeoff(conditions, shapes, dimsFor, uppFor) →
+//   { byCond: Map(condition_id → summary), cutsBySheet: Map(sheet_id → cut[]) }
+//
+// dimsFor(sheetId) → {w,h}|null (bitmap px), uppFor(sheetId) → feet-per-px|null.
+// Shapes on unscaled/unrendered sheets are skipped — a ring needs real feet.
+// Only floor_area shapes participate: a roll cut is a floor piece. Interior
+// holes (verts_norm_holes) deliberately do NOT shorten cuts — material runs
+// past a column and the cut piece is still full length; the hole nets out of
+// the AREA quantities, not the roll.
+//
+// summary: { material, config, direction, strips, nums, orderFt, rollCount,
+//            oversize, qty, unit, cutCount }
+//   orderFt is roundUpToInch'd (you order to the inch) and PER UNIT — the
+//   condition ×N multiplier applies at the report seam like every quantity.
+export function computeRollTakeoff(conditions, shapes, dimsFor, uppFor) {
+  const byCond = new Map();
+  const cutsBySheet = new Map();
+  const rollConds = (conditions || []).filter(hasRollSetup);
+  if (!rollConds.length) return { byCond, cutsBySheet };
+  const shapeById = new Map(shapes.map((s) => [s.id, s]));
+  for (const c of rollConds) {
+    const rs = c.roll_setup;
+    const config = rollConfig(rs);
+    const items = [];
+    for (const s of shapes) {
+      if (s.condition_id !== c.id || s.measure_role !== "floor_area") continue;
+      if (!Array.isArray(s.verts_norm) || s.verts_norm.length < 3) continue;
+      const dims = dimsFor(s.sheet_id), upp = uppFor(s.sheet_id);
+      if (!dims || !(dims.w > 0) || !(upp > 0)) continue;
+      items.push({ id: s.id, name: s.label || "", ring: s.verts_norm.map(([nx, ny]) => ({ x: nx * dims.w * upp, y: ny * dims.h * upp })) });
+    }
+    if (!items.length) continue;
+    const layout = computeRollLayout(items, config, collectRollOverrides(shapes));
+    const nums = rollCutNumbers(layout.strips);
+    const orderFt = roundUpToInch(rollLayoutOrderLengthFt(layout.strips));
+    const material = isRollType(rs.material) ? rs.material : "carpet";
+    const unit = rs.price_unit === "lf" || rs.price_unit === "sf" || rs.price_unit === "sy" ? rs.price_unit : "sf";
+    byCond.set(c.id, {
+      material, config, direction: layout.direction, strips: layout.strips, nums,
+      orderFt, rollCount: rollLayoutRollCount(layout.strips),
+      oversize: layout.strips.some((s) => s.overRoll),
+      qty: round2(rollQtyForUnit(orderFt, config.rollWidthFt, unit)), unit,
+      cutCount: layout.strips.length,
+    });
+    for (const strip of layout.strips) {
+      const src = shapeById.get(strip.srcId);
+      if (!src) continue;
+      const upp = uppFor(src.sheet_id);
+      const rect = stripSheetRect(strip, upp);
+      if (!rect) continue;
+      if (!cutsBySheet.has(src.sheet_id)) cutsBySheet.set(src.sheet_id, []);
+      cutsBySheet.get(src.sheet_id).push({
+        id: strip.id, srcId: strip.srcId, condId: c.id,
+        laneIndex: strip.laneIndex, laneCount: strip.laneCount, laneAxis: strip.laneAxis,
+        x: rect.x, y: rect.y, w: rect.w, h: rect.h,
+        runMin: strip.runMin, runMax: strip.runMax, upp,
+        lenFt: stripLenFt(strip), widthFt: stripWidthFt(strip),
+        num: nums.get(strip.id) || 0, overRoll: !!strip.overRoll,
+        multi: strip.laneCount > 1, material,
+      });
+    }
+  }
+  return { byCond, cutsBySheet };
+}
+
+// ── report seam ─────────────────────────────────────────────────────────────
+// The additive roll_goods block for opentakeoff.report.v1 (and the ctx the
+// Report's roll columns read). rows = conditionTotals output — finish_tag and
+// multiplier come from there so the block can never disagree with the table.
+// ×N applies here, the same convention as every other reported quantity: N
+// identical units are N cuttings of the same layout.
+export function rollReportRows(rollByCond, rows) {
+  if (!rollByCond || !rollByCond.size || !Array.isArray(rows)) return [];
+  const out = [];
+  for (const r of rows) {
+    const ri = rollByCond.get(r.id);
+    if (!ri) continue;
+    const mult = r.multiplier || 1;
+    out.push({
+      condition_id: r.id, finish_tag: r.finish_tag, material: ri.material,
+      roll_width_ft: ri.config.rollWidthFt, roll_length_ft: ri.config.rollLengthFt,
+      direction: ri.direction, cuts: ri.cutCount,
+      order_lf: round2(ri.orderFt * mult), rolls: ri.rollCount * mult,
+      order_qty: round2(ri.qty * mult), order_unit: ri.unit,
+      oversize: ri.oversize,
+    });
+  }
+  return out;
+}

--- a/web/src/lib/shapeCommands.js
+++ b/web/src/lib/shapeCommands.js
@@ -77,6 +77,7 @@ export const PROVENANCE_POLICY = {
   review: "origin.reviewed → true + accepted_ts per still-pending shape; restore puts the prior origin back verbatim",
   ruleApply: "add semantics (created_at + id mint per shape, ONE undo entry per batch); caller-built rule_v1 origin carries rule_id + seed_shape_id",
   cutout: "#137 — mints the deduct (id + created_at) AND patches its parent's verts_norm/verts_norm_holes/computed as ONE undo entry; parent patch stamps nothing, nothing counts; restore unmints the deduct and reverts the parent verbatim",
+  rollcut: "#136 — NO stamp: a manual roll-cut override (slide/resize/reorder/reset) writes LAYOUT metadata (shape.roll_layout) over the shape, never its geometry or provenance; a row without roll_layout clears the key; `prev` (grab-time rows) builds the inverse when a live preview already wrote the final state",
 };
 
 // Undo depth — one bounded gesture history, not an archive (revisions are).
@@ -316,6 +317,29 @@ export function applyShapeCommand(shapes, cmd) {
       if (!parentPrev) return { shapes, inverse: null };   // parent vanished mid-gesture — refuse rather than mint an orphaned deduct
       next.push(minted);
       return { shapes: next, inverse: { type: "cutout", restore: true, deductId: minted.id, parentId: cmd.parentId, parentPrev } };
+    }
+    case "rollcut": {
+      // #136 — patch shape.roll_layout across one or more shapes as ONE undo
+      // entry (a drag gesture, a whole-roll reorder, a reset). Rows are
+      // presence-aware like every restore in this file: a row carrying
+      // roll_layout sets it; a row without clears the key (back to the
+      // engine's auto layout). `prev` is the geom-command idea applied here:
+      // the caller's grab-time rows build the inverse when the live drag
+      // preview already wrote the final layout into the array — without it,
+      // the inverse reads the CURRENT shapes (the discrete-edit path).
+      const rows = cmd.rows || [];
+      const byId = new Map(rows.map((r) => [r.id, r]));
+      const prevRows = cmd.prev || shapes.filter((s) => byId.has(s.id))
+        .map((s) => ({ id: s.id, ...("roll_layout" in s ? { roll_layout: s.roll_layout } : {}) }));
+      const next = shapes.map((s) => {
+        const r = byId.get(s.id);
+        if (!r) return s;
+        if ("roll_layout" in r && r.roll_layout != null) return { ...s, roll_layout: r.roll_layout };
+        if (!("roll_layout" in s)) return s;
+        const { roll_layout: _rl, ...rest } = s;   // clear = key absent, never null
+        return rest;
+      });
+      return { shapes: next, inverse: { type: "rollcut", rows: prevRows } };
     }
     case "review": {
       if (cmd.restore) {

--- a/web/src/lib/totals.js
+++ b/web/src/lib/totals.js
@@ -394,9 +394,10 @@ export function totalsToCsv(rows, projectName = "", bySheet = null, sheetLabel =
  *   rfis?: any[], sheetLabel?: ((sheetId: any) => string)|null,
  *   conditionColumns?: Array<{id: string, name: string, values: string[]}>,
  *   attrsByCond?: Map<any, object>|null, shapeLabels?: string[],
- *   byLabel?: Array<{value: string|null, rows: any[]}>, displayUnits?: string}} args
+ *   byLabel?: Array<{value: string|null, rows: any[]}>, displayUnits?: string,
+ *   rollGoods?: any[]}} args
  */
-export function reportJson({ projectName = "", rows = [], bySheet = [], scaleInfo = [], markups = [], rfis = [], sheetLabel = null, conditionColumns = [], attrsByCond = null, shapeLabels = [], byLabel = [], displayUnits = "imperial" }) {
+export function reportJson({ projectName = "", rows = [], bySheet = [], scaleInfo = [], markups = [], rfis = [], sheetLabel = null, conditionColumns = [], attrsByCond = null, shapeLabels = [], byLabel = [], displayUnits = "imperial", rollGoods = [] }) {
   const label = (id) => (sheetLabel ? sheetLabel(id) : id);
   // destructuring defaults don't apply to an explicit null, and both values can
   // trace back to a corrupted payload — coerce (and drop malformed items) so
@@ -480,6 +481,13 @@ export function reportJson({ projectName = "", rows = [], bySheet = [], scaleInf
     // "JSON stays raw, but says so" contract.
     units: "imperial (SF/LF — raw internal values)",
     display_units: displayUnits === "metric" ? "metric" : "imperial",
+    // roll_goods APPENDS last (additive-only v1, #136): one row per roll-goods
+    // condition — the figured order (order_lf / rolls / order_qty in the
+    // condition's sell unit, ×N applied like every reported quantity) beside
+    // the measured quantities the conditions[] rows already carry. Always
+    // emitted; empty for projects with no roll-goods conditions, so every
+    // pre-#136 export round-trips byte-identically except this one key.
+    roll_goods: Array.isArray(rollGoods) ? rollGoods : [],
   };
 }
 

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -56,6 +56,12 @@ import { libFields, matFieldOverridden, libPushPatch, libRevertPatch, libEntryPa
 import RfiPanel from "../components/RfiPanel.jsx";
 import StampPanel from "../components/StampPanel.jsx";
 import ImportSchedulePanel from "../components/ImportSchedulePanel.jsx";
+// Roll goods (#136): lib/rollgoods.js is the pure packing engine (untouched
+// here), lib/rollTakeoff.js the pure shapes→engine bridge; RollPanel is the
+// docked diagram/reorder desk. Cut edits commit through the rollcut command.
+import RollPanel from "../components/RollPanel.jsx";
+import { rollColorForType } from "../lib/rollgoods.js";
+import { computeRollTakeoff } from "../lib/rollTakeoff.js";
 // In-canvas takeoff agent — BYO-key tool-use loop (lib/agentLoop) aiming the
 // registry of deterministic tools (lib/agentTools); this file provides the
 // CAPABILITIES those tools close over and the review gate their proposals
@@ -333,6 +339,11 @@ export default function TakeoffCanvas() {
   const [ruleOffer, setRuleOffer] = useState(null);   // { deduct, seed, tag }
   const [ruleStage, setRuleStage] = useState(null);   // { rule, candidates, proposed_ts }
   const [agentOpen, setAgentOpen] = useState(false);      // docked right-rail Agent panel
+  // ── roll goods (#136) — view state; the figured layouts are a memo below ──
+  const [rollShow, setRollShow] = useState(true);         // draw the figured cuts over the plan (on: opting a condition in shows its cuts immediately)
+  const [rollEdit, setRollEdit] = useState(false);        // cut-edit mode — cuts take pointer events (slide / resize / double-click reset)
+  const [rollPanelOpen, setRollPanelOpen] = useState(false); // docked Roll panel (diagram + reorder)
+  const rollDragRef = useRef(null);                       // live cut-drag gesture; commit is ONE rollcut command on release
   const [agentLog, setAgentLog] = useState([]);           // streaming run status [{kind, text}]
   const [agentRunning, setAgentRunning] = useState(false);
   const [showAiSettings, setShowAiSettings] = useState(false); // BYO-key config modal (ai.js seam)
@@ -729,6 +740,124 @@ export default function TakeoffCanvas() {
   useEffect(() => {
     agentStateRef.current = { panels, scales, scaleSources, detectedScales, conditions, status };
   });
+
+  // ── roll goods (#136): the figured layouts, one pure pass over the takeoff ──
+  // Rendered sheets only — a ring needs bitmap dims (panelImgs) plus a scale to
+  // speak feet. Memoized off geometry/config, never the transform: pan/zoom
+  // must not re-figure a roll. uppFor reads `scales` (a dep) plus a ref pinned
+  // to RENDER_SCALE, so the dep list is honest.
+  const rollTakeoff = useMemo(
+    () => computeRollTakeoff(conditions, shapes, (k) => panelImgs[k] || null, (k) => uppFor(k)),
+    [conditions, shapes, panelImgs, scales]   // uppFor: scales + a pinned ref
+  );
+  const rollByCond = rollTakeoff.byCond;
+  const rollCutsByPanel = rollTakeoff.cutsBySheet;
+
+  // Cut drag (#136) — the self-contained element-drag pattern (the panel-resize
+  // handle's): the cut's own <g> opts into pointer events in edit mode, captures
+  // the pointer, live-PREVIEWS by writing shape.roll_layout through raw
+  // setShapes (the sanctioned preview path — see the dispatchShape header), and
+  // commits ONE undoable `rollcut` command on release whose inverse is the
+  // grab-time row. kind: "body" slides the cut along its lane; "start"/"end"
+  // pull the run ends (the installer's call the math can't make — carry into a
+  // closet, stop short of a transition). A cut can never get shorter than 3″.
+  const beginRollCut = (e, ct, kind) => {
+    if (!rollEdit) return;
+    e.stopPropagation(); e.preventDefault();
+    const shape = shapes.find((s) => s.id === ct.srcId);
+    if (!shape) return;
+    rollDragRef.current = {
+      srcId: ct.srcId, laneIndex: ct.laneIndex, laneCount: ct.laneCount, kind,
+      runY: ct.laneAxis === "x", upp: ct.upp, sx: e.clientX, sy: e.clientY,
+      base: { runMin: ct.runMin, runMax: ct.runMax },
+      prevRow: { id: ct.srcId, ...("roll_layout" in shape ? { roll_layout: shape.roll_layout } : {}) },
+      moved: false, lastLayout: null,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+  const moveRollCut = (e) => {
+    const d = rollDragRef.current; if (!d) return;
+    const dFt = ((d.runY ? e.clientY - d.sy : e.clientX - d.sx) / tfRef.current.scale) * d.upp;
+    let { runMin, runMax } = d.base;
+    if (d.kind === "body") { runMin += dFt; runMax += dFt; }
+    else if (d.kind === "start") runMin = Math.min(d.base.runMax - 0.25, d.base.runMin + dFt);
+    else runMax = Math.max(d.base.runMin + 0.25, d.base.runMax + dFt);
+    d.moved = d.moved || Math.abs(dFt) > 1e-4;
+    // Build the target layout SYNCHRONOUSLY, from the grab-time row — never
+    // inside the setShapes updater: a fast flick's pointerup can land before
+    // React flushes the last move, and a commit that reads updater-written
+    // state would silently skip (the house drag pattern: gesture state lives
+    // in the ref, the updater only mirrors it). A stored layout from a
+    // DIFFERENT lane count is stale (reshaped room) — start fresh rather than
+    // resurrect overrides aimed at lanes that moved.
+    const prevRl = d.prevRow.roll_layout;
+    const prior = prevRl && typeof prevRl === "object" && prevRl.lanes && prevRl.laneCount === d.laneCount ? prevRl.lanes : {};
+    d.lastLayout = { laneCount: d.laneCount, lanes: { ...prior, [d.laneIndex]: { ...(prior[d.laneIndex] || {}), runMin, runMax } } };
+    setShapes((ss) => ss.map((s) => (s.id === d.srcId ? { ...s, roll_layout: d.lastLayout } : s)));
+  };
+  const endRollCut = () => {
+    const d = rollDragRef.current; if (!d) return;
+    rollDragRef.current = null;
+    if (!d.moved || !d.lastLayout) return;   // zero-motion = not an edit — no command, no undo entry
+    dispatchShape({ type: "rollcut", rows: [{ id: d.srcId, roll_layout: d.lastLayout }], prev: [d.prevRow] });
+  };
+  // double-click: hand THIS cut back to the figured layout (drop its lane
+  // override; the key clears entirely when no other lane holds an edit)
+  const resetRollCut = (ct) => {
+    const shape = shapes.find((s) => s.id === ct.srcId);
+    const rl = shape?.roll_layout;
+    if (!rl || !rl.lanes || !(ct.laneIndex in rl.lanes)) return;
+    const lanes = { ...rl.lanes };
+    delete lanes[ct.laneIndex];
+    const row = Object.keys(lanes).length ? { id: ct.srcId, roll_layout: { laneCount: rl.laneCount, lanes } } : { id: ct.srcId };
+    dispatchShape({ type: "rollcut", rows: [row] });
+  };
+  // RollPanel reorder: the dragged order becomes seq overrides (manual cuts
+  // pack FIRST, in that order — the engine's skyline re-packs, so a manual
+  // order can never overlap) — ONE rollcut command, one undo entry.
+  const onReorderRollCuts = (condId, orderedIds) => {
+    const ri = rollByCond.get(condId); if (!ri) return;
+    const laneCountBySrc = new Map(ri.strips.map((s) => [s.srcId, s.laneCount]));
+    const bySrc = new Map();
+    orderedIds.forEach((sid, idx) => {
+      const i = sid.lastIndexOf(":");
+      const srcId = sid.slice(0, i), lane = sid.slice(i + 1);
+      if (!bySrc.has(srcId)) bySrc.set(srcId, {});
+      bySrc.get(srcId)[lane] = idx;
+    });
+    const rows = [];
+    for (const [srcId, seqByLane] of bySrc) {
+      const shape = shapes.find((s) => s.id === srcId); if (!shape) continue;
+      const lc = laneCountBySrc.get(srcId);
+      const prior = shape.roll_layout?.laneCount === lc && shape.roll_layout.lanes ? shape.roll_layout.lanes : {};
+      const lanes = { ...prior };
+      for (const [lane, seq] of Object.entries(seqByLane)) lanes[lane] = { ...(lanes[lane] || {}), seq };
+      rows.push({ id: srcId, roll_layout: { laneCount: lc, lanes } });
+    }
+    if (rows.length) dispatchShape({ type: "rollcut", rows });
+  };
+  // strip only the seq keys — a floor-position edit (runMin/runMax) survives a
+  // cutting-order reset; that's a different decision than double-click reset
+  const onResetRollOrder = (condId) => {
+    const ri = rollByCond.get(condId); if (!ri) return;
+    const srcIds = new Set(ri.strips.map((s) => s.srcId));
+    const rows = [];
+    for (const s of shapes) {
+      if (!srcIds.has(s.id) || !s.roll_layout?.lanes) continue;
+      let changed = false;
+      const lanes = {};
+      for (const [k, o] of Object.entries(s.roll_layout.lanes)) {
+        if (o && typeof o === "object" && "seq" in o) {
+          const { seq: _seq, ...rest } = o;
+          changed = true;
+          if (Object.keys(rest).length) lanes[k] = rest;
+        } else lanes[k] = o;
+      }
+      if (!changed) continue;
+      rows.push(Object.keys(lanes).length ? { id: s.id, roll_layout: { laneCount: s.roll_layout.laneCount, lanes } } : { id: s.id });
+    }
+    if (rows.length) dispatchShape({ type: "rollcut", rows });
+  };
 
   // ── transform: tfRef is source of truth; write straight to the DOM ─────────
   const applyTf = useCallback(() => {
@@ -4871,6 +5000,7 @@ export default function TakeoffCanvas() {
     ...(c.thickness_in != null ? { thickness_in: c.thickness_in } : {}),
     ...(c.laborType != null ? { laborType: c.laborType } : {}),
     ...(c.subfloorType != null ? { subfloorType: c.subfloorType } : {}),
+    ...(c.roll_setup ? { roll_setup: { ...c.roll_setup } } : {}),   // #136 — the roll spec is part of what makes a CPT-1 template CPT-1
     materials: (c.materials || []).map(({ id: _id, ...m }) => (m.grout ? { ...m, grout: { ...m.grout } } : m)),   // ids are minted on instantiation; grout never shared by reference
   });
   const saveActiveAsTemplate = () => {
@@ -6176,6 +6306,55 @@ export default function TakeoffCanvas() {
                         </g>
                       );
                     })}
+                    {/* Roll-goods cut overlay (#136) — every figured cut drawn to
+                        scale over its room in the MATERIAL-TRUE color (carpet tan,
+                        vinyl/rubber grey — the engine's own palette, so cuts never
+                        mimic a condition's takeoff look), numbered in cutting
+                        order, dashed when the room seams across lanes. Inert
+                        drawing until edit mode; then each cut owns its pointer
+                        events — body slides along the lane, the two end handles
+                        pull the run ends, double-click resets to the figured
+                        layout. Adjacent cuts overlapping IS the seam (physical
+                        pieces carry the seam allowance). */}
+                    {rollShow && (rollCutsByPanel.get(p.key) || []).map((ct) => {
+                      const s = tf.scale;
+                      const col = rollColorForType(ct.material);
+                      const runY = ct.laneAxis === "x";     // strips run along screen y; lanes tile across x
+                      const hs = 5 / s;
+                      const showNum = ct.w * s > 16 && ct.h * s > 16;
+                      const strokeCol = ct.overRoll ? "#b03a26" : col;
+                      return (
+                        <g key={"roll" + ct.id}
+                          style={{ pointerEvents: rollEdit ? "auto" : "none", cursor: rollEdit ? "grab" : undefined }}
+                          onPointerDown={(e) => beginRollCut(e, ct, "body")}
+                          onPointerMove={moveRollCut} onPointerUp={endRollCut} onPointerCancel={endRollCut}
+                          onDoubleClick={() => rollEdit && resetRollCut(ct)}>
+                          <title>{`Cut ${ct.num} — ${condById[ct.condId]?.finish_tag || "?"}: ${fmtCheckLen(ct.lenFt, units)} × ${fmtCheckLen(ct.widthFt, units)}${ct.multi ? ` · lane ${ct.laneIndex + 1}/${ct.laneCount}` : ""}${ct.overRoll ? " · LONGER THAN ONE ROLL — needs a cross-seam" : ""}${rollEdit ? " · drag to slide, pull the square handles to resize, double-click to reset" : ""}`}</title>
+                          <rect x={ct.x} y={ct.y} width={ct.w} height={ct.h}
+                            fill={col + "38"} stroke={strokeCol}
+                            strokeWidth={(ct.overRoll ? 2.6 : 1.8) / s}
+                            strokeDasharray={ct.multi ? `${6 / s} ${4 / s}` : undefined} />
+                          {showNum && (
+                            <g style={{ pointerEvents: "none" }}>
+                              <circle cx={ct.x + 11 / s} cy={ct.y + 11 / s} r={7.5 / s} fill={strokeCol} stroke="#fff" strokeWidth={1 / s} />
+                              <text x={ct.x + 11 / s} y={ct.y + 14.4 / s} fontSize={10 / s} fontWeight={700} fill="#fff" textAnchor="middle" fontFamily="var(--f-mono,monospace)">{ct.num}</text>
+                            </g>
+                          )}
+                          {rollEdit && (
+                            <>
+                              <rect x={runY ? ct.x + ct.w / 2 - hs : ct.x - hs} y={runY ? ct.y - hs : ct.y + ct.h / 2 - hs}
+                                width={hs * 2} height={hs * 2} fill="#fff" stroke={strokeCol} strokeWidth={1.4 / s}
+                                style={{ cursor: runY ? "ns-resize" : "ew-resize" }}
+                                onPointerDown={(e) => beginRollCut(e, ct, "start")} />
+                              <rect x={runY ? ct.x + ct.w / 2 - hs : ct.x + ct.w - hs} y={runY ? ct.y + ct.h - hs : ct.y + ct.h / 2 - hs}
+                                width={hs * 2} height={hs * 2} fill="#fff" stroke={strokeCol} strokeWidth={1.4 / s}
+                                style={{ cursor: runY ? "ns-resize" : "ew-resize" }}
+                                onPointerDown={(e) => beginRollCut(e, ct, "end")} />
+                            </>
+                          )}
+                        </g>
+                      );
+                    })}
                   </g>
                 );
               })}
@@ -6477,6 +6656,7 @@ export default function TakeoffCanvas() {
           {panelBtn(() => setLeftTab((t) => (t === "rfi" ? null : "rfi")), "rfi", "RFI register — raise, track, and export Requests For Information", leftTab === "rfi", rfis.length)}
           {panelBtn(toggleTakeoffs, "takeoffs", "Takeoffs — conditions + running totals", takeoffsOpen, visibleShapes.length)}
           {panelBtn(() => setAgentOpen((o) => !o), "target", "Agent — describe a takeoff; it stages dashed proposals you accept or reject (bring your own AI key)", agentOpen, agentProposals.length)}
+          {rollByCond.size > 0 && panelBtn(() => setRollPanelOpen((o) => !o), "roll", "Roll goods — the cut diagram, cutting order, and figured order footage", rollPanelOpen, rollByCond.size)}
           {panelBtn(() => setShowRevisions(true), "revisions", "Revisions — save the takeoff at each bid revision, compare what moved", showRevisions)}
         </div>
 
@@ -6507,6 +6687,23 @@ export default function TakeoffCanvas() {
           />
         )}
 
+        {/* Roll panel (#136) — DOCKED right-rail sibling like the Agent panel:
+            per-condition cut diagrams (to scale, numbered), drag-to-reorder with
+            the engine re-pack, the overlay/edit toggles, and the figured order
+            lines. A pure view — layout state lives on the shapes (rollcut). */}
+        {rollPanelOpen && (
+          <RollPanel
+            layouts={[...rollByCond.entries()].map(([condId, ri]) => {
+              const c = condById[condId];
+              return { condId, tag: c?.finish_tag || "?", color: c?.color, fill: c?.fill, hatch: c?.hatch, multiplier: c?.multiplier || 1, ri };
+            })}
+            show={rollShow} onShow={setRollShow}
+            edit={rollEdit} onEdit={setRollEdit}
+            onReorder={onReorderRollCuts} onResetOrder={onResetRollOrder}
+            onClose={() => setRollPanelOpen(false)}
+          />
+        )}
+
         {/* Takeoffs panel — DOCKED in the layout row (reflows the canvas, not an
             overlay): every condition with its running totals, plus the Library,
             Materials, and Columns tabs. Extracted to components/TakeoffsPanel.jsx and
@@ -6527,6 +6724,7 @@ export default function TakeoffCanvas() {
           shapeLabels={shapeLabels}
           templates={templates}
           palette={palette}
+          rollByCond={rollByCond}
           matLib={matLib}
           matLibById={matLibById}
           linkedCountById={linkedCountById}
@@ -6597,6 +6795,7 @@ export default function TakeoffCanvas() {
           conditions={conditions} shapes={shapes} markups={markups} rfis={rfis}
           conditionColumns={conditionColumns} shapeLabels={shapeLabels}
           scaleInfo={Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px, scale_source: scaleSources[sheet_id] || "unknown" }))}
+          rollByCond={rollByCond}
           provenanceCounters={provCounters}
           sheetLabel={(k) => tabLabel(k)}
           onMarkedSet={exportMarkedSet} markedSetDark={darkMode}

--- a/web/test/reportColumns.test.ts
+++ b/web/test/reportColumns.test.ts
@@ -362,3 +362,23 @@ test("CSV is byte-identical to golden when no condition has a spec (spec cols co
   const csv = totalsToCsv(rows, projectName, sheetTotals(conditions, shapes), sheetLabel, cols);
   assert.equal(csv, golden);
 });
+
+// ── roll-goods columns (#136) ────────────────────────────────────────────────
+
+test("rollColProfile: empty without figured layouts; ×N-applied getters through ctx; metric converts order LF", async () => {
+  const { rollColProfile, applyUnits } = await import("../src/lib/reportColumns.js");
+  assert.deepEqual(rollColProfile(null), []);
+  assert.deepEqual(rollColProfile(new Map()), [], "no roll conditions → zero extra columns (golden CSV byte-safe)");
+  const rollByCond = new Map([["c1", { orderFt: 29, rollCount: 2 }]]);
+  const cols = rollColProfile(rollByCond);
+  assert.deepEqual(cols.map((c: any) => [c.key, c.header]), [["roll:order_lf", "Roll Order LF"], ["roll:rolls", "Rolls"]]);
+  const ctx = { rollByCond };
+  const row = { id: "c1", multiplier: 3 };
+  assert.equal(cols[0].get(row, ctx), 87, "order LF ×N");
+  assert.equal(cols[1].get(row, ctx), 6, "rolls ×N");
+  assert.equal(cols[0].get({ id: "other", multiplier: 1 }, ctx), "", "a non-roll condition's cell is blank");
+  // metric: the LF column converts at the descriptor like every dimensioned column
+  const [mOrder] = applyUnits(cols, "metric");
+  assert.equal(mOrder.header, "Roll Order m");
+  assert.equal(mOrder.get(row, ctx), round2(87 * 0.3048));
+});

--- a/web/test/rollTakeoff.test.ts
+++ b/web/test/rollTakeoff.test.ts
@@ -1,0 +1,134 @@
+// Roll-goods wiring (lib/rollTakeoff.js, #136) — the pure bridge between the
+// shape/condition model and the packing engine. The invariants:
+//   - opt-in is roll_setup PRESENCE (corrupt setups read as opted out);
+//   - rings convert verts_norm → feet through the sheet's dims × upp, and
+//     shapes on unscaled/unrendered sheets are skipped, never guessed;
+//   - overrides collect off shape.roll_layout keyed "<shapeId>:<laneIndex>"
+//     with the parent's laneCount (the engine's stale-override guard reads it);
+//   - the overlay rects land in SHEET PX on the right axes for both run
+//     directions;
+//   - report rows apply ×N (the house convention for every quantity) and
+//     stay quantities-only.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  hasRollSetup, mintRollSetup, rollConfig, collectRollOverrides,
+  computeRollTakeoff, rollReportRows, stripSheetRect,
+} from "../src/lib/rollTakeoff.js";
+import { conditionTotals } from "../src/lib/totals.js";
+
+// A 20×14-ft room drawn on a 1000×1000-px sheet at upp = 0.05 ft/px:
+// 20 ft = 400 px wide (x), 14 ft = 280 px tall (y), anchored at (100, 100) px.
+const UPP = 0.05;
+const DIMS = { w: 1000, h: 1000 };
+const room = (id: string, condId: string) => ({
+  id, condition_id: condId, sheet_id: "s1", measure_role: "floor_area",
+  verts_norm: [[0.1, 0.1], [0.5, 0.1], [0.5, 0.38], [0.1, 0.38]],
+  computed: { area_sf: 280, perimeter_lf: 68 },
+});
+const dimsFor = (k: string) => (k === "s1" ? DIMS : null);
+const uppFor = (k: string) => (k === "s1" ? UPP : null);
+
+test("opt-in is roll_setup presence; corrupt setups read as opted out", () => {
+  assert.equal(hasRollSetup({ roll_setup: mintRollSetup("carpet") }), true);
+  assert.equal(hasRollSetup({}), false);
+  assert.equal(hasRollSetup({ roll_setup: "corrupt" }), false);
+  assert.equal(hasRollSetup({ roll_setup: ["x"] }), false);
+  assert.equal(hasRollSetup({ roll_setup: { roll_width_ft: 0 } }), false);
+});
+
+test("mintRollSetup: engine defaults + the material class; carpet sells by SY, resilient by SF", () => {
+  const c = mintRollSetup("carpet");
+  assert.deepEqual({ m: c.material, w: c.roll_width_ft, u: c.price_unit }, { m: "carpet", w: 12, u: "sy" });
+  assert.equal(mintRollSetup("sheet_vinyl").price_unit, "sf");
+  assert.equal(mintRollSetup("nonsense").material, "carpet", "unknown class falls back, never throws");
+});
+
+test("rollConfig coerces every field and clamps direction to the engine's vocabulary", () => {
+  const cfg = rollConfig({ roll_width_ft: "12", seam_allowance_in: -3, wall_overage_in: null, direction: "diagonal" });
+  assert.deepEqual(cfg, { rollWidthFt: 12, rollLengthFt: 0, seamAllowanceIn: 0, wallOverageIn: 0, doorwayOverageIn: 0, direction: "auto" });
+});
+
+test("computeRollTakeoff: a 20×14 room on a 12-ft roll figures 2 lanes and a to-scale overlay", () => {
+  const conds = [{ id: "cpt", finish_tag: "CPT-1", roll_setup: { ...mintRollSetup("carpet"), direction: "ns" } }];
+  const shapes = [room("r1", "cpt")];
+  const { byCond, cutsBySheet } = computeRollTakeoff(conds, shapes, dimsFor, uppFor);
+  const ri = byCond.get("cpt");
+  assert.ok(ri, "the opted-in condition figures");
+  assert.equal(ri.direction, "ns");
+  assert.equal(ri.cutCount, 2, "20 ft across a 12-ft roll = 2 lanes");
+  // each N–S cut runs the room's 14-ft height + 3″ wall overage per end
+  const lens = ri.strips.map((s: any) => s.runMax - s.runMin);
+  for (const ln of lens) assert.ok(Math.abs(ln - 14.5) < 1e-9, `cut length ${ln} = 14 + 2×0.25 wall overage`);
+  // order footage: two cuts side-by-side won't fit one 12-ft width — they
+  // stack down the roll: 2 × 14.5 = 29 ft, rounded up to the inch
+  assert.ok(Math.abs(ri.orderFt - 29) < 1e-9, `orderFt ${ri.orderFt}`);
+  assert.equal(ri.rollCount, 1, "no max roll length = one continuous roll");
+  assert.ok(Math.abs(ri.qty - (29 * 12) / 9) < 0.01, "SY = orderFt × width ÷ 9");
+  // overlay rects: sheet px, lanes tiling across x (ns), full-lane cut 12 ft
+  // wide draws at the TRUE roll width incl. allowances, not the coverage split
+  const cuts = cutsBySheet.get("s1");
+  assert.equal(cuts.length, 2);
+  const c0 = cuts.find((c: any) => c.laneIndex === 0);
+  assert.ok(Math.abs(c0.h - 14.5 / UPP) < 1e-6, "run extent in sheet px");
+  assert.ok(c0.multi && c0.laneCount === 2, "a seamed room's cuts read as multi");
+  assert.ok(cuts.every((c: any) => c.num >= 1 && c.num <= 2), "numbered in cutting order");
+});
+
+test("computeRollTakeoff: unscaled sheets and non-floor shapes are skipped, never guessed", () => {
+  const conds = [{ id: "cpt", finish_tag: "CPT-1", roll_setup: mintRollSetup("carpet") }];
+  const offSheet = { ...room("r2", "cpt"), sheet_id: "unrendered" };
+  const linear = { ...room("r3", "cpt"), measure_role: "linear" };
+  const { byCond } = computeRollTakeoff(conds, [offSheet, linear], dimsFor, uppFor);
+  assert.equal(byCond.size, 0, "nothing figured — no ring can speak feet");
+});
+
+test("collectRollOverrides flattens lanes with the parent laneCount; corrupt layouts are ignored", () => {
+  const shapes = [
+    { id: "a", roll_layout: { laneCount: 2, lanes: { 0: { runMin: 1, runMax: 9 }, 1: { seq: 3 } } } },
+    { id: "b", roll_layout: "corrupt" },
+    { id: "c" },
+  ];
+  assert.deepEqual(collectRollOverrides(shapes), {
+    "a:0": { runMin: 1, runMax: 9, laneCount: 2 },
+    "a:1": { seq: 3, laneCount: 2 },
+  });
+});
+
+test("a manual run override rides into the figured layout (and the engine's laneCount guard drops stale ones)", () => {
+  const conds = [{ id: "cpt", finish_tag: "CPT-1", roll_setup: { ...mintRollSetup("carpet"), direction: "ns" } }];
+  const withOverride = [{ ...room("r1", "cpt"), roll_layout: { laneCount: 2, lanes: { 0: { runMin: 4, runMax: 20 } } } }];
+  const ri = computeRollTakeoff(conds, withOverride, dimsFor, uppFor).byCond.get("cpt");
+  const lane0 = ri.strips.find((s: any) => s.laneIndex === 0);
+  assert.deepEqual({ min: lane0.runMin, max: lane0.runMax }, { min: 4, max: 20 }, "override applied");
+  const stale = [{ ...room("r1", "cpt"), roll_layout: { laneCount: 5, lanes: { 0: { runMin: 4, runMax: 20 } } } }];
+  const ri2 = computeRollTakeoff(conds, stale, dimsFor, uppFor).byCond.get("cpt");
+  const lane0b = ri2.strips.find((s: any) => s.laneIndex === 0);
+  assert.ok(Math.abs((lane0b.runMax - lane0b.runMin) - 14.5) < 1e-9, "a laneCount mismatch (reshaped room) drops the override");
+});
+
+test("stripSheetRect maps both run directions onto the right screen axes", () => {
+  const ns = stripSheetRect({ laneAxis: "x", laneMin: 5, laneMax: 17, runMin: 5, runMax: 19 }, UPP);
+  assert.deepEqual(ns, { x: 100, y: 100, w: 240, h: 280 });
+  const ew = stripSheetRect({ laneAxis: "y", laneMin: 5, laneMax: 17, runMin: 5, runMax: 19 }, UPP);
+  assert.deepEqual(ew, { x: 100, y: 100, w: 280, h: 240 });
+  assert.equal(stripSheetRect({ laneAxis: "x", laneMin: 0, laneMax: 1, runMin: 0, runMax: 1 }, 0), null, "no upp, no rect");
+});
+
+test("rollReportRows: ×N applies like every reported quantity; only figured conditions emit; quantities-only", () => {
+  const conds = [
+    { id: "cpt", finish_tag: "CPT-1", multiplier: 3, roll_setup: { ...mintRollSetup("carpet"), direction: "ns" } },
+    { id: "vct", finish_tag: "VCT-1" },
+  ];
+  const shapes = [room("r1", "cpt"), room("r9", "vct")];
+  const { byCond } = computeRollTakeoff(conds, shapes, dimsFor, uppFor);
+  const rows = rollReportRows(byCond, conditionTotals(conds, shapes));
+  assert.equal(rows.length, 1, "only the roll-goods condition emits a row");
+  const r = rows[0];
+  assert.deepEqual(
+    { tag: r.finish_tag, lf: r.order_lf, rolls: r.rolls, unit: r.order_unit },
+    { tag: "CPT-1", lf: 87, rolls: 3, unit: "sy" },   // 29 ft × 3 units
+  );
+  assert.ok(!("price" in r) && !("cost" in r), "quantities only — no dollars, ever");
+  assert.deepEqual(rollReportRows(null, []), []);
+});

--- a/web/test/shapeCommands.test.ts
+++ b/web/test/shapeCommands.test.ts
@@ -406,3 +406,43 @@ test("ruleApply: add semantics — mints ids/created_at, one noCount-delete inve
   // ONE inverse deletes the whole batch, and never feeds the deletion counters
   assert.deepEqual(fwd.inverse, { type: "delete", ids: added.map((s) => s.id), noCount: true });
 });
+
+// ── rollcut (#136) — roll-layout metadata patches, presence-aware, no stamp ──
+
+test("rollcut: sets / clears roll_layout with an exact inverse; prev overrides the inverse source", () => {
+  const shapes = [
+    { id: "a", condition_id: "c1", measure_role: "floor_area", verts_norm: [[0, 0], [1, 0], [1, 1]] },
+    { id: "b", condition_id: "c1", measure_role: "floor_area", verts_norm: [[0, 0], [1, 0], [1, 1]], roll_layout: { laneCount: 2, lanes: { 0: { seq: 1 } } } },
+  ];
+  const rl = { laneCount: 2, lanes: { 1: { runMin: 0, runMax: 12 } } };
+  // set on a — inverse row carries NO roll_layout key (clear on undo)
+  const r1 = applyShapeCommand(shapes, { type: "rollcut", rows: [{ id: "a", roll_layout: rl }] });
+  assert.deepEqual(r1.shapes[0].roll_layout, rl);
+  assert.equal(r1.shapes[0].updated_at, undefined, "no stamp — layout metadata is not a shape edit");
+  assert.deepEqual(r1.inverse, { type: "rollcut", rows: [{ id: "a" }] });
+  const undone = applyShapeCommand(r1.shapes, r1.inverse);
+  assert.deepEqual(undone.shapes, shapes, "undo restores the input verbatim, key absence included");
+  // clear on b — inverse carries the prior layout
+  const r2 = applyShapeCommand(shapes, { type: "rollcut", rows: [{ id: "b" }] });
+  assert.equal("roll_layout" in r2.shapes[1], false);
+  assert.deepEqual(r2.inverse.rows, [{ id: "b", roll_layout: shapes[1].roll_layout }]);
+  // prev (the grab-time row) builds the inverse when a live preview already
+  // wrote the final state — the geom-command idea
+  const previewed = applyShapeCommand(shapes, { type: "rollcut", rows: [{ id: "a", roll_layout: rl }] }).shapes;
+  const r3 = applyShapeCommand(previewed, { type: "rollcut", rows: [{ id: "a", roll_layout: rl }], prev: [{ id: "a" }] });
+  assert.deepEqual(applyShapeCommand(r3.shapes, r3.inverse).shapes, shapes, "inverse from prev undoes past the preview");
+});
+
+test("rollcut: multi-row (a reorder) is ONE command with one exact inverse", () => {
+  const shapes = [
+    { id: "a", condition_id: "c1", measure_role: "floor_area", verts_norm: [[0, 0], [1, 0], [1, 1]], roll_layout: { laneCount: 1, lanes: { 0: { runMin: 1, runMax: 9 } } } },
+    { id: "b", condition_id: "c1", measure_role: "floor_area", verts_norm: [[0, 0], [1, 0], [1, 1]] },
+  ];
+  const cmd = { type: "rollcut", rows: [
+    { id: "a", roll_layout: { laneCount: 1, lanes: { 0: { runMin: 1, runMax: 9, seq: 0 } } } },
+    { id: "b", roll_layout: { laneCount: 1, lanes: { 0: { seq: 1 } } } },
+  ] };
+  const r = applyShapeCommand(shapes, cmd);
+  assert.deepEqual(r.shapes[0].roll_layout.lanes[0], { runMin: 1, runMax: 9, seq: 0 });
+  assert.deepEqual(applyShapeCommand(r.shapes, r.inverse).shapes, shapes);
+});

--- a/web/test/totals.test.ts
+++ b/web/test/totals.test.ts
@@ -127,11 +127,14 @@ test("reportJson: v1 key set pinned — top level, sheets[], markups[], by_sheet
   assert.equal(j.schema, "opentakeoff.report.v1");
   // condition_columns appended after markups (additive-only v1, 2026-07-07);
   // shape_labels + by_label appended after it (#112, additive-only, always
-  // emitted); units + display_units appended last (metric display port —
-  // quantities stay RAW feet, the export says which system the user was reading)
+  // emitted); units + display_units appended after that (metric display port —
+  // quantities stay RAW feet, the export says which system the user was
+  // reading); roll_goods appended last (#136, always emitted, empty without
+  // roll-goods conditions)
   assert.deepEqual(Object.keys(j),
-    ["schema", "project_name", "generated_with", "sheets", "conditions", "by_sheet", "totals", "materials", "markups", "rfis", "condition_columns", "shape_labels", "by_label", "units", "display_units"]);
+    ["schema", "project_name", "generated_with", "sheets", "conditions", "by_sheet", "totals", "materials", "markups", "rfis", "condition_columns", "shape_labels", "by_label", "units", "display_units", "roll_goods"]);
   assert.equal(j.display_units, "imperial");
+  assert.deepEqual(j.roll_goods, []);   // #136 — always emitted; empty when nothing carries a roll_setup
   // rfis[] appends after markups (additive v1); linked_markups/linked_sheets derived
   assert.deepEqual(Object.keys(j.rfis[0]),
     ["id", "number", "subject", "question", "status", "to", "priority", "cost_impact", "schedule_impact",
@@ -164,6 +167,12 @@ test("reportJson: v1 key set pinned — top level, sheets[], markups[], by_sheet
     ["id", "finish_tag", "color", "fill", "hatch", "multiplier", "waste_pct", "shape_count",
      "floor_sf", "wall_sf", "border_sf", "lf", "ea", "total_sf",
      "floor_sf_net", "wall_sf_net", "border_sf_net", "lf_net", "total_sf_net", "sy_net", "materials", "columns"]);
+});
+
+test("reportJson: roll_goods rides through verbatim; a non-array coerces to [] (#136)", () => {
+  const rows = [{ condition_id: "ct", finish_tag: "CPT-1", material: "carpet", roll_width_ft: 12, roll_length_ft: 0, direction: "ns", cuts: 3, order_lf: 46.5, rolls: 1, order_qty: 62, order_unit: "sy", oversize: false }];
+  assert.deepEqual(reportJson({ rollGoods: rows }).roll_goods, rows);
+  assert.deepEqual(reportJson({ rollGoods: "corrupt" as any }).roll_goods, []);
 });
 
 test("reportJson: by_sheet rows serialize round2-ed — incl. ea — with key order intact", () => {


### PR DESCRIPTION
#135 landed the engine; this is the canvas. Roll goods is an **opt-in on a condition** — a \`roll_setup\` present is what makes a condition roll goods (material class carpet / sheet vinyl / rubber; conditions stay trade-agnostic, exactly as the engine's header prescribes) — and the four surfaces the issue names all ship:

**Opt-in per condition.** A Roll Goods section in the condition's properties: material class, roll width (12′/15′ select for broadloom, ft+in for resilient), max roll length (0 = continuous), seam/wall allowances, run direction, sell unit — plus the live figured readout (\`order 4′ 11″ · 6.56 SY\`). \`roll_setup\` rides the persisted payload untouched and is captured into condition templates at both whitelist sites.

**Cut overlay.** Every figured cut drawn to scale over its room in the **material-true color** (the engine's own palette — cuts never mimic a condition's takeoff look), numbered in cutting order, dashed when a room seams across lanes, danger-red when a cut exceeds one physical roll. Edit mode: slide a cut along its lane, pull its run ends (min 3″), double-click resets — every edit commits through a new \`rollcut\` shape command with an exact inverse, so **cut edits are undoable** (⌘Z verified live).

**Roll panel.** A docked right-rail sibling: the cuts laid out on the roll to scale with per-cut dimensions, physical roll boundaries when a max length is set, over-roll warnings, and drag-to-reorder — a manual order becomes seq overrides and the engine's skyline **re-packs**, so a reordered roll can never overlap. Reset order keeps floor-position edits.

**Report integration.** \`Roll Order LF\` + \`Rolls\` columns beside the measured quantities — an opt-in profile that appears only when a condition figures a layout, so a project without roll goods is byte-identical (frozen CSV 13 untouched, golden test green). \`opentakeoff.report.v1\` gains an additive \`roll_goods\` block (always emitted, empty when unused; key-set pin updated), mirrored in the MCP \`export_report\` outputSchema. ×N applies to the order like every reported quantity. Quantities only — no dollars, enforced by test.

The bridge is a new pure module, \`web/src/lib/rollTakeoff.js\` (rings in feet through dims × upp, per-shape \`roll_layout\` override plumbing with the engine's stale-laneCount guard, per-sheet cut rects) — no React, no DOM, tested like the engine. The engine itself is untouched.

One bug found and fixed during live verification: the drag commit must read gesture state written **synchronously to the ref**, never state written inside the \`setShapes\` updater — a fast flick's pointerup can land before React flushes the last move, and the commit would silently skip.

Verified in the running app end-to-end: opt-in → figured readout → overlay → roll panel → reorder → drag + ⌘Z → report columns + totals → save/load round-trip → remove setup restores everything. \`npm run check\` green (1031 tests); \`mcp\` suite + dist smoke green; 0.9.4 → 0.9.5.

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)