### PR TITLE
feat(engine): read the PDF layer tree — OCGs as stated geometry roles (#85, phase 1)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/scripts/make-layered-fixture.mjs
+++ b/mcp/scripts/make-layered-fixture.mjs
@@ -1,0 +1,67 @@
+// Generates test/fixtures/layered-plan.pdf — the OCG fixture for #85 (neither
+// bundled demo plan carries Optional Content, so the layered case ships its
+// own). Deterministic byte output; re-run only to change the fixture:
+//   node scripts/make-layered-fixture.mjs
+//
+// The sheet (612×612 pt):
+//   A-WALL-FULL (on)   a 300×300 pt room, stroked — the boundary
+//   A-FLOR-PATT (on)   a 3×3 tile grid inside — only FOUR interior lines,
+//                      far below HATCH_MIN_RUN, so the pitch heuristics keep
+//                      them HARD and a naive flood traps in one tile cell;
+//                      the layer states what they are, which is the point
+//   A-ANNO-TEXT (on)   a leader line crossing the room — annotation ink
+//   A-WALL-DEMO (OFF)  a wall bisecting the room, hidden in the default
+//                      config — excluded unless explicitly included
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const OUT = join(dirname(fileURLToPath(import.meta.url)), "..", "test", "fixtures", "layered-plan.pdf");
+
+const content = [
+  "/OC /oc1 BDC",
+  "2 w",
+  "100 100 300 300 re S",
+  "EMC",
+  "/OC /oc2 BDC",
+  "0.5 w",
+  "200 100 m 200 400 l S",
+  "300 100 m 300 400 l S",
+  "100 200 m 400 200 l S",
+  "100 300 m 400 300 l S",
+  "EMC",
+  "/OC /oc3 BDC",
+  "0.5 w",
+  "110 110 m 390 390 l S",
+  "EMC",
+  "/OC /oc4 BDC",
+  "2 w",
+  "100 250 m 400 250 l S",
+  "EMC",
+].join("\n");
+
+const objects = [
+  "<< /Type /Catalog /Pages 2 0 R /OCProperties << /OCGs [5 0 R 6 0 R 7 0 R 8 0 R] /D << /Order [5 0 R 6 0 R 7 0 R 8 0 R] /OFF [8 0 R] >> >> >>",
+  "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+  "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 612] /Contents 4 0 R /Resources << /Properties << /oc1 5 0 R /oc2 6 0 R /oc3 7 0 R /oc4 8 0 R >> >> >>",
+  `<< /Length ${content.length} >>\nstream\n${content}\nendstream`,
+  "<< /Type /OCG /Name (A-WALL-FULL) >>",
+  "<< /Type /OCG /Name (A-FLOR-PATT) >>",
+  "<< /Type /OCG /Name (A-ANNO-TEXT) >>",
+  "<< /Type /OCG /Name (A-WALL-DEMO) >>",
+];
+
+let pdf = "%PDF-1.5\n";
+const offsets = [];
+objects.forEach((body, i) => {
+  offsets.push(pdf.length);
+  pdf += `${i + 1} 0 obj\n${body}\nendobj\n`;
+});
+const xrefAt = pdf.length;
+pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+for (const off of offsets) pdf += `${String(off).padStart(10, "0")} 00000 n \n`;
+pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefAt}\n%%EOF\n`;
+
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, pdf, "latin1");
+console.log(`wrote ${OUT} (${pdf.length} bytes)`);

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.5",
+  "version": "0.9.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -37,6 +37,14 @@ export const sheetInfoOutput = {
   scale_set: z.boolean(),
   upp: z.number().optional().describe("Real feet per image px at render scale 2.0 — present once the scale is set"),
   shape_count: z.number().int().describe("Committed shapes on this sheet"),
+  layers: z.array(z.object({
+    id: z.string().describe("Optional Content Group id — pass to one_click/detect_rooms layers.include/exclude"),
+    name: z.string().describe("The CAD layer name as exported (e.g. A-WALL-FULL)"),
+    role: z.enum(["boundary", "finish-pattern", "annotation", "structure", "demolition", "unknown"]).describe("What this layer's linework IS to a takeoff (lib/layers.ts) — boundary/structure plot hard, pattern/annotation/demolition are excluded, unknown falls back to the hatch heuristics"),
+    confidence: z.number().describe("0..1 — how sure the name classifier is"),
+    visible: z.boolean().describe("Default-config visibility — a hidden layer's ink is excluded outright (or you trace demolition)"),
+    seg_count: z.number().int().describe("Segments this layer owns on this sheet"),
+  })).describe("The sheet's PDF layer table (#85) — [] when no Optional Content survived export (every engine path then runs the heuristics unchanged)"),
 };
 
 export const setScaleOutput = {

--- a/mcp/src/pdf.ts
+++ b/mcp/src/pdf.ts
@@ -68,9 +68,16 @@ async function ensureCanvasGlobals(): Promise<void> {
   g.ImageData ??= napi.ImageData;
 }
 
+/** One Optional Content Group as the document declares it — id (pdf.js objId,
+ * what the operator list attributes segments to), the CAD layer name, and the
+ * DEFAULT-config visibility (#85). */
+export interface OcgEntry { id: string; name: string; visible: boolean; }
+
 export interface DocHandle {
   numPages: number;
   page(n: number): Promise<PageHandle>;
+  /** The document's Optional Content Groups (empty = no layers survived export). */
+  layers(): Promise<OcgEntry[]>;
   destroy(): Promise<void>;
 }
 
@@ -137,6 +144,12 @@ export async function openPdf(filePath: string): Promise<DocHandle> {
           }
         },
       };
+    },
+    async layers(): Promise<OcgEntry[]> {
+      const cfg = await doc.getOptionalContentConfig();
+      const groups = cfg ? (cfg.getGroups() as Record<string, { name?: string | null; visible?: boolean }> | null) : null;
+      if (!groups) return [];
+      return Object.entries(groups).map(([id, g]) => ({ id, name: String(g?.name ?? ""), visible: g?.visible !== false }));
     },
     destroy: () => doc.destroy().then(() => undefined),
   };

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -5,7 +5,8 @@
 // what the canvas commits (web/src/pages/TakeoffCanvas.jsx), so an exported
 // takeoff round-trips into the app.
 import path from "node:path";
-import { openPdf, positionedText, textSpans, OPS, type DocHandle, type PageHandle, type TextSpan } from "./pdf.ts";
+import { openPdf, positionedText, textSpans, OPS, type DocHandle, type PageHandle, type TextSpan, type OcgEntry } from "./pdf.ts";
+import { classifyLayerName, layerRoleCodes, segRoles, type LayerInfo } from "../../web/src/lib/layers.ts";
 import { UserError, round1, round2 } from "./format.ts";
 import { STANDARD_SCALES, RENDER_SCALE, detectScale, extractSheetNumber, type DetectedScale } from "../../web/src/lib/sheets.ts";
 import {
@@ -82,6 +83,10 @@ export interface ShapeOrigin {
    * to close the region (engine `gapBridged` — canvas parity: the rescue rides
    * provenance rather than passing itself off as a clean fill). */
   gap_bridged_px?: number;
+  /** one_click (#85): the flood ran against a mask whose boundary was STATED
+   * by the sheet's PDF layers (visible boundary/structure roles present) —
+   * categorically stronger evidence than a pitch-heuristic boundary. */
+  layer_bounded?: true;
   raster_traced?: true;
   fill_sensitivity?: number;
   /** Machine's original trace, frozen on first human edit (provenance.js). */
@@ -160,6 +165,9 @@ interface SheetState {
   hatch?: HatchFamily[];
   /** text as bbox spans (image px), built on first sheet_context */
   spans?: TextSpan[];
+  /** the sheet's Optional Content layers (#85), classified — built with geo;
+   * [] = no layers survived export (the silent, invisible fallback) */
+  layers?: LayerInfo[];
 }
 
 /** sheet_context decimation defaults (issue #29) — declared and stable, never
@@ -501,20 +509,79 @@ export class Session {
       const opList = await s.page.operatorList();
       s.geo = extractVectorGeometry(opList, s.page.viewport.transform, OPS);
       s.snap = buildSnapGrid(s.geo.points, SNAP_CELL);
+      // classify this sheet's Optional Content layers (#85): the doc declares
+      // id → (name, default visibility); the geometry attributes segments; the
+      // pure normalizer states each layer's ROLE. Only layers that actually
+      // own segments on this sheet are reported — an empty table is the
+      // unlayered case and every consumer falls through to the heuristics.
+      const layerIds = s.geo.layerIds || [];
+      if (layerIds.length && this.doc) {
+        const byId = new Map((await this.doc.layers()).map((g) => [g.id, g]));
+        const counts = new Map<number, number>();
+        const lo = s.geo.layerOf;
+        if (lo) for (let i = 0; i < lo.length; i++) if (lo[i] >= 0) counts.set(lo[i], (counts.get(lo[i]) || 0) + 1);
+        s.layers = layerIds.map((id, k) => {
+          const g = byId.get(id);
+          const name = g?.name || "";
+          const { role, confidence } = classifyLayerName(name);
+          return { id, name, role, confidence, visible: g ? g.visible : true, seg_count: counts.get(k) || 0 };
+        });
+      } else {
+        s.layers = [];
+      }
     }
     return s.geo;
   }
 
+  /** Per-layer role codes for buildMask (#85), with optional include/exclude
+   * OVERRIDES (by layer name or id, case-insensitive): include forces hard
+   * boundary, exclude drops the layer outright — the agent's judgment beats
+   * the table's. Unknown names error with the sheet's actual layer list
+   * (resolve-or-error, never a silent no-op). */
+  private rolesFor(s: SheetState, geo: VectorGeometry, layersOpt?: { include?: string[]; exclude?: string[] }): Uint8Array | null {
+    const infos = s.layers || [];
+    if (!infos.length || !geo.layerIds?.length) {
+      if (layersOpt && (layersOpt.include?.length || layersOpt.exclude?.length)) {
+        throw new UserError(`${s.key} has no PDF layers (no Optional Content survived export) — layers.include/exclude can't apply here.`);
+      }
+      return null;
+    }
+    const infoById = new Map(infos.map((l) => [l.id, { role: l.role, visible: l.visible }]));
+    if (layersOpt) {
+      const resolve = (ref: string): LayerInfo => {
+        const needle = ref.trim().toLowerCase();
+        const hit = infos.find((l) => l.id.toLowerCase() === needle || l.name.toLowerCase() === needle);
+        if (!hit) throw new UserError(`No layer ${JSON.stringify(ref)} on ${s.key}. Layers: ${infos.map((l) => l.name || l.id).join(" | ")}`);
+        return hit;
+      };
+      for (const ref of layersOpt.include || []) { const l = resolve(ref); infoById.set(l.id, { role: "boundary", visible: true }); }
+      for (const ref of layersOpt.exclude || []) { const l = resolve(ref); infoById.set(l.id, { role: l.role, visible: false }); }
+    }
+    return segRoles(geo.layerOf, layerRoleCodes(geo.layerIds, infoById));
+  }
+
   /** v1 masks come from the sheet's vector linework only. Raster seam: a scanned
    * sheet would render via a node canvas into a future rastermask module that
-   * returns this same MaskObj shape. */
+   * returns this same MaskObj shape. Layer roles (#85) ride in as the stated
+   * short-circuit; an unlayered sheet builds the identical pre-#85 mask. */
   async ensureMask(name: string): Promise<MaskObj | null> {
     const s = this.sheet(name);
     if (s.mask === undefined) {
       const geo = await this.ensureGeometry(s);
-      s.mask = geo.segs.length ? buildMask(geo.segs, s.widthPx, s.heightPx, MASK_MAX_DIM, geo.meta) : null;
+      s.mask = geo.segs.length ? buildMask(geo.segs, s.widthPx, s.heightPx, MASK_MAX_DIM, geo.meta, this.rolesFor(s, geo)) : null;
     }
     return s.mask;
+  }
+
+  /** The mask honoring per-call layer overrides — a fresh build when overrides
+   * are given (never cached: the default mask stays authoritative), the cached
+   * default otherwise. */
+  async maskWithLayers(name: string, layersOpt?: { include?: string[]; exclude?: string[] }): Promise<MaskObj | null> {
+    if (!layersOpt || (!layersOpt.include?.length && !layersOpt.exclude?.length)) return this.ensureMask(name);
+    const s = this.sheet(name);
+    const geo = await this.ensureGeometry(s);
+    if (!geo.segs.length) return null;
+    return buildMask(geo.segs, s.widthPx, s.heightPx, MASK_MAX_DIM, geo.meta, this.rolesFor(s, geo, layersOpt));
   }
 
   async sheetInfo(name: string) {
@@ -527,6 +594,9 @@ export class Session {
       scale_set: s.upp != null,
       ...(s.upp != null ? { upp: s.upp } : {}),
       shape_count: this.shapes.filter((x) => x.sheet_id === s.key).length,
+      // the sheet's PDF layer table (#85) — always emitted; [] = no Optional
+      // Content survived export and every engine path runs the heuristics
+      layers: (s.layers || []).map((l) => ({ id: l.id, name: l.name, role: l.role, confidence: l.confidence, visible: l.visible, seg_count: l.seg_count })),
     };
   }
 
@@ -608,9 +678,9 @@ export class Session {
     return shape;
   }
 
-  async oneClick(name: string, x: number, y: number, opts: { condition?: string; role: "floor_area" | "deduct"; returnVerts: boolean; sensitivity?: number }) {
+  async oneClick(name: string, x: number, y: number, opts: { condition?: string; role: "floor_area" | "deduct"; returnVerts: boolean; sensitivity?: number; layers?: { include?: string[]; exclude?: string[] } }) {
     const s = this.sheet(name);
-    const mask = await this.ensureMask(name);
+    const mask = await this.maskWithLayers(name, opts.layers);
     if (!mask) throw new UserError("This sheet has no vector linework (likely a scan); raster fallback not yet available in the MCP server.");
     const f = floodRegion(mask, x, y, opts.sensitivity ?? SENS_BALANCED);
     if (f.status === "leak") throw new UserError("That space isn't enclosed on the plan linework — the fill spilled through a gap or opening.");
@@ -649,6 +719,9 @@ export class Session {
         reviewed: false,
         ...(f.hatchFiltered ? { hatch_filtered: true as const } : {}),
         ...(f.gapBridged ? { gap_bridged_px: f.gapBridged } : {}),
+        // #85 — a trace bounded by DECLARED boundary layers is categorically
+        // stronger evidence than one bounded by a pitch heuristic
+        ...((s.layers || []).some((l) => l.visible && (l.role === "boundary" || l.role === "structure")) ? { layer_bounded: true as const } : {}),
         // canvas-parity provenance: a non-default fill sensitivity is part of
         // how the shape was made (ShapeOrigin.fill_sensitivity)
         ...(opts.sensitivity !== undefined && opts.sensitivity !== SENS_BALANCED ? { fill_sensitivity: opts.sensitivity } : {}),
@@ -688,9 +761,9 @@ export class Session {
    *       broom closet is ~10 SF): a door swing or wall cavity. Only applied
    *       once a scale exists, since without one there is no real area to
    *       judge and nothing commits anyway. */
-  async detectRooms(name: string, opts: { condition?: string; role: "floor_area" | "deduct"; returnVerts: boolean; minAreaSf?: number; sensitivity?: number }) {
+  async detectRooms(name: string, opts: { condition?: string; role: "floor_area" | "deduct"; returnVerts: boolean; minAreaSf?: number; sensitivity?: number; layers?: { include?: string[]; exclude?: string[] } }) {
     const s = this.sheet(name);
-    const mask = await this.ensureMask(name);
+    const mask = await this.maskWithLayers(name, opts.layers);
     if (!mask) throw new UserError("This sheet has no vector linework (likely a scan); raster fallback not yet available in the MCP server.");
     const minAreaSf = opts.minAreaSf ?? 5;
     if (!s.spans) s.spans = textSpans(s.page);

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -22,6 +22,14 @@ const COORDS = "Coordinates are image px at render scale 2.0: PDF pt × 2, origi
 
 const pointSchema = z.tuple([z.number(), z.number()]);
 const roleSchema = z.enum(["floor_area", "deduct"]).default("floor_area");
+// #85 — per-call layer overrides on the flood mask. sheet_info's layer table
+// is the vocabulary; include forces a layer's ink to plot as hard boundary,
+// exclude drops it outright. An unknown name errors with the sheet's actual
+// layer list; on an unlayered sheet the filter errors rather than no-ops.
+const layersFilterSchema = z.object({
+  include: z.array(z.string()).optional().describe("Layer names or ids whose ink must plot as HARD boundary"),
+  exclude: z.array(z.string()).optional().describe("Layer names or ids whose ink must not block the flood at all"),
+}).optional().describe("Override the sheet's classified layer roles for THIS call (see sheet_info.layers)");
 
 const run = (tool: string, fn: (args: any) => unknown | Promise<unknown>) =>
   async (args: any): Promise<ToolReply> => {
@@ -80,9 +88,10 @@ export function registerTools(server: McpServer, session: Session): void {
       role: roleSchema,
       return_verts: z.boolean().default(false).describe("Include the traced polygon's vertices (image px)"),
       sensitivity: z.number().min(0).max(1).optional().describe("Fill sensitivity, the same knob the canvas has: 0 strict (hatch/light linework always blocks), 0.5 balanced (default), 1 aggressive (crosses more hatch, tolerates more growth). Raise it when a flood stops short at hatching INSIDE the room; verify the grown ring with view_sheet overlay before committing"),
+      layers: layersFilterSchema,
     },
     outputSchema: oneClickOutput,
-  }, run("one_click", (a) => session.oneClick(a.sheet, a.x, a.y, { condition: a.condition, role: a.role, returnVerts: a.return_verts, sensitivity: a.sensitivity })));
+  }, run("one_click", (a) => session.oneClick(a.sheet, a.x, a.y, { condition: a.condition, role: a.role, returnVerts: a.return_verts, sensitivity: a.sensitivity, layers: a.layers })));
 
   server.registerTool("detect_rooms", {
     description: `Batch room detection: reads every room-number label off the sheet's text layer (e.g. "134", "OFFICE 101") and runs One-Click at each — one call instead of read_sheet_text + reasoning + N one_click calls. A seed is only reported as a room once it survives three gates, and everything skipped is counted and reasoned in \`withheld\` — never dropped silently, because a room the tool tells you it skipped is a question you can ask, while one it hides is a hole in a bid. The gates: a flood that leaked or landed in dense linework never becomes a region; two labels flooding the SAME region commit once (the extra labels ride on \`merged_labels\` — double-counting an area is the worst failure an estimating tool has); and a flood that is enclosed and clean but smaller than min_area_sf is a room-number bubble, a door swing, or a wall cavity rather than a room. With the sheet's scale set, returns area_sf/perimeter_lf per room; pass condition to commit every detected room under that finish tag (role "deduct" makes them subtract). Without a scale, returns px-only quantities per room and commits nothing — the plausibility floor needs real units, so it only applies once a scale is set. ${COORDS}`,
@@ -93,9 +102,10 @@ export function registerTools(server: McpServer, session: Session): void {
       return_verts: z.boolean().default(false).describe("Include each traced polygon's vertices (image px)"),
       min_area_sf: z.number().positive().default(5).describe("Plausibility floor: enclosed non-bubble regions smaller than this are withheld as cavities, not rooms. Default 5 SF — below any real finished space (a broom closet is ~10 SF). Lower it to inspect what was skipped."),
       sensitivity: z.number().min(0).max(1).optional().describe("Fill sensitivity, the same knob the canvas has: 0 strict (hatch/light linework always blocks), 0.5 balanced (default), 1 aggressive (crosses more hatch, tolerates more growth). Raise it when a flood stops short at hatching INSIDE the room; verify the grown ring with view_sheet overlay before committing"),
+      layers: layersFilterSchema,
     },
     outputSchema: detectRoomsOutput,
-  }, run("detect_rooms", (a) => session.detectRooms(a.sheet, { condition: a.condition, role: a.role, returnVerts: a.return_verts, minAreaSf: a.min_area_sf, sensitivity: a.sensitivity })));
+  }, run("detect_rooms", (a) => session.detectRooms(a.sheet, { condition: a.condition, role: a.role, returnVerts: a.return_verts, minAreaSf: a.min_area_sf, sensitivity: a.sensitivity, layers: a.layers })));
 
   server.registerTool("measure_polygon", {
     description: `Measure a closed polygon you supply (min 3 vertices, image px): area_sf and perimeter_lf at the sheet's scale. Requires the scale to be set. Pass condition to commit it; role "deduct" subtracts. ${COORDS}`,

--- a/mcp/test/conformance.test.ts
+++ b/mcp/test/conformance.test.ts
@@ -420,3 +420,55 @@ test("deduct role: committed deducts subtract in the summary and export as measu
   const exported = await callOk(client, "export_takeoff");
   assert.deepEqual(exported.shapes.map((s: any) => s.measure_role), ["floor_area", "deduct"]);
 });
+
+// ── PDF layers (#85): the layered fixture drives the whole loop ─────────────
+// test/fixtures/layered-plan.pdf (see scripts/make-layered-fixture.mjs): a
+// 300×300 pt room on A-WALL-FULL, a 3×3 tile grid on A-FLOR-PATT (FOUR lines
+// — far below HATCH_MIN_RUN, so pitch heuristics keep them hard and a naive
+// flood traps in one cell), a leader on A-ANNO-TEXT crossing the room, and a
+// demolition wall on A-WALL-DEMO hidden in the default config.
+const LAYERED = fileURLToPath(new URL("./fixtures/layered-plan.pdf", import.meta.url));
+
+test("layers (#85): the table reads, stated roles feed the mask, include/exclude bite, unlayered refuses", async () => {
+  const client = await pair();
+  const LKEY = "layered-plan.pdf";
+  const loaded = await callOk(client, "load_plan", { path: LAYERED });
+  assert.equal(loaded.page_count, 1);
+
+  const info = await callOk(client, "sheet_info", { sheet: LKEY });
+  const byName = Object.fromEntries(info.layers.map((l: any) => [l.name, l]));
+  assert.deepEqual(Object.keys(byName).sort(), ["A-ANNO-TEXT", "A-FLOR-PATT", "A-WALL-DEMO", "A-WALL-FULL"]);
+  assert.equal(byName["A-WALL-FULL"].role, "boundary");
+  assert.equal(byName["A-FLOR-PATT"].role, "finish-pattern");
+  assert.equal(byName["A-ANNO-TEXT"].role, "annotation");
+  assert.deepEqual({ role: byName["A-WALL-DEMO"].role, visible: byName["A-WALL-DEMO"].visible },
+    { role: "demolition", visible: false }, "hidden demolition arrives stated, not guessed");
+  assert.ok(info.layers.every((l: any) => l.seg_count > 0 && l.confidence > 0.5), "every layer owns ink and classifies confidently");
+
+  await callOk(client, "set_scale", { sheet: LKEY, upp: 1 / 24 });
+  // seed (300, 924) image px = pdf (150, 150) — inside ONE tile cell. The
+  // stated layers exclude the grid (pattern), the leader (annotation), and
+  // the hidden demo wall, so the flood reaches the whole 25×25 ft room.
+  const room = await callOk(client, "one_click", { sheet: LKEY, x: 300, y: 924, condition: "CPT-1" });
+  assert.ok(Math.abs(room.area_sf - 625) < 20, `whole room, not a tile cell: ${room.area_sf} SF`);
+
+  // provenance: a trace bounded by DECLARED layers says so on the wire
+  const payload = await callOk(client, "export_takeoff");
+  assert.equal(payload.shapes[0].origin.layer_bounded, true);
+
+  // include: the hidden demolition wall becomes hard boundary — the room halves
+  const half = await callOk(client, "one_click", { sheet: LKEY, x: 300, y: 924, layers: { include: ["A-WALL-DEMO"] } });
+  assert.ok(Math.abs(half.area_sf - 312.5) < 15, `the included demo wall splits the room: ${half.area_sf} SF`);
+
+  // exclude the boundary itself → nothing encloses (never a silent guess)
+  assert.match(await callErr(client, "one_click", { sheet: LKEY, x: 300, y: 924, layers: { exclude: ["A-WALL-FULL"] } }), /isn't enclosed/);
+  // unknown layer name → resolve-or-error, listing the sheet's actual layers
+  assert.match(await callErr(client, "one_click", { sheet: LKEY, x: 300, y: 924, layers: { exclude: ["NOPE"] } }), /No layer "NOPE".*A-WALL-FULL/);
+
+  // the unlayered world stays exactly as it was: empty table, and a layer
+  // filter REFUSES rather than silently no-ops
+  await callOk(client, "load_plan", { path: PLAN });
+  const plain = await callOk(client, "sheet_info", { sheet: KEY });
+  assert.deepEqual(plain.layers, []);
+  assert.match(await callErr(client, "one_click", { sheet: KEY, x: 600, y: 1084, layers: { exclude: ["A-WALL-FULL"] } }), /no PDF layers/);
+});

--- a/mcp/test/fixtures/layered-plan.pdf
+++ b/mcp/test/fixtures/layered-plan.pdf
@@ -1,0 +1,62 @@
+%PDF-1.5
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /OCProperties << /OCGs [5 0 R 6 0 R 7 0 R 8 0 R] /D << /Order [5 0 R 6 0 R 7 0 R 8 0 R] /OFF [8 0 R] >> >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 612] /Contents 4 0 R /Resources << /Properties << /oc1 5 0 R /oc2 6 0 R /oc3 7 0 R /oc4 8 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 240 >>
+stream
+/OC /oc1 BDC
+2 w
+100 100 300 300 re S
+EMC
+/OC /oc2 BDC
+0.5 w
+200 100 m 200 400 l S
+300 100 m 300 400 l S
+100 200 m 400 200 l S
+100 300 m 400 300 l S
+EMC
+/OC /oc3 BDC
+0.5 w
+110 110 m 390 390 l S
+EMC
+/OC /oc4 BDC
+2 w
+100 250 m 400 250 l S
+EMC
+endstream
+endobj
+5 0 obj
+<< /Type /OCG /Name (A-WALL-FULL) >>
+endobj
+6 0 obj
+<< /Type /OCG /Name (A-FLOR-PATT) >>
+endobj
+7 0 obj
+<< /Type /OCG /Name (A-ANNO-TEXT) >>
+endobj
+8 0 obj
+<< /Type /OCG /Name (A-WALL-DEMO) >>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000009 00000 n 
+0000000165 00000 n 
+0000000222 00000 n 
+0000000388 00000 n 
+0000000679 00000 n 
+0000000731 00000 n 
+0000000783 00000 n 
+0000000835 00000 n 
+trailer
+<< /Size 9 /Root 1 0 R >>
+startxref
+887
+%%EOF

--- a/web/src/lib/layers.ts
+++ b/web/src/lib/layers.ts
@@ -1,0 +1,118 @@
+// PDF layer (Optional Content Group) semantics — issue #85. Pure and
+// table-driven: raw CAD layer names → the role their linework plays in a
+// takeoff, so buildMask can consume what the file STATES instead of guessing
+// with pitch heuristics. No pdf.js, no DOM — the extraction side hands this
+// module names; it hands back roles.
+//
+// Doctrine: refusal over guessing. Only a POSITIVE identification earns a
+// role; anything unrecognized is `unknown` and flows through today's
+// heuristic path untouched — a wrong `unknown` costs nothing, a wrong
+// `boundary` seals a corridor and a wrong `annotation` erases a wall. The
+// tables grow by fixture, not by speculation.
+
+export type LayerRole = "boundary" | "finish-pattern" | "annotation" | "structure" | "demolition" | "unknown";
+
+/** Per-segment role codes (buildMask consumes these; layers stay strings
+ * everywhere else). HIDDEN is visibility, not semantics — a layer OFF in the
+ * default config is excluded whatever its name says (or we trace demolition). */
+export const ROLE_CODE: Record<LayerRole, number> = {
+  unknown: 0, boundary: 1, "finish-pattern": 2, annotation: 3, structure: 4, demolition: 5,
+};
+export const ROLE_HIDDEN = 6;
+
+/** One sheet-level layer row — what sheet_info reports and the mask consumes. */
+export interface LayerInfo {
+  id: string;          // pdf.js OCG id (objId) — stable within the document
+  name: string;        // the raw layer name, verbatim
+  role: LayerRole;
+  confidence: number;  // 0..1 — how sure the classifier is of the role
+  visible: boolean;    // default-config visibility (hidden ⇒ excluded outright)
+  seg_count: number;   // segments attributed to this layer on the sheet
+}
+
+// Token tables. AIA CAD Layer Guidelines core plus the field variants that
+// survive export: xref-bind prefixes, separator drift, truncation. Every
+// entry is a WHOLE token match after normalization — substring matches are
+// how "COLOR" becomes a column.
+const DEMOLITION = new Set(["DEMO", "DEMOL", "DEMOLITION", "REMV", "REMOVE"]);
+const PATTERN = new Set(["PATT", "PATTERN", "PATTERNS", "HATCH", "HATCHING", "POCHE"]);
+// High-confidence annotation: ink that describes the drawing, not the building.
+const ANNOTATION = new Set([
+  "ANNO", "TEXT", "DIM", "DIMS", "NOTE", "NOTES", "SYMB", "SYMBOL", "IDEN", "TAG", "TAGS",
+  "TTLB", "TITLEBLOCK", "LEGN", "LEGEND", "SHBD", "NPLT", "PLOT", "GRID", "GRIDS", "LEVL", "REVS", "REV",
+]);
+// Objects that live INSIDE rooms — real geometry, but never a room boundary;
+// excluding them cleans interiors (lower confidence: field naming is looser).
+const FIXTURES = new Set(["FURN", "FURNITURE", "EQPM", "EQUIP", "EQUIPMENT", "CASE", "CASW", "CASEWORK", "MILL", "MILLWORK", "PLMB", "PFIX", "APPL", "SPCL", "SEAT", "SEATING"]);
+const STRUCTURE = new Set(["COLS", "COL", "COLUMN", "COLUMNS", "BEAM", "BEAMS", "BRACE", "FNDN", "FOUNDATION", "JOIS", "JOIST", "SLAB"]);
+// What bounds a room: walls full and partial height, partitions, glazing and
+// storefront, floor/room outlines, doors and windows (their linework seals
+// the openings walls leave).
+const BOUNDARY = new Set([
+  "WALL", "WALLS", "PRHT", "FULL", "PART", "PARTN", "PARTITION", "PARTITIONS",
+  "GLAZ", "GLAZING", "STOR", "STOREFRONT", "CWMG",
+  "OTLN", "OUTLINE", "OUTLINES", "RM", "ROOM", "ROOMS", "AREA", "AREAS",
+  "DOOR", "DOORS", "DR", "WNDW", "WIND", "WINDOW", "WINDOWS",
+]);
+// AIA discipline designators — the leading token of a conforming name. Used
+// only to grade confidence (a match inside "A-WALL-FULL" is surer than a bare
+// "WALL") and to catch S-* structural wholesale.
+const DISCIPLINES = new Set(["A", "S", "M", "E", "P", "F", "C", "L", "T", "I", "Q", "G", "H", "V", "W", "X", "Z"]);
+
+/** Normalize a raw layer name to comparable tokens: strip the xref path
+ * (everything before the LAST `|`), fold AutoCAD bind separators (`$n$`),
+ * uppercase, split on every non-alphanumeric run. */
+export function layerNameTokens(raw: string): string[] {
+  const base = String(raw || "").split("|").pop() || "";
+  return base.replace(/\$\d+\$/g, "-").toUpperCase().split(/[^A-Z0-9]+/).filter(Boolean);
+}
+
+/** Raw layer name → { role, confidence }. Pure, total, never throws. */
+export function classifyLayerName(raw: string): { role: LayerRole; confidence: number } {
+  const s = String(raw || "").trim();
+  // the degenerate cases: everything on layer 0 / "Layer 1" / unnamed — the
+  // exporter flattened or the drafter never layered; nothing is stated
+  if (!s || /^0$/.test(s) || /^layer\s*\d*$/i.test(s)) return { role: "unknown", confidence: 0 };
+  const toks = layerNameTokens(s);
+  if (!toks.length) return { role: "unknown", confidence: 0 };
+  const conforming = DISCIPLINES.has(toks[0]) && toks.length > 1;
+  const grade = (base: number) => (conforming ? base : Math.max(0.5, base - 0.2));
+  const has = (table: Set<string>) => toks.some((t) => table.has(t));
+  // Order matters: demolition beats boundary ("A-WALL-DEMO" is demolition —
+  // traced as a wall it produces a confident wrong number), pattern beats
+  // boundary ("A-FLOR-PATT" under a floor outline family is still pattern).
+  if (has(DEMOLITION)) return { role: "demolition", confidence: grade(0.95) };
+  if (has(PATTERN)) return { role: "finish-pattern", confidence: grade(0.9) };
+  if (has(ANNOTATION)) return { role: "annotation", confidence: grade(0.85) };
+  if (toks[0] === "S" && toks.length > 1) return { role: "structure", confidence: 0.85 };
+  if (has(STRUCTURE)) return { role: "structure", confidence: grade(0.8) };
+  if (has(BOUNDARY)) return { role: "boundary", confidence: grade(0.9) };
+  if (has(FIXTURES)) return { role: "annotation", confidence: grade(0.65) };
+  return { role: "unknown", confidence: 0.2 };
+}
+
+/** Build the per-layer role-code table (aligned to layerIds order) from the
+ * classified infos. Hidden wins over any role. */
+export function layerRoleCodes(layerIds: string[], infoById: Map<string, { role: LayerRole; visible: boolean }>): Uint8Array {
+  const codes = new Uint8Array(layerIds.length);
+  layerIds.forEach((id, k) => {
+    const info = infoById.get(id);
+    if (!info) return; // unknown layer: code 0 — heuristics decide
+    codes[k] = info.visible === false ? ROLE_HIDDEN : ROLE_CODE[info.role];
+  });
+  return codes;
+}
+
+/** Per-SEGMENT role codes for buildMask: layerOf[si] → the layer's code;
+ * segments outside any layer (−1) stay 0 (unknown → heuristic path). */
+export function segRoles(layerOf: Int32Array | number[] | undefined, codes: Uint8Array): Uint8Array | null {
+  if (!layerOf || !codes.length) return null;
+  const n = layerOf.length;
+  const out = new Uint8Array(n);
+  let any = false;
+  for (let i = 0; i < n; i++) {
+    const li = layerOf[i];
+    if (li >= 0 && li < codes.length && codes[li]) { out[i] = codes[li]; any = true; }
+  }
+  return any ? out : null;   // an all-unknown sheet short-circuits to the heuristic path
+}

--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -31,8 +31,14 @@ export interface OpList { fnArray: number[]; argsArray: any[]; }  // per-op args
 /** pdf.js's OPS code table (op name → numeric code); passed in so this module never imports pdfjs. */
 export type OpsTable = Record<string, number>;
 /** meta: one byte per segment — SEG_* bits + device line width in the high nibble.
- *  imageArea: total placed image area in device px² (scan/photo underlay detection). */
-export interface VectorGeometry { points: Point[]; segs: number[]; meta: Uint8Array; imageArea: number; }
+ *  imageArea: total placed image area in device px² (scan/photo underlay detection).
+ *  layerOf/layerIds (#85): per-segment index into layerIds (−1 = outside any
+ *  Optional Content Group); layerIds carries pdf.js OCG ids in first-seen
+ *  order. The id→name/visibility mapping is the CALLER's (pdf.js API side) —
+ *  this module never resolves it, which is what keeps it pure. Optional so
+ *  hand-built geometry (rastermask, tests) needs no ceremony; extraction
+ *  always emits both (empty table on an unlayered sheet). */
+export interface VectorGeometry { points: Point[]; segs: number[]; meta: Uint8Array; imageArea: number; layerOf?: Int32Array; layerIds?: string[]; }
 export interface MaskObj { mask: Uint8Array; mw: number; mh: number; ws: number; softCount: number; }
 export interface RegionResult { region: Uint8Array; mw: number; mh: number; ws: number; count?: number; }
 export type FloodResult =
@@ -111,6 +117,22 @@ export function extractVectorGeometry(opList: OpList, transform: number[], OPS: 
   let m = transform.slice();
   let lw = 1;                          // graphics-state line width (user space)
   const stack: Array<[number[], number]> = [];
+  // Marked-content / Optional Content (#85): a purely SEQUENTIAL stack — not
+  // graphics state, so save/restore never touches it, and a Form XObject with
+  // /OC arrives as its own begin/end pair around the form's ops (the worker
+  // emits them), so the linear walk covers page content and forms alike.
+  // Every begin pushes (−1 for non-OC marked content — it still nests); every
+  // end pops; a segment is attributed to the NEAREST enclosing OC layer.
+  const layerIds: string[] = [];
+  const layerIdxById = new Map<string, number>();
+  const layerOfArr: number[] = [];
+  const mcStack: number[] = [];
+  let curLayer = -1;
+  const layerIdxFor = (id: string): number => {
+    let k = layerIdxById.get(id);
+    if (k === undefined) { k = layerIds.length; layerIds.push(id); layerIdxById.set(id, k); }
+    return k;
+  };
   const mul = (a: number[], b: number[]): number[] => [a[0] * b[0] + a[2] * b[1], a[1] * b[0] + a[3] * b[1], a[0] * b[2] + a[2] * b[3], a[1] * b[2] + a[3] * b[3], a[0] * b[4] + a[2] * b[5] + a[4], a[1] * b[4] + a[3] * b[5] + a[5]];
   const tx = (x: number, y: number): Point => [m[0] * x + m[2] * y + m[4], m[1] * x + m[3] * y + m[5]];
   const fns = opList.fnArray, A = opList.argsArray;
@@ -135,6 +157,28 @@ export function extractVectorGeometry(opList: OpList, transform: number[], OPS: 
     else if (fn === OPS.setGState) { for (const pr of args[0] || []) if (pr && pr[0] === "LW") lw = pr[1]; }
     else if (fn === OPS.paintFormXObjectBegin) { stack.push([m.slice(), lw]); if (args && args[0]) m = mul(m, args[0]); }
     else if (fn === OPS.paintFormXObjectEnd) { const p = stack.pop(); if (p) { m = p[0]; lw = p[1]; } }
+    else if (fn === OPS.beginMarkedContent) { mcStack.push(-1); }
+    else if (fn === OPS.beginMarkedContentProps) {
+      // worker emits ["OC", data] where data is {type:"OCG", id}, an OCMD
+      // ({ids, policy} / {expression}) or null. Attribute to a SINGLE stated
+      // group only — a multi-group OCMD or an expression is a visibility rule,
+      // not an authorship claim, and misattributing it would poison the roles.
+      const data = args && args[0] === "OC" ? args[1] : null;
+      let li = -1;
+      if (data && typeof data === "object") {
+        if (typeof data.id === "string" && data.id) li = layerIdxFor(data.id);
+        else if (Array.isArray(data.ids) && data.ids.length === 1 && typeof data.ids[0] === "string" && data.ids[0]) li = layerIdxFor(data.ids[0]);
+      }
+      mcStack.push(li);
+      if (li >= 0) curLayer = li;
+    }
+    else if (fn === OPS.endMarkedContent) {
+      if (mcStack.length) {
+        mcStack.pop();
+        curLayer = -1;
+        for (let k = mcStack.length - 1; k >= 0; k--) if (mcStack[k] >= 0) { curLayer = mcStack[k]; break; }
+      }
+    }
     else if (fn === OPS.paintImageXObject || fn === OPS.paintInlineImageXObject || fn === OPS.paintImageMaskXObject) {
       // the singular paint ops are each preceded by their OWN `transform` op
       // (already folded into `m` above), mapping the image's unit square onto
@@ -184,8 +228,9 @@ export function extractVectorGeometry(opList: OpList, transform: number[], OPS: 
       const flags = paintFlags(i) | (devW << 4);
       const ops = args[0], co = args[1];
       let c = 0, cur: Point | null = null, start: Point | null = null;
+      const pathLayer = curLayer;   // one path = one marked-content scope (#85)
       const visit = (p: Point) => { points.push(p); };
-      const lineTo = (p: Point) => { if (cur) { segs.push(cur[0], cur[1], p[0], p[1]); metaArr.push(flags); } cur = p; visit(p); };
+      const lineTo = (p: Point) => { if (cur) { segs.push(cur[0], cur[1], p[0], p[1]); metaArr.push(flags); layerOfArr.push(pathLayer); } cur = p; visit(p); };
       for (const op of ops) {
         if (op === OPS.moveTo) { cur = tx(co[c], co[c + 1]); start = cur; visit(cur); c += 2; }
         else if (op === OPS.lineTo) { lineTo(tx(co[c], co[c + 1])); c += 2; }
@@ -203,22 +248,22 @@ export function extractVectorGeometry(opList: OpList, transform: number[], OPS: 
               u * u * u * p0[0] + 3 * u * u * t * p1[0] + 3 * u * t * t * p2[0] + t * t * t * p3[0],
               u * u * u * p0[1] + 3 * u * u * t * p1[1] + 3 * u * t * t * p2[1] + t * t * t * p3[1],
             ];
-            if (cur) { segs.push(cur[0], cur[1], q[0], q[1]); metaArr.push(flags | SEG_CURVE); }
+            if (cur) { segs.push(cur[0], cur[1], q[0], q[1]); metaArr.push(flags | SEG_CURVE); layerOfArr.push(pathLayer); }
             cur = q;
           }
           visit(p3);
         }
-        else if (op === OPS.closePath) { if (cur && start) { segs.push(cur[0], cur[1], start[0], start[1]); metaArr.push(flags); cur = start; } }
+        else if (op === OPS.closePath) { if (cur && start) { segs.push(cur[0], cur[1], start[0], start[1]); metaArr.push(flags); layerOfArr.push(pathLayer); cur = start; } }
         else if (op === OPS.rectangle) {
           const x = co[c], y = co[c + 1], w = co[c + 2], h = co[c + 3]; c += 4;
           const q: Point[] = [tx(x, y), tx(x + w, y), tx(x + w, y + h), tx(x, y + h)];
-          for (let k = 0; k < 4; k++) { const a = q[k], b = q[(k + 1) % 4]; segs.push(a[0], a[1], b[0], b[1]); metaArr.push(flags); visit(a); }
+          for (let k = 0; k < 4; k++) { const a = q[k], b = q[(k + 1) % 4]; segs.push(a[0], a[1], b[0], b[1]); metaArr.push(flags); layerOfArr.push(pathLayer); visit(a); }
           cur = q[0]; start = q[0];
         }
       }
     }
   }
-  return { points, segs, meta: Uint8Array.from(metaArr), imageArea };
+  return { points, segs, meta: Uint8Array.from(metaArr), imageArea, layerOf: Int32Array.from(layerOfArr), layerIds };
 }
 
 // ── 2. hatch classification ────────────────────────────────────────────────
@@ -442,14 +487,28 @@ export function hatchFamilies(segs: number[], meta: Uint8Array): HatchFamily[] {
 // continuous. Without meta the mask is bit-identical to the original (every
 // cell 1). With meta, wall cells carry bit 1 and suspected-hatch cells bit 2 —
 // a cell crossed by both keeps bit 1, so hard always wins.
-export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = MASK_MAX_DIM, meta: Uint8Array | null = null): MaskObj {
+//
+// roles (#85, optional): one code per segment from a sheet whose layers STATE
+// what the ink is (lib/layers.ts) — a short-circuit over the heuristics,
+// never a replacement:
+//   boundary / structure → hard (bit 1), no classifyHatchSegs vote;
+//   finish-pattern / annotation / demolition / hidden → not plotted at all —
+//     the file says this ink is not a wall (a hidden layer is excluded
+//     whatever its name, or a demolished wall traces as a real one);
+//   unknown (0) → exactly today's path.
+// Null roles (unlayered sheet, or nothing classified) is bit-identical to the
+// pre-#85 mask — the fallback must be invisible, and a regression test holds
+// it there.
+export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = MASK_MAX_DIM, meta: Uint8Array | null = null, roles: Uint8Array | null = null): MaskObj {
   const ws = Math.min(1, maxDim / Math.max(imgW, imgH, 1));
   const mw = Math.max(2, Math.ceil(imgW * ws)), mh = Math.max(2, Math.ceil(imgH * ws));
   const mask = new Uint8Array(mw * mh);
   const soft = meta ? classifyHatchSegs(segs, meta, ws) : null;
   let softCount = 0;
   for (let i = 0, si = 0; i + 3 < segs.length; i += 4, si++) {
-    const v = soft && soft[si] ? 2 : 1;
+    const role = roles ? roles[si] : 0;
+    if (role === 2 || role === 3 || role === 5 || role === 6) continue;  // pattern/annotation/demolition/hidden — stated non-boundary ink
+    const v = role === 1 || role === 4 ? 1 : soft && soft[si] ? 2 : 1;   // stated boundary/structure: hard, no heuristic vote
     if (v === 2) softCount++;
     let x0 = Math.round(segs[i] * ws), y0 = Math.round(segs[i + 1] * ws);
     const x1 = Math.round(segs[i + 2] * ws), y1 = Math.round(segs[i + 3] * ws);

--- a/web/test/layerExtract.test.ts
+++ b/web/test/layerExtract.test.ts
@@ -1,0 +1,133 @@
+// Marked-content layer attribution in extractVectorGeometry + the buildMask
+// role short-circuit (#85). Synthetic op lists — the same fake-OPS idiom the
+// pure engine was built for; no PDF, no pdf.js. The invariants:
+//   - the marked-content stack NESTS: a segment belongs to its nearest
+//     enclosing OC group; non-OC marked content pushes but never claims;
+//   - only a single stated group attributes (OCG id, or a one-id OCMD) —
+//     multi-group OCMDs and expressions stay −1;
+//   - unbalanced pops never throw and never mis-attribute;
+//   - no marked content ⇒ empty table, all −1, and buildMask WITHOUT roles is
+//     byte-identical to the pre-#85 mask (the invisible fallback);
+//   - with roles: pattern/annotation/demolition/hidden ink vanishes from the
+//     mask, boundary plots hard — the tile-grid discriminator flood proves
+//     the lift the heuristics can't reach (4 grid lines < HATCH_MIN_RUN stay
+//     hard heuristically; the layer states what they are).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractVectorGeometry, buildMask, floodRegion } from "../src/lib/oneclick.ts";
+import { classifyLayerName, layerRoleCodes, segRoles, type LayerRole } from "../src/lib/layers.ts";
+
+// a fake OPS table — only what the walk consults
+const OPS = {
+  save: 1, restore: 2, transform: 3, setLineWidth: 4, setGState: 5,
+  constructPath: 10, moveTo: 11, lineTo: 12, curveTo: 13, curveTo2: 14, curveTo3: 15, closePath: 16, rectangle: 17,
+  endPath: 20, clip: 21, eoClip: 22, fill: 23, eoFill: 24, stroke: 25,
+  beginMarkedContent: 30, beginMarkedContentProps: 31, endMarkedContent: 32,
+  paintFormXObjectBegin: 33, paintFormXObjectEnd: 34,
+} as const;
+const ID = [1, 0, 0, 1, 0, 0];
+
+type Op = [number, unknown[] | null];
+const opList = (ops: Op[]) => ({ fnArray: ops.map((o) => o[0]), argsArray: ops.map((o) => o[1]) });
+const oc = (id: string): Op => [OPS.beginMarkedContentProps, ["OC", { type: "OCG", id }]];
+const line = (x1: number, y1: number, x2: number, y2: number): Op =>
+  [OPS.constructPath, [[OPS.moveTo, OPS.lineTo], [x1, y1, x2, y2]]];
+const END: Op = [OPS.endMarkedContent, null];
+
+test("attribution follows the nearest enclosing OC group, through nesting and non-OC marked content", () => {
+  const geo = extractVectorGeometry(opList([
+    line(0, 0, 5, 0),                        // before any marked content → −1
+    oc("wall"),
+    line(0, 0, 10, 0),                       // wall
+    [OPS.beginMarkedContent, null],          // a plain BMC nests but never claims
+    line(0, 1, 10, 1),                       // still wall (nearest enclosing OC)
+    oc("hatch"),
+    line(0, 2, 10, 2),                       // hatch (inner OC wins)
+    END,                                     // pop hatch
+    line(0, 3, 10, 3),                       // wall again
+    END,                                     // pop the plain BMC
+    END,                                     // pop wall
+    line(0, 4, 10, 4),                       // −1
+    END,                                     // UNBALANCED extra pop — must not throw
+    line(0, 5, 10, 5),                       // still −1
+  ]), ID, OPS as never);
+  assert.deepEqual(geo.layerIds, ["wall", "hatch"]);
+  assert.deepEqual([...geo.layerOf!], [-1, 0, 0, 1, 0, -1, -1]);
+});
+
+test("only a single stated group attributes: one-id OCMDs do, multi-id OCMDs and null don't", () => {
+  const geo = extractVectorGeometry(opList([
+    [OPS.beginMarkedContentProps, ["OC", { type: "OCMD", ids: ["only"], policy: "AnyOn", expression: null }]],
+    line(0, 0, 1, 0), END,
+    [OPS.beginMarkedContentProps, ["OC", { type: "OCMD", ids: ["a", "b"], policy: "AnyOn", expression: null }]],
+    line(0, 1, 1, 1), END,
+    [OPS.beginMarkedContentProps, ["OC", null]],   // malformed OC props (worker warns, emits null)
+    line(0, 2, 1, 2), END,
+  ]), ID, OPS as never);
+  assert.deepEqual(geo.layerIds, ["only"]);
+  assert.deepEqual([...geo.layerOf!], [0, -1, -1]);
+});
+
+test("no marked content: empty table, all −1 — and the roleless mask is byte-identical (the invisible fallback)", () => {
+  const ops: Op[] = [line(0, 0, 50, 0), line(0, 10, 50, 10), line(20, 0, 20, 10)];
+  const geo = extractVectorGeometry(opList(ops), ID, OPS as never);
+  assert.deepEqual(geo.layerIds, []);
+  assert.ok(geo.layerOf!.every((v) => v === -1));
+  const a = buildMask(geo.segs, 60, 20, 3000, geo.meta);
+  const b = buildMask(geo.segs, 60, 20, 3000, geo.meta, null);
+  assert.deepEqual(Buffer.from(a.mask), Buffer.from(b.mask), "null roles = the pre-#85 mask, bit for bit");
+});
+
+// ── the discriminator: the fixture scene, flooded three ways ────────────────
+// A 300×300 room; a 3×3 tile grid inside (FOUR lines — far under
+// HATCH_MIN_RUN, so heuristics keep them hard); an annotation leader crossing
+// the room; a hidden demolition wall bisecting it.
+function fixtureScene() {
+  return extractVectorGeometry(opList([
+    oc("wall"), [OPS.constructPath, [[OPS.rectangle], [100, 100, 300, 300]]], END,
+    oc("patt"),
+    line(200, 100, 200, 400), line(300, 100, 300, 400),
+    line(100, 200, 400, 200), line(100, 300, 400, 300),
+    END,
+    oc("anno"), line(110, 110, 390, 390), END,
+    oc("demo"), line(100, 250, 400, 250), END,
+  ]), ID, OPS as never);
+}
+const NAMES: Record<string, string> = { wall: "A-WALL-FULL", patt: "A-FLOR-PATT", anno: "A-ANNO-TEXT", demo: "A-WALL-DEMO" };
+const infoFor = (visibleDemo: boolean, demoRole?: LayerRole) => {
+  const m = new Map<string, { role: LayerRole; visible: boolean }>();
+  for (const [id, name] of Object.entries(NAMES)) {
+    const { role } = classifyLayerName(name);
+    m.set(id, { role: id === "demo" && demoRole ? demoRole : role, visible: id === "demo" ? visibleDemo : true });
+  }
+  return m;
+};
+
+test("stated layers unlock what the pitch heuristics cannot: the tile-grid room floods WHOLE", () => {
+  const geo = fixtureScene();
+  const seed: [number, number] = [150, 150];   // inside one tile cell
+  // heuristic-only mask: 4 grid lines are far below HATCH_MIN_RUN — they stay
+  // hard and the flood traps inside one of nine cells
+  const naive = buildMask(geo.segs, 1200, 1200, 3000, geo.meta);
+  const fNaive = floodRegion(naive, seed[0], seed[1]);
+  assert.equal(fNaive.status, "ok");
+  // layered mask: the file SAYS patt is pattern, anno is annotation, demo is
+  // hidden — all excluded; wall says boundary — hard
+  const roles = segRoles(geo.layerOf, layerRoleCodes(geo.layerIds!, infoFor(false)))!;
+  const layered = buildMask(geo.segs, 1200, 1200, 3000, geo.meta, roles);
+  const fLayered = floodRegion(layered, seed[0], seed[1]);
+  assert.equal(fLayered.status, "ok");
+  const nCell = (fNaive as { count: number }).count, nRoom = (fLayered as { count: number }).count;
+  assert.ok(nRoom > 5 * nCell, `stated layers must free the flood: cell=${nCell}, room=${nRoom}`);
+  assert.ok(nRoom > 280 * 280, `the whole 300×300 room, not a slice: ${nRoom}`);
+});
+
+test("an INCLUDED demolition wall splits the room — visibility and overrides both bite", () => {
+  const geo = fixtureScene();
+  const roles = segRoles(geo.layerOf, layerRoleCodes(geo.layerIds!, infoFor(true, "boundary")))!;
+  const mask = buildMask(geo.segs, 1200, 1200, 3000, geo.meta, roles);
+  const f = floodRegion(mask, 150, 150);       // seed above the y=250 demo wall
+  assert.equal(f.status, "ok");
+  const n = (f as { count: number }).count;
+  assert.ok(n > 280 * 130 && n < 300 * 170, `half the room, bounded by the demo wall: ${n}`);
+});

--- a/web/test/layers.test.ts
+++ b/web/test/layers.test.ts
@@ -1,0 +1,74 @@
+// Layer-name semantics (lib/layers.ts, #85). The invariants:
+//   - only POSITIVE identifications earn a role — bare/degenerate names are
+//     unknown (refusal over guessing: unknown costs nothing downstream);
+//   - demolition beats boundary ("A-WALL-DEMO" traced as a wall is a wrong
+//     number produced confidently), pattern beats boundary;
+//   - xref prefixes, separator drift, and truncation all resolve;
+//   - conforming AIA names grade higher confidence than bare words;
+//   - hidden wins over any role in the code table.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyLayerName, layerNameTokens, layerRoleCodes, segRoles, ROLE_CODE, ROLE_HIDDEN, type LayerRole } from "../src/lib/layers.ts";
+
+const role = (name: string): LayerRole => classifyLayerName(name).role;
+
+test("AIA core names classify to their stated roles", () => {
+  assert.equal(role("A-WALL-FULL"), "boundary");
+  assert.equal(role("A-WALL-PRHT"), "boundary");
+  assert.equal(role("A-FLOR-OTLN"), "boundary");
+  assert.equal(role("A-GLAZ"), "boundary");
+  assert.equal(role("A-DOOR"), "boundary");
+  assert.equal(role("A-FLOR-PATT"), "finish-pattern");
+  assert.equal(role("A-ANNO-TEXT"), "annotation");
+  assert.equal(role("A-ANNO-DIMS"), "annotation");
+  assert.equal(role("A-GRID"), "annotation");
+  assert.equal(role("S-COLS"), "structure");
+  assert.equal(role("S-BEAM"), "structure");
+  assert.equal(role("A-WALL-DEMO"), "demolition");
+  assert.equal(role("A-FURN"), "annotation");
+});
+
+test("the precedence that prevents confident wrong numbers: DEMO and PATT beat WALL/FLOR", () => {
+  assert.equal(role("A-WALL-DEMO"), "demolition");
+  assert.equal(role("WALL-DEMO"), "demolition");
+  assert.equal(role("A-FLOR-PATT"), "finish-pattern");
+});
+
+test("field variants: xref prefixes, bind separators, spaces, truncation, bare words", () => {
+  assert.equal(role("ARCH-FLOOR|A-WALL-FULL"), "boundary", "xref path strips to the last pipe");
+  assert.equal(role("XREF$0$A-WALL-FULL"), "boundary", "AutoCAD bind separator folds");
+  assert.equal(role("A-WALL FULL HT"), "boundary", "spaces tokenize like dashes");
+  assert.equal(role("A-WALL-1"), "boundary", "renumbered variant");
+  assert.equal(role("WALL"), "boundary", "bare word still identifies…");
+  assert.ok(classifyLayerName("WALL").confidence < classifyLayerName("A-WALL-FULL").confidence,
+    "…but a conforming AIA name grades surer than a bare word");
+});
+
+test("the degenerate cases are unknown — the exporter flattened, nothing is stated", () => {
+  for (const name of ["0", "", "Layer 1", "Layer1", "LAYER 12", "XYZ-99", "MISC"]) {
+    assert.equal(role(name), "unknown", name);
+  }
+  assert.equal(classifyLayerName("0").confidence, 0);
+});
+
+test("layerNameTokens: strips xref path, folds $n$, uppercases, splits on any separator run", () => {
+  assert.deepEqual(layerNameTokens("arch|A-Wall_full ht"), ["A", "WALL", "FULL", "HT"]);
+  assert.deepEqual(layerNameTokens("X$2$S-COLS"), ["X", "S", "COLS"]);
+  assert.deepEqual(layerNameTokens(""), []);
+});
+
+test("layerRoleCodes + segRoles: hidden wins over role; −1/unknown stay 0; all-unknown short-circuits to null", () => {
+  const ids = ["w", "p", "d"];
+  const info = new Map<string, { role: LayerRole; visible: boolean }>([
+    ["w", { role: "boundary", visible: true }],
+    ["p", { role: "finish-pattern", visible: true }],
+    ["d", { role: "demolition", visible: false }],   // hidden beats demolition
+  ]);
+  const codes = layerRoleCodes(ids, info);
+  assert.deepEqual([...codes], [ROLE_CODE.boundary, ROLE_CODE["finish-pattern"], ROLE_HIDDEN]);
+  const roles = segRoles(Int32Array.from([0, 1, 2, -1]), codes)!;
+  assert.deepEqual([...roles], [1, 2, ROLE_HIDDEN, 0]);
+  // nothing classified → null, so buildMask takes the identical pre-#85 path
+  assert.equal(segRoles(Int32Array.from([0, 1]), layerRoleCodes(["a", "b"], new Map())), null);
+  assert.equal(segRoles(undefined, codes), null);
+});


### PR DESCRIPTION
Phase 1 of #85, built exactly as the design comment on the RFC lays out. The heuristics exist to recover information the file already states — this makes the engine read it.

**Extraction.** \`extractVectorGeometry\` gains the marked-content cases in its existing op switch: a nesting-aware stack (non-OC marked content pushes but never claims; unbalanced pops never throw), attribution to the nearest enclosing OC group, and only a SINGLE stated group attributes — one-id OCMDs do, multi-group OCMDs and visibility expressions stay unclaimed rather than guessed. Output: a per-segment layer index + id table, additive on \`VectorGeometry\`; the id→name/visibility mapping stays the caller's, which is what keeps the module pure.

**\`lib/layers.ts\`** — the normalizer the RFC names: raw layer name → \`{role, confidence}\`, table-driven. AIA core, xref prefixes (\`ARCH-FLOOR|A-WALL-FULL\`), AutoCAD bind separators, separator drift and truncation (\`A-WALL FULL HT\`), the layer-0 degenerate case. Doctrine enforced by test: only positive identifications earn a role; **DEMO beats WALL** (a demolished wall traced as real is a wrong number produced confidently) and PATT beats FLOR.

**\`buildMask\` consumes roles as a short-circuit, never a replacement:** boundary/structure plot hard with no \`classifyHatchSegs\` vote; pattern/annotation/demolition ink is not plotted at all; **hidden-in-default-config is excluded whatever its name says** (or you trace demolition); unknown runs today's path untouched. A roleless call is **byte-identical** to the pre-#85 mask — asserted bit-for-bit, and the whole existing suite (1042 web + 58 mcp) runs over the unlayered demo plans unchanged: the zero-delta gate.

**Surfacing (MCP).** \`sheet_info\` returns the layer table (id, name, role, confidence, visible, seg_count — always emitted, \`[]\` = unlayered). \`one_click\` / \`detect_rooms\` take \`layers: {include, exclude}\` — include forces hard boundary, exclude drops the layer; unknown names resolve-or-error with the sheet's actual list, and a filter on an unlayered sheet refuses rather than silently no-ops. \`one_click\` stamps \`layer_bounded\` provenance when declared boundary layers fed the mask. 0.9.5 → 0.9.6.

**The numbers, per the finish line.** Neither demo PDF carries OCGs, so a generated layered fixture ships with its generator (\`scripts/make-layered-fixture.mjs\` → \`test/fixtures/layered-plan.pdf\`). The discriminator is the exact #60 failure class: four \`A-FLOR-PATT\` tile-grid lines sit far below \`HATCH_MIN_RUN\`, so the pitch heuristics keep them hard and the flood traps in **one of nine cells (~69 SF)**; the stated layers free the **whole 625 SF room** — measured in both the pure web test (flood-count ratio > 5×) and live MCP conformance. The hidden \`A-WALL-DEMO\` wall splits the room to **312.5 SF** only when explicitly included. Unlayered fixtures: exactly zero delta.

Left for phase 2 (the RFC stays open): the canvas layer-visibility panel (browser-side role plumbing), the corpus-wide IoU numbers once #60's benchmark lands, and dialect growth in the name tables — by fixture, not speculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)