### PR TITLE
chore(mcp): 0.9.18 — version surfaces agree, well-known manifest unstuck from 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-01 — registry freshness
+
+### Fixed
+- **`/.well-known/mcp.json` tells the truth again** — the deployed manifest still declared 0.8.0 while npm and the MCP registry served 0.9.17; the well-known file now versions with the release. Directory indexers (Smithery among them) cache whatever they last scanned, so a stale manifest quietly under-reports the server — Smithery was still describing the 17-tool era of a 31-tool server.
+
+### Released
+- **opentakeoff-mcp 0.9.18** (tag `mcp-v0.9.18`) — no tool changes; a version-surface release so registry re-scans pick up the current 31-tool record. npm latest, MCP registry, GitHub release + MCPB bundle.
+
 ## 2026-07-31 — sheet revisions: a re-drop is never a silent overwrite
 
 ### Added

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.8",
+  "version": "0.9.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.8",
+      "version": "0.9.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,9 +1,9 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
-  "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",
+  "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20"

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.17",
+  "version": "0.9.18",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.17",
+      "version": "0.9.18",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.8.0",
+  "version": "0.9.18",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.8.0",
+      "version": "0.9.18",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Registry-freshness release, no tool changes.

- `mcp/package.json` + `mcp/server.json` (both fields): 0.9.17 → 0.9.18
- `web/public/.well-known/mcp.json`: **0.8.0** → 0.9.18 — the deployed manifest had been stale since the 0.8.0 era, quietly under-reporting the server to directory indexers. Smithery's cached scan still shows 17–18 tools vs the real 31; a fresh published version is the re-scan trigger.
- CHANGELOG entry.

`mcp`: typecheck + tests + build + `smoke:dist` green on Node 24. `web`: `npm run check` green; built `dist/.well-known/mcp.json` verified at 0.9.18.

After merge: tag `mcp-v0.9.18` → the publish workflow's version-consistency gate passes (all three fields agree) and handles npm + registry + release + MCPB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)