### PR TITLE
feat: root .mcp.json — the repo configures its own MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "opentakeoff": {
+      "command": "npx",
+      "args": ["-y", "opentakeoff-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
One file: a root `.mcp.json` declaring `opentakeoff-mcp` via `npx`.

Two audiences: (1) anyone who clones the repo in an MCP-aware client (Claude Code etc.) gets the server offered automatically; (2) directory auto-detectors that follow the Open Plugins spec (cursor.directory's importer) look for exactly this file at the repo root — its absence is the likely reason OpenTakeoff can't be listed there.

No code paths touch it; CI is the formality here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)