### PR TITLE
server: lock /ai behind an X-API-Key gate (fail-closed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,3 +152,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: python3 capture/capture_server.py selftest
+
+  server:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements.txt -r requirements-dev.txt
+      - run: python -m pytest -q

--- a/server/README.md
+++ b/server/README.md
@@ -20,14 +20,30 @@ playground.
 ```bash
 cd server
 pip install -r requirements.txt
-uvicorn app:app --reload --port 8000
-# or: docker build -t opentakeoff-ai . && docker run -p 8000:8000 opentakeoff-ai
+OT_SANDBOX_API_KEY=<any-secret> uvicorn app:app --reload --port 8000
+# or: docker build -t opentakeoff-ai . && docker run -p 8000:8000 -e OT_SANDBOX_API_KEY=<any-secret> opentakeoff-ai
 ```
 
 Then `GET http://localhost:8000/health` → `{"ok": true, "adapter": "heuristic (no model)"}`.
 
 In dev, the web app proxies `/ai/*` to `localhost:8000` (see `web/vite.config.js`),
-so browser calls to `/ai/suggest-scale` reach this server.
+so browser calls to `/ai/suggest-scale` reach this server. Export the same
+`OT_SANDBOX_API_KEY` in the shell that runs `npm run dev` and the proxy attaches
+the header for you.
+
+## The lock
+
+The `/ai/*` endpoints require an `X-API-Key` header matching the server's
+`OT_SANDBOX_API_KEY` — any secret you choose. **With the env var unset the
+endpoints answer 401**: an unconfigured sandbox is locked, never open by
+accident, so a dev instance that ends up reachable beyond localhost (a tunnel,
+a `--host 0.0.0.0`) exposes nothing. `/health` stays open as a liveness probe.
+
+```bash
+curl -s -X POST localhost:8000/ai/classify-finish \
+  -H "Content-Type: application/json" -H "X-API-Key: <your-secret>" \
+  -d '{"context": "LVT-1 luxury vinyl tile"}'
+```
 
 ## Endpoints
 

--- a/server/app.py
+++ b/server/app.py
@@ -13,14 +13,23 @@ to a `TakeoffAI` implementation (see adapters/base.py and adapters/heuristic.py)
 It deliberately does NOT include any estimate, pricing, risk, or scope engine —
 this is just the takeoff canvas's optional AI playground.
 
-Run:  uvicorn app:app --reload --port 8000
+The AI endpoints are LOCKED until you set an API key — pick any secret you like:
+
+Run:  OT_SANDBOX_API_KEY=<any-secret> uvicorn app:app --reload --port 8000
+
+Callers must send the same value in an `X-API-Key` header. With the env var
+unset, /ai/* answers 401 — never "open because unconfigured": a server this
+socket may one day front (your GPU box, your API budget) should refuse
+strangers even when someone forgets to configure it, or exposes a dev
+instance beyond localhost. /health stays open as a liveness probe.
 """
 from __future__ import annotations
 
 import importlib
 import os
+import secrets
 
-from fastapi import FastAPI
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, field_validator, model_validator
 
@@ -29,14 +38,38 @@ from adapters.heuristic import HeuristicAdapter
 
 app = FastAPI(title="OpenTakeoff AI sandbox", version="0.1.0")
 
-# Wide-open CORS by default — this is a local dev sandbox. Lock it down if you
-# expose it beyond localhost.
+# Wide-open CORS — fine because every /ai route also demands the API key; a
+# browser page can only call this with a key its user configured.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def require_api_key(x_api_key: str | None = Header(default=None)) -> None:
+    """Gate every /ai route on `X-API-Key` matching OT_SANDBOX_API_KEY.
+
+    The env var is read at CALL time (not import) so it's rotatable and
+    testable, and the compare is constant-time. Fail-closed in both
+    directions: no key configured ⇒ 401 regardless of what's presented
+    (never open-because-unconfigured); key configured ⇒ anything but an
+    exact match is 401. The secret rides a header, never a URL path or
+    query string, so it stays out of access logs and proxy caches.
+    """
+    expected = os.environ.get("OT_SANDBOX_API_KEY", "").strip()
+    if not expected:
+        raise HTTPException(
+            status_code=401,
+            detail="sandbox locked: start the server with OT_SANDBOX_API_KEY set, "
+            "then send that value in the X-API-Key header",
+        )
+    if not (x_api_key and secrets.compare_digest(x_api_key, expected)):
+        raise HTTPException(status_code=401, detail="invalid or missing X-API-Key")
+
+
+ai = APIRouter(prefix="/ai", dependencies=[Depends(require_api_key)])
 
 
 def _load_adapter() -> TakeoffAI:
@@ -151,23 +184,23 @@ def health() -> dict:
     return {"ok": True, "adapter": adapter.name}
 
 
-@app.post("/ai/suggest-scale", response_model=SuggestScaleOut)
+@ai.post("/suggest-scale", response_model=SuggestScaleOut)
 def suggest_scale(body: SuggestScaleIn) -> SuggestScaleOut:
     return SuggestScaleOut(**adapter.suggest_scale(body.page_text))
 
 
-@app.post("/ai/detect-rooms", response_model=DetectRoomsOut)
+@ai.post("/detect-rooms", response_model=DetectRoomsOut)
 def detect_rooms(body: DetectRoomsIn) -> DetectRoomsOut:
     out = adapter.detect_rooms(body.width, body.height, body.segments)
     return DetectRoomsOut(**out)
 
 
-@app.post("/ai/classify-finish", response_model=ClassifyFinishOut)
+@ai.post("/classify-finish", response_model=ClassifyFinishOut)
 def classify_finish(body: ClassifyFinishIn) -> ClassifyFinishOut:
     return ClassifyFinishOut(**adapter.classify_finish(body.context))
 
 
-@app.post("/ai/parse-schedule", response_model=ParseScheduleOut)
+@ai.post("/parse-schedule", response_model=ParseScheduleOut)
 def parse_schedule(body: ParseScheduleIn) -> ParseScheduleOut:
     out = adapter.parse_schedule(body.image_b64, body.width, body.height)
     # Validate/coerce each row through ScheduleRow and drop untagged ones (a row
@@ -176,3 +209,6 @@ def parse_schedule(body: ParseScheduleIn) -> ParseScheduleOut:
     rows = [ScheduleRow(**r) for r in out.get("rows", []) if isinstance(r, dict)]
     rows = [r for r in rows if r.finish_tag.strip()]
     return ParseScheduleOut(rows=rows, note=out.get("note", ""))
+
+
+app.include_router(ai)

--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8
+httpx>=0.27

--- a/server/tests/test_api_key_gate.py
+++ b/server/tests/test_api_key_gate.py
@@ -1,0 +1,75 @@
+"""The X-API-Key gate on /ai/* — fail-closed in both directions.
+
+Contract pinned here (see require_api_key in app.py):
+- OT_SANDBOX_API_KEY unset ⇒ every /ai route is 401, with or without a header —
+  an unconfigured sandbox is LOCKED, never open-because-unconfigured;
+- key set ⇒ missing or wrong X-API-Key is 401, the exact key is 200 with the
+  real adapter payload;
+- /health stays open in both modes (liveness probe, no capability);
+- the env var is read at call time, so setting it after import takes effect
+  (rotation without a restart-order dance).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from app import app  # noqa: E402
+
+KEY = "test-sandbox-key"
+HDR = {"X-API-Key": KEY}
+
+AI_ROUTES = [
+    ("/ai/suggest-scale", {"page_text": 'SCALE: 1/8" = 1\'-0"'}),
+    ("/ai/detect-rooms", {"width": 100, "height": 100}),
+    ("/ai/classify-finish", {"context": "LVT-1 luxury vinyl tile"}),
+    ("/ai/parse-schedule", {"image_b64": "", "width": 0, "height": 0}),
+]
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.delenv("OT_SANDBOX_API_KEY", raising=False)
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("path,body", AI_ROUTES)
+def test_unset_key_is_locked_with_and_without_header(client, path, body):
+    assert client.post(path, json=body).status_code == 401
+    # presenting a key against an unconfigured server must not fall through
+    assert client.post(path, json=body, headers=HDR).status_code == 401
+
+
+@pytest.mark.parametrize("path,body", AI_ROUTES)
+def test_set_key_rejects_missing_and_wrong(client, monkeypatch, path, body):
+    monkeypatch.setenv("OT_SANDBOX_API_KEY", KEY)
+    assert client.post(path, json=body).status_code == 401
+    assert client.post(path, json=body, headers={"X-API-Key": "nope"}).status_code == 401
+
+
+def test_right_key_serves_real_payloads(client, monkeypatch):
+    monkeypatch.setenv("OT_SANDBOX_API_KEY", KEY)
+    r = client.post("/ai/suggest-scale", json=AI_ROUTES[0][1], headers=HDR)
+    assert r.status_code == 200
+    assert set(r.json()) == {"label", "confidence", "source"}
+    r = client.post("/ai/parse-schedule", json=AI_ROUTES[3][1], headers=HDR)
+    assert r.status_code == 200
+    assert r.json()["rows"] == []
+
+
+def test_health_is_open_in_both_modes(client, monkeypatch):
+    assert client.get("/health").status_code == 200
+    monkeypatch.setenv("OT_SANDBOX_API_KEY", KEY)
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_env_is_read_at_call_time(client, monkeypatch):
+    # locked before, serving after — same app object, no reimport
+    path, body = AI_ROUTES[0]
+    assert client.post(path, json=body, headers=HDR).status_code == 401
+    monkeypatch.setenv("OT_SANDBOX_API_KEY", KEY)
+    assert client.post(path, json=body, headers=HDR).status_code == 200

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -26,7 +26,15 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/ai": "http://localhost:8000",
+      // The sandbox's /ai routes are key-locked (server/README.md). Export the
+      // same OT_SANDBOX_API_KEY in the shell running `npm run dev` and the
+      // proxy stamps the header on — the browser never handles the secret.
+      "/ai": {
+        target: "http://localhost:8000",
+        headers: process.env.OT_SANDBOX_API_KEY
+          ? { "X-API-Key": process.env.OT_SANDBOX_API_KEY }
+          : {},
+      },
     },
   },
   build: {


### PR DESCRIPTION
## What

The optional AI sandbox (`server/app.py`) had zero auth and wide-open CORS — fine bound to localhost, but nothing about it stayed safe if a dev instance was ever exposed (a tunnel, a `--host 0.0.0.0`). Its `/ai/*` endpoints now require an `X-API-Key` header matching the server's `OT_SANDBOX_API_KEY` env var.

## Contract

- **Fail-closed both directions:** env unset ⇒ every `/ai` route answers 401 with an actionable message — an unconfigured sandbox is locked, never open by accident. Key set ⇒ missing/wrong header is 401.
- Constant-time compare (`secrets.compare_digest`); env read at call time (rotatable, testable).
- The secret rides a **header**, never a URL path or query string.
- `/health` stays open as a liveness probe.
- The Vite dev proxy stamps the header from the same env var exported in the `npm run dev` shell, so the browser schedule-scan flow works unchanged and the client never handles the secret.

## Verification

- 11 new tests (`server/tests/test_api_key_gate.py`) pin the contract, including call-time env reads; new `server` CI job runs them.
- Live matrix verified: keyless server → /health 200, /ai 401 with and without header; keyed server → 401/401/200 with real adapter payloads.
- End-to-end through the dev proxy: POST to `localhost:5173/ai/parse-schedule` with no client header → 200 via injected header.
- `npm run check` green on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)