### PR TITLE
One-Click: Create selects the takeoff it just made

### DIFF
--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -3578,7 +3578,19 @@ export default function TakeoffCanvas() {
       // pre-edit ring only when Create didn't already.
       origin: { method: "one_click_v1", seed_norm: [r.seed[0] / tp.img.w, r.seed[1] / tp.img.h], reviewed: true, confidence: r.cf ?? 1, ...(r.cff?.length ? { confidence_factors: r.cff } : {}), ...(r.hf ? { hatch_filtered: true } : {}), ...(r.sl ? { gap_sealed_px: r.sl } : {}), ...(r.gap ? { gap_bridged_px: r.gap } : {}), ...(r.mp ? { min_pass_px: r.mp, min_pass_delta: r.mpd } : {}), ...(r.wg ? { door_wedges: r.wg } : {}), ...(r.rw ? { ring_interiors: r.rw } : {}), ...(r.rt ? { raster_traced: true } : {}), ...(r.sens != null ? { fill_sensitivity: r.sens } : {}), ...(r.touched ? { edited_before_create: true, proposed_verts_norm: r.poly0.map(([x, y]) => [x / tp.img.w, y / tp.img.h]) } : {}) },
     }));
-    dispatchShape({ type: "add", shapes: made });   // the creation gate — id/created_at minted by the command
+    const res = dispatchShape({ type: "add", shapes: made });   // the creation gate — id/created_at minted by the command
+    // ...and the new takeoff is SELECTED. Without this, Create left nothing
+    // selected, so the ⌫ that had been deleting the proposal a moment earlier
+    // suddenly did nothing and the only way to undo a bad fill was the Edit
+    // menu — the one moment in the flow where the keyboard stopped working.
+    // Same idiom as pasteClipboard: a plain add appends, so the minted shapes
+    // are the array's last N. Deliberately WITHOUT pasteClipboard's
+    // setTool("select") — the status message says "Click the next room" and
+    // it has to stay true. Selecting while One-Click is armed is safe: a
+    // shape's own handles only grab under tool === "select", and the
+    // proposal branch sits ahead of `selectedId` in the ⌫ chain, so the next
+    // fill's ⌫ still discards that proposal first.
+    if (res?.shapes?.length) selectShape(res.shapes[res.shapes.length - 1].id);
     const sf = prop.regions.reduce((n, r) => n + (r.kind === "neg" ? -r.area_sf : r.area_sf), 0);
     // condById is a render closure — a condition minted THIS utterance is only
     // in the live mirror, so fall through to it for the tag


### PR DESCRIPTION
Reported from the field:

> the backspace button doesnt delete proposed shapes but escape does and then when something is commited it makes me go to the edit menu

The second half is exactly what the code did. `commitOneClickRegions` dispatched the add and returned, leaving `selectedId` null — so the very next keystroke fell through the whole ⌫ chain to nothing.

The keyboard worked *before* Create and worked again after a manual click. It only died at the one moment you're most likely to want it: when you've just watched a fill land wrong.

## Fix

`pasteClipboard`'s existing idiom — a plain add appends, so the minted shapes are the array's last N, and the newest gets selected.

Deliberately **without** `pasteClipboard`'s `setTool("select")`: the status message says *"Click the next room"* and that has to stay true.

Selecting while One-Click is armed is safe, and both halves were checked:
- a committed shape's handles only grab under `tool === "select"` in `onPointerDown`, so the next click still runs a fill;
- the `proposal` branch sits *ahead* of `selectedId` in the ⌫ chain, so the next fill's ⌫ still discards that proposal first rather than deleting the room you just kept.

Covers the agent and voice commit paths too — they land in the same gate.

## Still open

The first half of the report — ⌫ not clearing a *proposal* — I could not reproduce from the code. The chain does handle it (`proposal.regions` pops, and a single-region proposal goes to null), there's no input in the review panel to swallow the key, and `ocSel` is only set by clicking a handle. Needs the exact sequence before I change key semantics on a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)