### PR TITLE
The deployed MCP manifest is a release surface, so the guard checks it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,23 @@ jobs:
             exit 1
           fi
 
+          # ...and the DEPLOYED manifest, which is the surface nobody remembers.
+          # AGENTS.md has always said the version lives on three surfaces, but
+          # this guard only ever checked two, so the third silently rotted: at
+          # 0.9.29 the well-known file still said 0.9.27 while npm and the
+          # registry served 0.9.29. It is not cosmetic — directory indexers
+          # (Smithery among them) cache whatever they last scanned, and the same
+          # drift once had them describing the 17-tool era of a 31-tool server.
+          # It ships from web/, not mcp/, which is exactly why a change confined
+          # to mcp/ forgets it, so it is checked HERE where mcp/ is the trigger.
+          WK=web/public/.well-known/mcp.json
+          WKV=$(jq -r .version "$WK")
+          WKPKG=$(jq -r '.packages[0].version' "$WK")
+          if [ "$PKG" != "$WKV" ] || [ "$PKG" != "$WKPKG" ]; then
+            echo "::error file=$WK::the deployed manifest still says $WKV/$WKPKG while mcp/ is $PKG — bump BOTH version fields in $WK too, or the directories keep advertising the old server"
+            exit 1
+          fi
+
           BASE_PKG=$(git show "$BASE:mcp/package.json" | jq -r .version)
           if [ "$PKG" = "$BASE_PKG" ]; then
             echo "::error file=mcp/package.json::mcp/ changed but the version is still $PKG. Bump mcp/package.json AND mcp/server.json (.version and .packages[0].version), or the change ships to nobody: the registry only ever sees a published mcp-v* tag."

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.27",
+  "version": "0.9.29",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.27",
+      "version": "0.9.29",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
`AGENTS.md` has always said the MCP version lives on **three** surfaces — `mcp/package.json`, `mcp/server.json`, and `web/public/.well-known/mcp.json` — but `mcp-version-guard` only ever checked two.

So the third rotted, exactly as it had before. Tonight 0.9.29 published to npm and the MCP registry while the deployed manifest still declared **0.9.27**.

That isn't cosmetic. Directory indexers cache whatever they last scanned, and the CHANGELOG already records this failure once:

> a stale manifest quietly under-reports the server — Smithery was still describing the 17-tool era of a 31-tool server

## Why it keeps happening

It's structural. The manifest ships from `web/`, not `mcp/`, so a change confined to `mcp/` never touches it and nothing complains. It's therefore checked **here**, in the job `mcp/` already triggers, against the same version the other two must agree on. The surface you forget is the one that needs the machine watching it.

## In this PR

- `web/public/.well-known/mcp.json` → 0.9.29, matching what is live on npm and the registry.
- `mcp-version-guard` now fails the PR when the manifest disagrees, naming the file and both numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)