### PR TITLE
The manual is in the app now — "?" or the toolbar button

### DIFF
--- a/web/bench/results.json
+++ b/web/bench/results.json
@@ -48,7 +48,7 @@
    "sfErr": 0,
    "leak": false,
    "refused": false,
-   "confidence": 0.93,
+   "confidence": 0.92,
    "tags": [
     "door-swing",
     "wedge-included"
@@ -133,7 +133,7 @@
    "sfErr": 0,
    "leak": false,
    "refused": false,
-   "confidence": 0.92,
+   "confidence": 0.91,
    "tags": [
     "door-swing",
     "multi-door"
@@ -299,11 +299,11 @@
    "probeName": "elevator-e01",
    "expect": "golden",
    "status": "ok",
-   "iou": 0.9979244589540138,
-   "sfErr": 0.00027502215351562093,
+   "iou": 0.9920689506942355,
+   "sfErr": 0.005964405002622087,
    "leak": false,
    "refused": false,
-   "confidence": 0.97,
+   "confidence": 0.92,
    "tags": [
     "door-swing"
    ]
@@ -382,7 +382,7 @@
  ],
  "aggregate": {
   "goldenProbes": 21,
-  "meanIoU": 0.9993004094836125,
+  "meanIoU": 0.9990215757569564,
   "floorIoU": 0.9903403448587162,
   "refusalRate": 0,
   "leakRate": 0,
@@ -407,12 +407,12 @@
    "caseName": "va-finish-plan",
    "probes": 8,
    "sumGoldenSF": 2614.3091975308735,
-   "sumEngineSF": 2614.4159740923087,
-   "ratio": 1.0000408431265653,
+   "sumEngineSF": 2615.2274407589775,
+   "ratio": 1.000351237424009,
    "overlapSF": 0,
-   "maxSfErr": 0.0006276338205593411,
-   "maxSfAbs": 0.050546087710870324,
-   "maxSfAbsProbe": "ward-room",
+   "maxSfErr": 0.005964405002622073,
+   "maxSfAbs": 0.8506925925892688,
+   "maxSfAbsProbe": "elevator-e01",
    "humanMeasured": false
   }
  ],
@@ -975,7 +975,7 @@
    ],
    "statusAgree": true,
    "iouByRes": [
-    0.9998267198059262,
+    0.9937139412727116,
     0.9603188355570959,
     0.9312944030497314
    ],
@@ -1006,7 +1006,7 @@
    "iouByRes": [
     0.9995268387571631,
     0.4775177491454115,
-    0.6354319949548034
+    0.6285143727994115
    ],
    "subFloorRes": [
     0.75,
@@ -1064,8 +1064,8 @@
    "statusAgree": true,
    "iouByRes": [
     0.9999858403069821,
-    0.9882082641122618,
-    0.9765518411434954
+    0.9879686605862363,
+    0.982298198045529
    ],
    "subFloorRes": [
     0.75,
@@ -1157,7 +1157,7 @@
    },
    {
     "probe": "door-swing-3ft/center",
-    "confidence": 0.93
+    "confidence": 0.92
    },
    {
     "probe": "hatched-room/center",
@@ -1165,7 +1165,7 @@
    },
    {
     "probe": "two-door-room/center",
-    "confidence": 0.92
+    "confidence": 0.91
    },
    {
     "probe": "sample-plan/break-103",
@@ -1194,10 +1194,6 @@
    {
     "probe": "va-finish-plan/patient-toilet-137a",
     "confidence": 0.9
-   },
-   {
-    "probe": "va-finish-plan/elevator-e01",
-    "confidence": 0.97
    },
    {
     "probe": "va-finish-plan/ward-room",
@@ -1535,10 +1531,10 @@
    {
     "caseName": "va-finish-plan",
     "probeName": "elevator-e01",
-    "iou": 0.9506654033334769,
-    "sfErr": 0.041180853877427696,
-    "prodIou": 0.9979244589540138,
-    "prodSfErr": 0.00027502215351562093
+    "iou": 0.9491873835678036,
+    "sfErr": 0.03177031923836624,
+    "prodIou": 0.9920689506942355,
+    "prodSfErr": 0.005964405002622087
    },
    {
     "caseName": "va-finish-plan",
@@ -1573,7 +1569,7 @@
     "prodSfErr": 0.00015917263913391673
    }
   ],
-  "meanIoU": 0.9693748770510208,
+  "meanIoU": 0.9693044951574175,
   "floorIoU": 0.8602150537634409,
   "worstSfErr": 0.07834835470271602,
   "crossFloorIoU": 0.9618671926364234,

--- a/web/src/components/PlanNavigator.jsx
+++ b/web/src/components/PlanNavigator.jsx
@@ -80,7 +80,14 @@ export default function PlanNavigator({
     const onKey = (e) => {
       if (e.key === "Escape") { e.stopPropagation(); escRef.current(); return; }
       const tag = e.target?.tagName;
-      if (tag !== "INPUT" && tag !== "SELECT" && tag !== "TEXTAREA") e.stopPropagation();
+      if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") return;
+      // "?" is app-level help, not a canvas tool shortcut, so it is not ours to
+      // swallow — and this screen is exactly where someone reaches for it. With
+      // no plan open the navigator is what's mounted, so suppressing "?" here
+      // meant the manual could not be opened by keyboard by the one person most
+      // likely to want it: a first-time visitor who has not loaded anything yet.
+      if (e.key === "?") return;
+      e.stopPropagation();
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);

--- a/web/src/components/UserGuide.jsx
+++ b/web/src/components/UserGuide.jsx
@@ -1,0 +1,168 @@
+// The in-app manual — the short version, reachable without leaving the canvas.
+//
+// docs/USER_GUIDE.md is 705 lines and good, and until now NOTHING in the app
+// pointed at it: a first-time visitor to the demo had no way to learn that a
+// manual exists. (The one icon that reads as help is the RFI hexagon, whose own
+// comment calls it "a question motif".) This is the overlay that closes that
+// gap — the five-minute path plus the real key bindings, with the long-form
+// manual one link away.
+//
+// DELIBERATELY NOT a rendering of the markdown. Bundling a parser to re-display
+// a document that lives in the repo buys a dependency and a second thing to
+// keep true; what an estimator needs mid-trace is the shortcut and the next
+// step, not sixteen sections. The bindings below are transcribed from
+// USER_GUIDE.md §15, which is itself maintained against the code — if a
+// shortcut changes, §15 and this table move together.
+import { useEffect } from "react";
+
+const GUIDE_URL = "https://github.com/Kentucky-ai/opentakeoff/blob/main/docs/USER_GUIDE.md";
+
+function Kbd({ children }) {
+  return (
+    <kbd style={{
+      fontFamily: "var(--f-mono)", fontSize: 11, padding: "2px 6px", border: "1px solid var(--ink-faint)",
+      borderBottomWidth: 2, borderRadius: 5, background: "var(--paper-bright)", color: "var(--ink)", whiteSpace: "nowrap",
+    }}>{children}</kbd>
+  );
+}
+
+function Keys({ combo }) {
+  return (
+    <span style={{ display: "inline-flex", gap: 3, alignItems: "center" }}>
+      {combo.map((k, i) => <Kbd key={i}>{k}</Kbd>)}
+    </span>
+  );
+}
+
+function Table({ rows }) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "auto 1fr", gap: "7px 14px", alignItems: "baseline" }}>
+      {rows.map(([combo, what], i) => (
+        <div key={i} style={{ display: "contents" }}>
+          <div style={{ justifySelf: "start" }}><Keys combo={combo} /></div>
+          <div style={{ fontSize: 12.5, color: "var(--ink-soft)", lineHeight: 1.45 }}>{what}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <div style={{ marginBottom: 26 }}>
+      <div className="t-label" style={{ marginBottom: 10 }}>{title}</div>
+      {children}
+    </div>
+  );
+}
+
+const START = [
+  ["Open a plan", "Drag a PDF, an image, or a whole .zip plan set onto the canvas — or click Load sample plan to use the bundled VA finish plan. Nothing leaves your machine."],
+  ["Set the scale first", "Every quantity depends on it. The Scale menu offers what the sheet's own title block states; hover it to preview a calibrated ruler on the drawing, or calibrate two points of a known dimension. Remembered per sheet."],
+  ["Add a condition", "A condition is a finish — CPT-1, LVT, base. Give it a tag, a waste %, and a colour. Press 1–9 to arm one."],
+  ["Measure", "One-Click a room and it selects itself; or trace by hand with Area, Rectangle, Linear or Count. In One-Click, ⏎ creates it."],
+  ["Read the report", "REPORT totals every condition, applies waste, and gives you order quantities, a buy list, and CSV / Excel export."],
+];
+
+const TOOLS = [
+  [["O"], "One-Click Area — click inside a room, it selects itself"],
+  [["A"], "Area"], [["R"], "Rectangle"], [["L"], "Linear"], [["Q"], "Curved Line"],
+  [["S"], "Surface Area (walls)"], [["C"], "Count"],
+  [["D"], "Deduct shape (Cut Out)"], [["⇧", "D"], "Deduct rectangle"],
+  [["H"], "Highlighter"], [["K"], "Check a dimension against what the drawing says"],
+  [["V"], "Select"], [["P"], "Pan"], [["G"], "Sheet gallery"],
+  [["1", "–", "9"], "Arm condition N"],
+  [["hold", "M"], "Push-to-talk dictation — release runs it, Esc discards"],
+];
+
+const DRAW = [
+  [["⏎"], "Finish the shape. In One-Click: Create the selection"],
+  [["⌫"], "Back out one step — the last point, then the picked vertex, the region, the selected shape, the markup"],
+  [["⌘", "Z"], "Mid-trace pops the last point; otherwise undo"],
+  [["⇧", "⌘", "Z"], "Redo"],
+  [["Esc"], "Back out one level — vertex pick first, then anything in progress"],
+  [["hold", "⇧"], "Force the 45° angle lock at any cursor angle"],
+  [["⌥", "click"], "In One-Click: carve a cutout inside a selected space"],
+  [["⇧", "click"], "Insert a vertex at an edge midpoint, and drag it"],
+  [["⌘", "C"], "Copy"], [["⌘", "V"], "Paste under the cursor"], [["⌘", "D"], "Duplicate"],
+];
+
+const VIEW = [
+  [["scroll"], "Zoom toward the cursor"],
+  [["two-finger"], "Pan, both axes"],
+  [["⇧", "scroll"], "Pan"],
+  [["hold", "Space"], "Pan with any tool armed — as does middle-drag or right-drag"],
+  [["?"], "Open this guide"],
+];
+
+export default function UserGuide({ onClose }) {
+  // The dialog closes ITSELF, and that is not a style preference. The canvas's
+  // Escape chain lives in an effect that early-returns while the plan-set
+  // gallery is up — so a guide dismissed from there would have swallowed the
+  // key and stayed open, which is precisely the first-time visitor who came
+  // looking for the manual. Owning the key here makes dismissal independent of
+  // whatever view is behind. Capture phase + stopPropagation so the same press
+  // cannot also back out of a trace the user cannot see behind the overlay.
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopPropagation();
+      onClose();
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed", inset: 0, zIndex: 9000, background: "rgba(0,0,0,0.45)",
+        display: "flex", alignItems: "flex-start", justifyContent: "center", padding: "5vh 16px", overflow: "auto",
+      }}>
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="OpenTakeoff user guide"
+        className="panel"
+        style={{
+          width: "min(760px, 100%)", background: "var(--paper-bright)", color: "var(--ink)",
+          border: "1px solid var(--ink-faint)", borderRadius: 12, padding: "22px 26px 26px",
+          boxShadow: "var(--shadow-2)",
+        }}>
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12, marginBottom: 4 }}>
+          <strong style={{ fontFamily: "var(--f-display)", fontSize: 17, letterSpacing: "-0.02em" }}>How OpenTakeoff works</strong>
+          <button onClick={onClose} title="Close (Esc)"
+            style={{ background: "none", border: "none", color: "var(--ink-soft)", fontSize: 18, cursor: "pointer", lineHeight: 1, padding: 4 }}>×</button>
+        </div>
+        <p style={{ fontSize: 12.5, color: "var(--ink-soft)", lineHeight: 1.5, margin: "0 0 22px" }}>
+          A takeoff canvas that runs entirely in your browser — no account, no upload, no install. Open a plan,
+          set the scale, measure the finishes, export a priced quantity report.
+        </p>
+
+        <Section title="Five minutes to a takeoff">
+          <ol style={{ margin: 0, paddingLeft: 18, display: "grid", gap: 9 }}>
+            {START.map(([t, d]) => (
+              <li key={t} style={{ fontSize: 12.5, lineHeight: 1.5 }}>
+                <strong style={{ color: "var(--ink)" }}>{t}</strong>
+                <span style={{ color: "var(--ink-soft)" }}> — {d}</span>
+              </li>
+            ))}
+          </ol>
+        </Section>
+
+        <Section title="Tools"><Table rows={TOOLS} /></Section>
+        <Section title="Drawing & editing"><Table rows={DRAW} /></Section>
+        <Section title="Getting around"><Table rows={VIEW} /></Section>
+
+        <div style={{ borderTop: "1px solid var(--ink-faint)", paddingTop: 14, fontSize: 12.5, color: "var(--ink-soft)", lineHeight: 1.5 }}>
+          This is the short version. The full manual covers conditions, markups and RFIs, revisions,
+          the report and exports, the Agent panel, and driving OpenTakeoff from an AI agent over MCP —{" "}
+          <a href={GUIDE_URL} target="_blank" rel="noreferrer" style={{ color: "var(--cobalt)" }}>read the complete guide</a>.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -27,6 +27,7 @@ import ToolMenu from "../components/ToolMenu.jsx";
 import PlanNavigator from "../components/PlanNavigator.jsx";
 import ReportPanel from "../components/ReportPanel.jsx";
 import RevisionsPanel from "../components/RevisionsPanel.jsx";
+import UserGuide from "../components/UserGuide.jsx";
 import TakeoffsPanel, { clampPanelW, CONDITION_DND_MIME, ConditionAppearanceEditor } from "../components/TakeoffsPanel.jsx";
 import { HATCHES, PALETTE, NO_FILL, HatchPattern, HatchSwatch } from "../components/hatches.jsx";
 import { Icon } from "../brand/icons.jsx";
@@ -335,6 +336,7 @@ export default function TakeoffCanvas() {
   const [palette, setPalette] = useState([]);   // ordered condition ids pinned to the top-bar quick-access palette (≤ PALETTE_MAX)
   const [shapes, setShapes] = useState([]);
   const [poly, setPoly] = useState([]);
+  const [guideOpen, setGuideOpen] = useState(false);   // the in-app manual overlay (? / the toolbar button)
   const [proposal, setProposal] = useState(null);  // One-Click selection under review: { key, regions: [{kind:'pos'|'neg', seed, poly, area_sf, perim_lf}] } — panel-LOCAL px
   // ── in-canvas takeoff agent state ──────────────────────────────────────────
   // agentProposals are NOT shapes: committed truth stays committed. Each entry
@@ -2158,6 +2160,10 @@ export default function TakeoffCanvas() {
       if (tg === "INPUT" || tg === "SELECT" || tg === "TEXTAREA") return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (menuDepthRef.current > 0) return;
+      // "?" opens the manual. Here rather than in its own listener so it
+      // inherits this effect's guards — a "?" typed into a condition tag or
+      // with a toolbar menu open must not pop a dialog over the work.
+      if (e.key === "?") { e.preventDefault(); setGuideOpen(true); return; }
       if (e.key === "Enter") {
         // router offer confirm takes the key FIRST (RFC #59 slice 5): the
         // offer is the most recent thing the user was told ⏎ does, and it
@@ -5834,6 +5840,11 @@ export default function TakeoffCanvas() {
         )}
         <div style={{ flex: 1 }} />
         <span style={{ fontSize: 11, color: "var(--ink-muted)", minWidth: 44, fontFamily: "var(--f-mono)" }}>{saveState === "saving" ? "saving…" : saveState === "saved" ? "saved ✓" : ""}</span>
+        <button onClick={() => setGuideOpen(true)} title="How OpenTakeoff works — the five-minute path and every shortcut (?)"
+          aria-label="How OpenTakeoff works"
+          style={{ display: "inline-flex", alignItems: "center", padding: "6px 10px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", cursor: "pointer", fontSize: 13, fontWeight: 700, lineHeight: 1 }}>
+          ?
+        </button>
         <button onClick={toggleTheme} title="App theme — light / dark chrome (sheets unaffected; use ☾ on the canvas to invert the print)"
           aria-label="App theme — light / dark chrome" aria-pressed={theme === "dark"}
           style={{ display: "inline-flex", alignItems: "center", padding: "6px 9px", border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--ink)", cursor: "pointer", fontSize: 14, lineHeight: 1 }}>
@@ -7430,6 +7441,8 @@ export default function TakeoffCanvas() {
           (the Agent panel links here; closing re-renders, so `configured`
           re-reads immediately). */}
       {showAiSettings && <AiSettings onClose={() => setShowAiSettings(false)} />}
+      {/* the manual, last in the tree so it sits above every panel and dock */}
+      {guideOpen && <UserGuide onClose={() => setGuideOpen(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
`docs/USER_GUIDE.md` is 705 good lines and **nothing in the app pointed at it**. A first-time visitor to the demo had no way to learn a manual existed. The only icon that reads as help is the RFI hexagon — whose own comment in `icons.jsx` calls it *"a question motif"*, which is exactly why it misleads.

So: a **`?` button** in the top deck beside the theme toggle, and the **`?` key**. Contents are the five-minute path and the real key bindings, transcribed from `USER_GUIDE.md` §15 (itself maintained against the code), with the long-form manual one link away.

**Deliberately not a markdown rendering.** Bundling a parser to re-display a document that already lives in the repo buys a dependency and a second thing to keep true. What an estimator wants mid-trace is the shortcut and the next step, not sixteen sections.

## Three defects that only appeared by driving the built app

Each of these passed lint, typecheck and build:

- **The panel was transparent.** There is no `--paper` token — the palette has `--paper-cream` / `--paper-bright` / `--paper-shadow` — so the background resolved to nothing and the page behind read straight through the dialog. Now on `--paper-bright` with `.panel` and `--shadow-2`, the same idiom `AiSettings` uses. Every other token the component names was checked to exist rather than assumed.
- **Escape didn't close it.** The canvas Escape chain lives in an effect that early-returns while the plan-set gallery is up, so a guide opened from the landing screen swallowed the key and stayed open — the first-time visitor again. The dialog now owns its own Escape in the capture phase, which makes dismissal independent of whatever view is behind *and* stops the same press also backing out of a trace hidden by the overlay.
- **The `?` key did nothing on the landing screen.** `PlanNavigator` stops propagation on every non-input key while mounted, to keep canvas tool shortcuts from firing over the gallery. Right for tool letters, wrong for `?`, which is app-level help — and with no plan open the navigator is what's mounted, so the one person most likely to press `?` was the one person it couldn't work for. Exempted, with the reason in the code.

## Verification

The browser extension was down, so this was driven through **headless Chrome over CDP** (Node's built-in WebSocket, no new deps). On the landing view *and* again on the canvas with the sample plan loaded:

| check | result |
|---|---|
| button opens it | ✅ 4 sections, 47 `kbd` chips |
| `?` opens it | ✅ both views |
| `Esc` closes it | ✅ both views |
| does **not** open while typing in a field | ✅ |
| canvas still alive underneath | ✅ |

`npm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)