### PR TITLE
chore: point the demo at opentakeoff.kentucky-ai.com (mcp 0.9.31)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ Measured value vs. expected value, the sheet's scale, and whether waste/multipli
 
 **Environment**
 - Browser + version:
-- Where: opentakeoff.netlify.app / self-hosted / local dev
+- Where: opentakeoff.kentucky-ai.com / self-hosted / local dev
 - Plan source: PDF / image / .zip (vector or scanned?)
 
 **Screenshots**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,12 @@ npm run check    # typecheck + lint + test + build — exactly what CI runs; gre
 `main` is protected on GitHub via a ruleset (PR-only, one approving review,
 green `web` check, branch up to date — the repo owner has a standing bypass
 as the solo maintainer). **Merging to `main` deploys to production**
-(<https://opentakeoff.netlify.app>) via `.github/workflows/deploy.yml`, which
+(<https://opentakeoff.kentucky-ai.com>) via `.github/workflows/deploy.yml`, which
 re-runs `npm run check` and publishes `web/dist` to Netlify with `--no-build`
 — Netlify never builds anything itself.
 
 > **This is the canonical `Kentucky-ai/opentakeoff` repo — production is
-> <https://opentakeoff.netlify.app>, nothing else.** A downstream fork
+> <https://opentakeoff.kentucky-ai.com>, nothing else.** A downstream fork
 > (`knmurphy/opentakeoff`) tracks this repo as its own upstream and deploys
 > separately to `takeoff.345flooring.com` — that URL belongs to *that* fork,
 > not this repo. If you're seeing `takeoff.345flooring.com` referenced

--- a/AGENT_BRIEF.md
+++ b/AGENT_BRIEF.md
@@ -2,7 +2,7 @@
 
 **Project:** Open-source browser-based construction takeoff tool for flooring.
 
-**Live demo:** https://opentakeoff.netlify.app
+**Live demo:** https://opentakeoff.kentucky-ai.com
 
 **Repo:** https://github.com/Kentucky-ai/opentakeoff
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,10 +9,10 @@
 ブラウザで動作 — アカウント不要、アップロード不要、インストール不要。
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Live demo](https://img.shields.io/badge/demo-opentakeoff.netlify.app-2ea44f.svg)](https://opentakeoff.netlify.app)
+[![Live demo](https://img.shields.io/badge/demo-opentakeoff.kentucky--ai.com-2ea44f.svg)](https://opentakeoff.kentucky-ai.com)
 [![Built with React + Vite](https://img.shields.io/badge/React%2018-Vite-444.svg)](#技術スタック)
 
-[**▶ ライブデモを試す**](https://opentakeoff.netlify.app) · [クイックスタート](#クイックスタート) · [機能](#主な機能) · [AI エージェント向け](mcp/) · [English](README.md) · [한국어](README.ko.md) · [简体中文](README.zh-Hans.md)
+[**▶ ライブデモを試す**](https://opentakeoff.kentucky-ai.com) · [クイックスタート](#クイックスタート) · [機能](#主な機能) · [AI エージェント向け](mcp/) · [English](README.md) · [한국어](README.ko.md) · [简体中文](README.zh-Hans.md)
 
 <br/>
 
@@ -51,7 +51,7 @@ OpenTakeoff は、建築図面から数量を測る — **拾い出し**（takeo
 
 ## クイックスタート
 
-使うだけならインストールは不要です — [**ライブデモ**](https://opentakeoff.netlify.app)を開いて、
+使うだけならインストールは不要です — [**ライブデモ**](https://opentakeoff.kentucky-ai.com)を開いて、
 図面をドラッグするだけです。
 
 自分で動かす場合:

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,10 +9,10 @@
 브라우저에서 실행 — 계정 없음, 업로드 없음, 설치 없음.
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Live demo](https://img.shields.io/badge/demo-opentakeoff.netlify.app-2ea44f.svg)](https://opentakeoff.netlify.app)
+[![Live demo](https://img.shields.io/badge/demo-opentakeoff.kentucky--ai.com-2ea44f.svg)](https://opentakeoff.kentucky-ai.com)
 [![Built with React + Vite](https://img.shields.io/badge/React%2018-Vite-444.svg)](#기술-스택)
 
-[**▶ 라이브 데모 실행**](https://opentakeoff.netlify.app) · [빠른 시작](#빠른-시작) · [기능](#주요-기능) · [AI 에이전트용](mcp/) · [English](README.md) · [日本語](README.ja.md) · [简体中文](README.zh-Hans.md)
+[**▶ 라이브 데모 실행**](https://opentakeoff.kentucky-ai.com) · [빠른 시작](#빠른-시작) · [기능](#주요-기능) · [AI 에이전트용](mcp/) · [English](README.md) · [日本語](README.ja.md) · [简体中文](README.zh-Hans.md)
 
 <br/>
 
@@ -51,7 +51,7 @@ OpenTakeoff가 바로 그 도구입니다. 업계에 무상으로 제공되는 �
 
 ## 빠른 시작
 
-쓰기만 할 거라면 설치할 것이 없습니다 — [**라이브 데모**](https://opentakeoff.netlify.app)를 열고
+쓰기만 할 거라면 설치할 것이 없습니다 — [**라이브 데모**](https://opentakeoff.kentucky-ai.com)를 열고
 도면을 끌어다 놓으면 됩니다.
 
 직접 실행하려면:

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Same flood fill, same scale gate, same math, same record. Every measurement stor
 what makes it training data.
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Live demo](https://img.shields.io/badge/demo-opentakeoff.netlify.app-2ea44f.svg)](https://opentakeoff.netlify.app)
+[![Live demo](https://img.shields.io/badge/demo-opentakeoff.kentucky--ai.com-2ea44f.svg)](https://opentakeoff.kentucky-ai.com)
 [![MCP registry](https://img.shields.io/badge/MCP-io.github.Kentucky--ai%2Fopentakeoff-6f42c1.svg)](https://registry.modelcontextprotocol.io)
 [![npm](https://img.shields.io/npm/v/opentakeoff-mcp?label=opentakeoff-mcp)](https://www.npmjs.com/package/opentakeoff-mcp)
 [![Benchmark](https://img.shields.io/badge/benchmark-OpenTakeoff%20Academy-orange.svg)](https://aec.kentucky-ai.com)
 [![Sponsor](https://img.shields.io/github/sponsors/Kentucky-ai?logo=githubsponsors&label=sponsor&color=EA4AAA)](https://github.com/sponsors/Kentucky-ai)
 
-[**For agents**](#for-agents--start-here) · [**Try the canvas**](https://opentakeoff.netlify.app) · [The engine's contract](#the-contract-that-makes-it-drivable) · [For the person at the canvas](#for-the-person-at-the-canvas) · [The data layer](#the-data-layer--why-this-engine-exists) · [Research](#the-research-program) · [Build on it](#build-on-top-of-it) · [Contribute](#contributing)
+[**For agents**](#for-agents--start-here) · [**Try the canvas**](https://opentakeoff.kentucky-ai.com) · [The engine's contract](#the-contract-that-makes-it-drivable) · [For the person at the canvas](#for-the-person-at-the-canvas) · [The data layer](#the-data-layer--why-this-engine-exists) · [Research](#the-research-program) · [Build on it](#build-on-top-of-it) · [Contribute](#contributing)
 
 **Read this in:** [日本語](README.ja.md) · [한국어](README.ko.md) · [简体中文](README.zh-Hans.md)
 
@@ -206,7 +206,7 @@ npm install
 npm run dev        # http://localhost:5173
 ```
 
-Or just open the [**live demo**](https://opentakeoff.netlify.app). Drag in
+Or just open the [**live demo**](https://opentakeoff.kentucky-ai.com). Drag in
 `demo/sample-plan.pdf`, accept the detected scale, pick a condition, hit **One-Click Area**,
 click inside a room. Open **Report** for the breakdown and the exports. The complete
 zero-to-exported walkthrough is the [**user manual**](docs/USER_GUIDE.md).

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -9,10 +9,10 @@
 无需账号，无需上传，无需安装。
 
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Live demo](https://img.shields.io/badge/demo-opentakeoff.netlify.app-2ea44f.svg)](https://opentakeoff.netlify.app)
+[![Live demo](https://img.shields.io/badge/demo-opentakeoff.kentucky--ai.com-2ea44f.svg)](https://opentakeoff.kentucky-ai.com)
 [![Built with React + Vite](https://img.shields.io/badge/React%2018-Vite-444.svg)](#技术栈)
 
-[**▶ 打开在线演示**](https://opentakeoff.netlify.app) · [快速开始](#快速开始) · [功能](#主要功能) · [给 AI 智能体](mcp/) · [English](README.md) · [日本語](README.ja.md) · [한국어](README.ko.md)
+[**▶ 打开在线演示**](https://opentakeoff.kentucky-ai.com) · [快速开始](#快速开始) · [功能](#主要功能) · [给 AI 智能体](mcp/) · [English](README.md) · [日本語](README.ja.md) · [한국어](README.ko.md)
 
 <br/>
 
@@ -49,7 +49,7 @@ OpenTakeoff 就是这个工具：一个免费开源的替代品，交给这个�
 
 ## 快速开始
 
-只是想用的话，什么都不用装 —— 打开[**在线演示**](https://opentakeoff.netlify.app)，
+只是想用的话，什么都不用装 —— 打开[**在线演示**](https://opentakeoff.kentucky-ai.com)，
 把图纸拖进去就行。
 
 想自己跑：

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 How OpenTakeoff ships: every change lands on `main` through a pull request,
 and every merge to `main` is automatically deployed to production at
-<https://opentakeoff.netlify.app>. There is no manual deploy step and no
+<https://opentakeoff.kentucky-ai.com>. There is no manual deploy step and no
 "deploy later" state — **a merge is a deploy**.
 
 (This file's mechanism description is accurate for this repo — it originally
@@ -20,7 +20,7 @@ branch → npm run check (local) → PR → CI (`web` check) → squash-merge
                                           npm ci → npm run check → netlify deploy
                                                              │
                                                              ▼
-                                          https://opentakeoff.netlify.app
+                                          https://opentakeoff.kentucky-ai.com
 ```
 
 - **CI** (`.github/workflows/ci.yml`) runs on every PR: `npm ci` then

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.30",
+  "version": "0.9.31",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/scripts/build-mcpb.mjs
+++ b/mcp/scripts/build-mcpb.mjs
@@ -49,7 +49,7 @@ writeFileSync(resolve(staging, 'manifest.json'), JSON.stringify({
   long_description: 'Construction takeoff for AI agents: load plan PDFs, browse the sheet set as resources, set and verify drawing scale, one-click room areas, measure, and export takeoff quantities with provenance. The same measuring engine as the OpenTakeoff web app.',
   author: { name: 'Kentucky AI', url: 'https://github.com/Kentucky-ai' },
   repository: { type: 'git', url: 'https://github.com/Kentucky-ai/opentakeoff' },
-  homepage: 'https://opentakeoff.netlify.app',
+  homepage: 'https://opentakeoff.kentucky-ai.com',
   documentation: 'https://github.com/Kentucky-ai/opentakeoff/blob/main/mcp/README.md',
   license: pkg.license,
   keywords: ['construction', 'takeoff', 'estimating', 'blueprints', 'measurement'],

--- a/mcp/scripts/build-smithery-mcpb.mjs
+++ b/mcp/scripts/build-smithery-mcpb.mjs
@@ -116,7 +116,7 @@ writeFileSync(resolve(staging, 'manifest.json'), JSON.stringify({
   long_description: 'Construction takeoff for AI agents: load plan PDFs, browse the sheet set as resources, set and verify drawing scale, one-click room areas, measure, and export takeoff quantities with provenance. The same measuring engine as the OpenTakeoff web app.',
   author: { name: 'Kentucky AI', url: 'https://github.com/Kentucky-ai' },
   repository: { type: 'git', url: 'https://github.com/Kentucky-ai/opentakeoff' },
-  homepage: 'https://opentakeoff.netlify.app',
+  homepage: 'https://opentakeoff.kentucky-ai.com',
   documentation: 'https://github.com/Kentucky-ai/opentakeoff/blob/main/mcp/README.md',
   license: pkg.license,
   keywords: ['construction', 'takeoff', 'estimating', 'blueprints', 'measurement'],

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.30",
+  "version": "0.9.31",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.30",
+      "version": "0.9.31",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Kentucky-ai/opentakeoff",
   "title": "OpenTakeoff",
   "description": "Construction takeoff for AI agents: load plans, set scale, measure, count, export with provenance.",
-  "websiteUrl": "https://opentakeoff.netlify.app",
+  "websiteUrl": "https://opentakeoff.kentucky-ai.com",
   "repository": {
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,21 @@
   directory    = "netlify/functions"
   node_bundler = "esbuild"
 
+# One canonical host. Netlify is *documented* to 301 the .netlify.app subdomain
+# to the primary custom domain on its own, but it was still answering 200 on
+# both hosts after the domain was promoted — so this is declared rather than
+# assumed. Two hostnames serving identical 200s splits link equity and is the
+# duplicate-content case search engines penalise; the canonical tag in
+# index.html alone does not stop a crawler indexing the other host.
+# force = true is required: without it the rule loses to an existing static
+# asset at the same path, which is every path on this site.
+# This must stay FIRST — the /* catch-all below would otherwise swallow it.
+[[redirects]]
+  from   = "https://opentakeoff.netlify.app/*"
+  to     = "https://opentakeoff.kentucky-ai.com/:splat"
+  status = 301
+  force  = true
+
 # Gated "Import from scanned schedule" — must precede the SPA catch-all, else
 # /* swallows it and the POST returns index.html.
 [[redirects]]

--- a/web/index.html
+++ b/web/index.html
@@ -4,21 +4,21 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="canonical" href="https://opentakeoff.netlify.app/" />
+    <link rel="canonical" href="https://opentakeoff.kentucky-ai.com/" />
     <meta name="description" content="Free, open-source construction & flooring takeoff — the first engine an AI agent can drive natively over MCP. Trace plans, get quantities, no account." />
     <title>OpenTakeoff — free, AI-native takeoff for construction & flooring</title>
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://opentakeoff.netlify.app" />
+    <meta property="og:url" content="https://opentakeoff.kentucky-ai.com" />
     <meta property="og:title" content="OpenTakeoff — the first takeoff canvas built for people and AI agents" />
     <meta property="og:description" content="A free, open-source PDF takeoff canvas. Trace plans and get quantities yourself, or point an AI agent at the same engine over MCP. Runs entirely in your browser, no account." />
-    <meta property="og:image" content="https://opentakeoff.netlify.app/og-card.png" />
+    <meta property="og:image" content="https://opentakeoff.kentucky-ai.com/og-card.png" />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="640" />
     <meta property="og:image:alt" content="OpenTakeoff — three patient rooms traced wall to wall in wood and a VCT room on a real floor finish plan, 743.4 SF of wood flooring counted." />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="OpenTakeoff — the first takeoff canvas built for people and AI agents" />
     <meta name="twitter:description" content="A free, open-source PDF takeoff canvas. Trace plans and get quantities yourself, or point an AI agent at the same engine over MCP. Runs entirely in your browser, no account." />
-    <meta name="twitter:image" content="https://opentakeoff.netlify.app/og-card.png" />
+    <meta name="twitter:image" content="https://opentakeoff.kentucky-ai.com/og-card.png" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -27,7 +27,7 @@
         "applicationCategory": "BusinessApplication",
         "applicationSubCategory": "Construction Estimating Software",
         "operatingSystem": "Any (runs in a web browser)",
-        "url": "https://opentakeoff.netlify.app",
+        "url": "https://opentakeoff.kentucky-ai.com",
         "description": "Free, open-source PDF takeoff software for construction and flooring estimating. The first takeoff engine an AI agent can drive natively over the Model Context Protocol (MCP), with the same measuring math and provenance as a human at the canvas.",
         "offers": {
           "@type": "Offer",

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.30",
+  "version": "0.9.31",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.30",
+      "version": "0.9.31",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -3,7 +3,7 @@
   "name": "io.github.Kentucky-ai/opentakeoff",
   "title": "OpenTakeoff",
   "description": "Construction takeoff for AI agents: load plans, set scale, measure, count, export with provenance.",
-  "websiteUrl": "https://opentakeoff.netlify.app",
+  "websiteUrl": "https://opentakeoff.kentucky-ai.com",
   "repository": {
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -6,7 +6,7 @@ OpenTakeoff is the open-source alternative to subscription takeoff tools (STACK,
 
 ## Docs
 
-- [Live app](https://opentakeoff.netlify.app): try it in the browser — includes a one-click sample plan (a real medical-center floor finish plan)
+- [Live app](https://opentakeoff.kentucky-ai.com): try it in the browser — includes a one-click sample plan (a real medical-center floor finish plan)
 - [README](https://github.com/Kentucky-ai/opentakeoff#readme): features, quick start, deploy-it-yourself, build-on-top-of-it
 - [MCP server](https://github.com/Kentucky-ai/opentakeoff/blob/main/mcp/README.md): `npx -y opentakeoff-mcp` on the [npm registry](https://www.npmjs.com/package/opentakeoff-mcp) — `load_plan`, `read_sheet_text`, `set_scale`, `one_click`, `view_sheet`, `takeoff_summary`, `export_takeoff`, and more
 - [Agent usage guide + example transcript](https://github.com/Kentucky-ai/opentakeoff/blob/main/docs/MCP.md): how an agent opens a plan, adopts the scale, traces rooms, and exports a takeoff over MCP

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -20,4 +20,4 @@ Allow: /
 User-agent: CCBot
 Allow: /
 
-Sitemap: https://opentakeoff.netlify.app/sitemap.xml
+Sitemap: https://opentakeoff.kentucky-ai.com/sitemap.xml

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://opentakeoff.netlify.app/</loc>
+    <loc>https://opentakeoff.kentucky-ai.com/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
Moves the declared production host from `opentakeoff.netlify.app` to `opentakeoff.kentucky-ai.com`. The DNS is live, Netlify has the domain primary, and Let's Encrypt has issued — both hosts currently answer 200, which this PR resolves.

**Why:** with no custom domain there is no Search Console property (so no keyword data can exist at all), link equity accrues to `netlify.app`, and software directories decline a vendor subdomain as a product listing. That last one is the blocker on the AlternativeTo / SourceForge listings, which are what LLMs actually quote when someone asks for takeoff software.

### What changed
- **Canonical surfaces:** `web/index.html` (canonical, OG, Twitter, JSON-LD), `sitemap.xml`, `robots.txt`, `llms.txt`, `.well-known/mcp.json`.
- **Registry surfaces:** `mcp/server.json` `websiteUrl`, both `.mcpb` builders' `homepage`.
- **Docs:** all four READMEs, `AGENTS.md`, `AGENT_BRIEF.md`, `docs/DEPLOYMENT.md`, bug-report template.
- **`netlify.toml`:** an explicit 301 from the old host.
- **mcp 0.9.30 → 0.9.31** across all four surfaces the guard enforces.

### Three things worth reading
**The redirect is declared, not assumed.** Netlify documents an automatic 301 from `.netlify.app` to the primary custom domain. After promoting the domain, `curl` showed both hosts still returning 200 — so it is written into `netlify.toml` with `force = true`. Without `force`, a redirect loses to an existing static asset at the same path, and on a static site that is every path. Two hosts serving identical 200s splits link equity; a canonical tag expresses a preference, it does not stop a crawler indexing the other host.

**The shields badge needs `kentucky--ai.com`.** shields.io treats a single `-` as its label/message/color separator, so the un-escaped hostname would split the color off and break the badge in all four READMEs. Verified the escaped URL returns 200.

**The version bump is not ceremonial.** `websiteUrl` in `server.json` is what directory indexers and agent clients read, and the registry only ever sees a published `mcp-v*` tag — so without the bump the registry would keep advertising the old host indefinitely.

`CHANGELOG.md` keeps its old-URL reference; that entry is history.

Typecheck and build pass; built `dist/` carries the new host in index.html, sitemap and robots.