### PR TITLE
Silence the uppFor exhaustive-deps warning with a documented disable (#195)

### DIFF
--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -893,6 +893,7 @@ export default function TakeoffCanvas() {
   // to RENDER_SCALE, so the dep list is honest.
   const rollTakeoff = useMemo(
     () => computeRollTakeoff(conditions, shapes, (k) => panelImgs[k] || null, (k) => uppFor(k)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- uppFor reads scales (listed) + renderScalesRef pinned to RENDER_SCALE; listing it would re-figure rolls on every render
     [conditions, shapes, panelImgs, scales]   // uppFor: scales + a pinned ref
   );
   const rollByCond = rollTakeoff.byCond;


### PR DESCRIPTION
Verified before silencing, per the issue's ask: `uppFor` (TakeoffCanvas.jsx:883) is `panelGeom.uppFor(scales, renderScalesRef.current, key)` — `scales` is already in the dep list, `renderScalesRef` is a ref pinned to RENDER_SCALE, and `panelGeom` is a pure module import. The dep list is honest, so the deliberate exception is now machine-visible instead of a warning to scroll past.

`cd web && npm run check` prints zero warnings.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)