### PR TITLE
CI runs the bench and fails when results.json stops matching the engine (#198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,18 @@ jobs:
       - run: node scripts/fetch-voice-model.mjs
       - run: npm run typecheck
       - run: npm test
+      # The bench is a ruler, and a ruler that silently stops matching the
+      # engine is worse than no ruler (#198): results.json is committed, the
+      # runner rewrites it on every run, and nothing used to compare the two —
+      # so an engine PR could change flood-fill behavior without the numbers
+      # moving in the same PR, where a reviewer would see the delta.
+      - run: npm run bench
+      - name: bench/results.json must match what the engine produces (#198)
+        run: |
+          git diff --exit-code -- bench/results.json || {
+            echo "::error file=web/bench/results.json::the engine no longer produces the committed bench numbers — run 'cd web && npm run bench' and commit the regenerated results.json in this PR so the delta is reviewed with the change that caused it"
+            exit 1
+          }
       - run: npm run build
 
   mcp:


### PR DESCRIPTION
Two findings while working the issue:

**Part 1 (regenerate) is a no-op on current main.** `npm run bench` from a clean tree now leaves `results.json` untouched — the runner rewrites the file unconditionally on every run and today's output is byte-identical to what's committed. The drift observed 08-03 healed when later engine merges (the One-Click swing follow-ups) moved the probes back. Nothing to regenerate, which also means no hidden regression to eyeball.

**CI never ran the bench at all.** The web job was typecheck + test + build, so beyond the stale-file problem, the bench's own gates weren't protecting `main`. This PR adds `npm run bench` to the job, followed by the guard the issue asked for: `git diff --exit-code -- bench/results.json`, with an error message that tells the author exactly what to run and why.

The stated judgment call, stated: every engine PR now carries its bench-result diff. That's the intent — the delta gets reviewed in the PR that caused it.

Verified locally: guard exits 0 on a clean tree, exits 1 (naming the file) on a simulated drift.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)