### PR TITLE
Tidy shape + vertex-drag auto-straighten (ringTidy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-09 — rings you can live with: Tidy + drag auto-straighten
+
+### Added
+- **Tidy shape** (Edit menu) — one geometry pass on the selected area takeoff: collinear/micro-segment staircase chains collapse, vertices sitting on CAD endpoints hold exactly (drifted ones pull home), near-square walls square up between those anchors, and genuinely angled walls (beyond 8°) are left alone. Built for mask-derived rings — a One-Click or detect_rooms trace carries vertices no hand can drag straight. One ⌘Z undoes the pass, and a result that would move the shape's area by more than 3% is refused outright: worst case the ring comes back untouched. Raster-traced shapes tidy without endpoint anchoring (a scan has no true endpoints), which is exactly simplify + square. New pure lib `web/src/lib/ringTidy.ts` (no React, no DOM; `test/ringTidy.test.ts`), stamped on provenance as `edits.tidy`.
+- **Vertex drag auto-straighten** — with the 45° toggle on, a dragged vertex locks onto its neighbors' axes, so the wall being edited stays straight instead of drifting a pixel off square; near a corner both axes lock and the corner lands square. Endpoint snap still wins (a real corner beats an inferred axis); toggling 45° off frees the hand for genuinely angled work.
+
 ## 2026-08-05 — a real hole, reconciled; opentakeoff-mcp 0.9.38
 
 ### Added

--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -2831,7 +2831,7 @@ function perpDist(p: Point, a: Point, b: Point): number {
   if (!L) return Math.hypot(p[0] - a[0], p[1] - a[1]);
   return Math.abs(dy * p[0] - dx * p[1] + b[0] * a[1] - b[1] * a[0]) / L;
 }
-function rdpOpen(pts: Point[], eps: number): Point[] {
+export function rdpOpen(pts: Point[], eps: number): Point[] {
   if (pts.length < 3) return pts.slice();
   let imax = 0, dmax = -1;
   const a = pts[0], b = pts[pts.length - 1];

--- a/web/src/lib/ringTidy.ts
+++ b/web/src/lib/ringTidy.ts
@@ -1,0 +1,172 @@
+// ── ringTidy — one geometry pass for rings people have to live with ────────
+// A mask-derived ring (One-Click flood, detect_rooms, a raster trace) carries
+// dozens–hundreds of staircase vertices; hand-dragging them can't produce a
+// straight wall. One shared pass fixes what the trace left jagged:
+//   anchorFlags   which vertices sit ON a CAD endpoint (re-derived from the
+//                 snap grid — per-vertex snap provenance is never stored)
+//   tidyRing      consolidate collinear/micro-segment runs BETWEEN anchors,
+//                 then Manhattan-lock near-axis runs — anchors never move,
+//                 and drifted near-anchor vertices pull home
+//   axisLockPoint live-drag helper: a dragged vertex locks onto its
+//                 neighbors' axes so edited walls stay straight
+// Pure TypeScript (no React, no DOM) like the rest of lib/. Everything works
+// in image px (panel-local); callers convert at their edges. Discipline
+// inherited from snapVertices: never return something worse than the input —
+// a degenerate or area-drifting result falls back to the input ring.
+import { rdpOpen, rdpClosed, ringArea } from "./oneclick.js";
+import type { Point, NearestFn } from "./oneclick.js";
+
+// A vertex within this of a CAD endpoint counts as anchored to it. Tight on
+// purpose: anchors are vertices the snap tail ALREADY placed on an endpoint,
+// not vertices that merely pass near one.
+export const ANCHOR_TOL_PX = 1.25;
+
+// A segment within this many degrees of horizontal/vertical is a wall the
+// drafter meant straight; beyond it, a genuinely angled wall — left alone.
+export const AXIS_TOL_DEG = 8;
+
+export interface TidyResult {
+  ring: Point[];
+  anchors: boolean[];
+  changed: boolean;
+}
+
+export interface TidyOpts {
+  nearest?: NearestFn | null;   // snap-grid lookup; null → no anchors (pure simplify+ortho)
+  eps?: number;                 // RDP tolerance, image px (1.5 — the mask-trace law)
+  minGapPx?: number;            // micro-segment collapse distance (2, snapVertices' own)
+  axisTolDeg?: number;
+  maxAreaDriftPct?: number;     // guardrail: result drifting more area than this is refused
+  anchorTol?: number;
+}
+
+export function anchorFlags(ring: Point[], nearest?: NearestFn | null, tol = ANCHOR_TOL_PX): boolean[] {
+  if (!nearest) return ring.map(() => false);
+  return ring.map(([x, y]) => {
+    const hit = nearest(x, y, tol);
+    return !!hit && Math.hypot(hit[0] - x, hit[1] - y) <= tol;
+  });
+}
+
+// Consolidate: RDP each run between anchors (anchors are run endpoints, so
+// they survive by construction); with no anchors at all, closed-ring RDP.
+// Then collapse micro-segments, always keeping the anchor of a close pair.
+function consolidate(ring: Point[], anchors: boolean[], eps: number, minGapPx: number): { ring: Point[]; anchors: boolean[] } {
+  const n = ring.length;
+  const anchorIdx: number[] = [];
+  for (let i = 0; i < n; i++) if (anchors[i]) anchorIdx.push(i);
+  let out: Point[], outAnchors: boolean[];
+  if (!anchorIdx.length) {
+    out = rdpClosed(ring, eps);
+    outAnchors = out.map(() => false);
+  } else {
+    out = []; outAnchors = [];
+    for (let k = 0; k < anchorIdx.length; k++) {
+      const a = anchorIdx[k], b = anchorIdx[(k + 1) % anchorIdx.length];
+      const run: Point[] = [];
+      for (let i = a; ; i = (i + 1) % n) { run.push(ring[i]); if (i === b && run.length > 1) break; if (run.length > n + 1) break; }
+      const simp = rdpOpen(run, eps);
+      for (let j = 0; j < simp.length - 1; j++) {        // b opens the next run
+        out.push(simp[j]); outAnchors.push(j === 0);
+      }
+    }
+  }
+  // micro-segment collapse — drop the non-anchor of any too-close pair
+  const keep = out.map(() => true);
+  for (let i = 0; i < out.length; i++) {
+    if (!keep[i]) continue;
+    const j = (i + 1) % out.length;
+    if (!keep[j] || i === j) continue;
+    if (Math.hypot(out[i][0] - out[j][0], out[i][1] - out[j][1]) <= minGapPx) {
+      if (outAnchors[j] && !outAnchors[i]) keep[i] = false; else if (!outAnchors[j]) keep[j] = false;
+    }
+  }
+  const ring2: Point[] = [], anchors2: boolean[] = [];
+  for (let i = 0; i < out.length; i++) if (keep[i]) { ring2.push([out[i][0], out[i][1]]); anchors2.push(outAnchors[i]); }
+  return { ring: ring2, anchors: anchors2 };
+}
+
+// Manhattan pass: classify each segment against the ORIGINAL geometry (one
+// stable read — no drift across iterations), then relax non-anchor endpoints
+// so near-horizontal segments share a y and near-vertical segments share an
+// x. An anchored endpoint donates its coordinate; two anchors on one segment
+// pin it as drawn (the CAD knows better than the tolerance). A few
+// Gauss-Seidel passes settle chains between anchors.
+function orthogonalize(ring: Point[], anchors: boolean[], axisTolDeg: number): Point[] {
+  const n = ring.length;
+  if (n < 3) return ring;
+  const tol = Math.tan((axisTolDeg * Math.PI) / 180);
+  const cls: number[] = new Array(n).fill(0);   // 0 none, 1 horizontal, 2 vertical
+  for (let i = 0; i < n; i++) {
+    const a = ring[i], b = ring[(i + 1) % n];
+    const dx = Math.abs(b[0] - a[0]), dy = Math.abs(b[1] - a[1]);
+    if (dx === 0 && dy === 0) continue;
+    if (dy <= dx * tol) cls[i] = 1; else if (dx <= dy * tol) cls[i] = 2;
+  }
+  const out: Point[] = ring.map((p) => [p[0], p[1]]);
+  for (let pass = 0; pass < 4; pass++) {
+    for (let i = 0; i < n; i++) {
+      if (!cls[i]) continue;
+      const j = (i + 1) % n;
+      const c = cls[i] === 1 ? 1 : 0;           // horizontal locks y, vertical locks x
+      const A = out[i], B = out[j];
+      if (anchors[i] && anchors[j]) continue;
+      const target = anchors[i] ? A[c] : anchors[j] ? B[c] : (A[c] + B[c]) / 2;
+      if (!anchors[i]) A[c] = target;
+      if (!anchors[j]) B[c] = target;
+    }
+  }
+  return out;
+}
+
+// Returns { ring, anchors, changed } — `changed` false means the input came
+// back (already tidy, or the guardrail refused the result).
+export function tidyRing(ring: Point[], opts: TidyOpts = {}): TidyResult {
+  const { nearest = null, eps = 1.5, minGapPx = 2,
+          axisTolDeg = AXIS_TOL_DEG, maxAreaDriftPct = 3,
+          anchorTol = ANCHOR_TOL_PX } = opts;
+  if (!Array.isArray(ring) || ring.length < 3)
+    return { ring, anchors: (ring || []).map(() => false), changed: false };
+  // Anchored vertices are also PULLED onto their endpoint — a freshly snapped
+  // trace is already there (no-op); a hand-dragged vertex that drifted a hair
+  // off its corner comes home.
+  const flags: boolean[] = [];
+  const pulled: Point[] = ring.map(([x, y]) => {
+    const hit = nearest ? nearest(x, y, anchorTol) : null;
+    if (hit && Math.hypot(hit[0] - x, hit[1] - y) <= anchorTol) { flags.push(true); return [hit[0], hit[1]]; }
+    flags.push(false); return [x, y];
+  });
+  const c = consolidate(pulled, flags, eps, minGapPx);
+  const tidy = c.ring.length >= 3 ? orthogonalize(c.ring, c.anchors, axisTolDeg) : ring;
+  const anchors = c.ring.length >= 3 ? c.anchors : flags;
+  const a0 = Math.abs(ringArea(ring)), a1 = Math.abs(ringArea(tidy));
+  const drift = a0 > 0 ? (Math.abs(a1 - a0) / a0) * 100 : 100;
+  if (tidy.length < 3 || drift > maxAreaDriftPct)
+    return { ring, anchors: flags, changed: false };
+  const changed = tidy.length !== ring.length ||
+    tidy.some((p, i) => p[0] !== ring[i][0] || p[1] !== ring[i][1]);
+  return { ring: tidy, anchors, changed };
+}
+
+// Live-drag straightener: lock the dragged point onto its neighbors' axes so
+// the two segments it carries stay straight as they were meant to be. Each
+// axis locks independently to whichever neighbor is nearer on that axis
+// (within tolPx) — near a corner both lock and the corner lands square.
+// Callers pass tolPx in image px (screen tolerance ÷ zoom). Endpoint snap
+// (osnap) wins upstream — call this only when no CAD endpoint claimed the
+// point.
+export function axisLockPoint(p: Point, prev: Point | null, next: Point | null, tolPx: number): { pt: Point; locked: boolean } {
+  const out: Point = [p[0], p[1]];
+  let locked = false;
+  for (const c of [0, 1] as const) {
+    let best: number | null = null;
+    for (const nb of [prev, next]) {
+      if (!nb) continue;
+      const d = Math.abs(p[c] - nb[c]);
+      if (d <= tolPx && (best === null || d < Math.abs(p[c] - best)))
+        best = nb[c];
+    }
+    if (best !== null) { out[c] = best; locked = true; }
+  }
+  return { pt: out, locked };
+}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -45,6 +45,7 @@ import { mintTwin, variantTag,
   markRowLocal, dropRowLocal, followFamily, splitFromFamily, promoteOnDelete } from "../lib/variants.ts";
 import { isGoogleConfigured, isSignedIn, isAllowedDomain, getAccessToken, orgDomainHint } from "../lib/google/auth.js";
 import { extractVectorGeometry, buildMask, floodRegionSealed, sealRadiiFor, doorWedgeCapPx, minPassRadiusFor, oneClickRing, ringArea, MASK_MAX_DIM, MIN_PASS_FT, SENS_STRICT, SENS_BALANCED, SENS_AGGRESSIVE } from "../lib/oneclick";
+import { tidyRing, axisLockPoint } from "../lib/ringTidy";
 import { traceConfidence, floodSignals } from "../lib/confidence";
 import { buildRasterMask, RASTER_MIN_IMG_FRAC, RASTER_MIN_SEGS, RASTER_RDP_EPS } from "../lib/rastermask";
 // PDF layer roles (#85): the pure name→role classifier and the override
@@ -2864,7 +2865,23 @@ export default function TakeoffCanvas() {
         const sp = panelByKey(d.shape.sheet_id);
         let vn;
         if (d.kind === "vertex") {
-          const [slx, sly] = ocSnap(sp.key, p[0] - sp.xOffset, p[1], !!d.shape.origin?.raster_traced);   // snap the corner to true endpoints (never on a raster-traced shape — see ocSnap)
+          let [slx, sly] = ocSnap(sp.key, p[0] - sp.xOffset, p[1], !!d.shape.origin?.raster_traced);   // snap the corner to true endpoints (never on a raster-traced shape — see ocSnap)
+          // auto-straighten (45° toggle): when no endpoint claimed the point,
+          // the dragged vertex locks onto its neighbors' axes — an edited wall
+          // stays straight instead of drifting a pixel off square. Osnap wins;
+          // toggle 45° off to place genuinely angled vertices freely.
+          if (angleOn && slx === p[0] - sp.xOffset && sly === p[1]) {
+            const base = d.prev.verts_norm, n0 = base.length;
+            const closed = d.shape.measure_role !== "linear" && d.shape.measure_role !== "surface_area";
+            const pick = (i) => {
+              let k = i;
+              if (closed) k = ((i % n0) + n0) % n0; else if (k < 0 || k >= n0) return null;
+              const v = base[k];
+              return v ? [v[0] * sp.img.w, v[1] * sp.img.h] : null;
+            };
+            const lock = axisLockPoint([slx, sly], pick(d.vIndex - 1), pick(d.vIndex + 1), 8 / tfRef.current.scale);
+            if (lock.locked) [slx, sly] = lock.pt;
+          }
           vn = d.prev.verts_norm.map((v, i) => (i === d.vIndex ? [slx / sp.img.w, sly / sp.img.h] : v));
         } else if (d.kind === "edge") {
           // translate BOTH endpoints of the line by the drag delta; each end snaps
@@ -3851,6 +3868,34 @@ export default function TakeoffCanvas() {
       type: "geom", id: sel.id, editKind: "vertex",
       verts_norm: vn, computed: recomputeShape({ ...sel, verts_norm: vn }), prev: geomSnapshot(sel),
     });
+  }
+  // ── Tidy — one geometry pass on the selected takeoff (ringTidy) ────────────
+  // A mask-derived ring (One-Click, detect_rooms, a raster trace) carries
+  // dozens–hundreds of staircase vertices no hand can drag straight. One pass:
+  // collinear/micro-segment chains collapse, vertices on CAD corners hold
+  // (drifted ones pull home), near-square walls square up between anchors;
+  // genuinely angled walls survive. Closed rings only — a linear run's
+  // vertices are its measurement. The lib refuses any result that moves area
+  // >3%; worst case the shape comes back untouched. One command = one ⌘Z.
+  function tidySelected() {
+    const sel = shapes.find((s) => s.id === selectedId);
+    if (!sel) return;
+    if (sel.measure_role === "count" || sel.measure_role === "linear" || sel.measure_role === "surface_area") {
+      setCommitMsg("Tidy works on area takeoffs — a linear run's vertices are its measurement."); return;
+    }
+    const sp = panelByKey(sel.sheet_id);
+    if (!sp || !sp.img.w || (sel.verts_norm || []).length < 3) return;
+    const grid = snapGridsRef.current.get(sel.sheet_id);
+    const rt = !!sel.origin?.raster_traced;   // no true endpoints on a scan — pure simplify+square
+    const ringPx = sel.verts_norm.map(([nx, ny]) => [nx * sp.img.w, ny * sp.img.h]);
+    const r = tidyRing(ringPx, { nearest: (x, y, dd) => (!rt && grid ? nearestSnap(grid, x, y, dd) : null) });
+    if (!r.changed) { setCommitMsg("Nothing to tidy — this takeoff is already clean."); return; }
+    const vn = r.ring.map(([x, y]) => [x / sp.img.w, y / sp.img.h]);
+    dispatchShape({
+      type: "geom", id: sel.id, editKind: "tidy",
+      verts_norm: vn, computed: recomputeShape({ ...sel, verts_norm: vn }), prev: geomSnapshot(sel),
+    });
+    setCommitMsg(`Tidied — ${ringPx.length} → ${r.ring.length} vertices; corners held to plan lines, near-square walls squared. ⌘Z undoes.`);
   }
   // ── markup (cloud / callout / text) — annotations, not measurements ─────────
   // markupDraft holds STAGE px (so the live preview spans panels); a markup
@@ -6129,6 +6174,7 @@ export default function TakeoffCanvas() {
               "divider",
               { id: "flipH", label: "Flip Horizontal", disabled: !selectedId, onSelect: () => flipSelected("h") },
               { id: "flipV", label: "Flip Vertical", disabled: !selectedId, onSelect: () => flipSelected("v") },
+              { id: "tidy", label: "Tidy shape", disabled: !selectedId, onSelect: tidySelected },
               "divider",
               { id: "finish", icon: "check", label: `Finish shape${poly.length ? ` (${poly.length} pts)` : ""}`, shortcut: "↵", disabled: !finishOk, onSelect: finishShape },
               { id: "undopt", icon: "undo", label: "Undo last point", shortcut: "⌘Z", disabled: !poly.length, onSelect: () => setPoly((q) => q.slice(0, -1)) },

--- a/web/test/ringTidy.test.ts
+++ b/web/test/ringTidy.test.ts
@@ -1,0 +1,83 @@
+// ringTidy tests — the tidy pass is pure (no DOM), so it runs straight under
+// node. Synthetic rings with known tidy answers. Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { anchorFlags, axisLockPoint, tidyRing } from "../src/lib/ringTidy";
+import { ringArea } from "../src/lib/oneclick";
+import type { Point, NearestFn } from "../src/lib/oneclick";
+
+const corners: Point[] = [[0, 0], [100, 0], [100, 100], [0, 100]];
+const nearest: NearestFn = (x, y, d) => {
+  let best: Point | null = null, bd = d;
+  for (const c of corners) {
+    const dd = Math.hypot(c[0] - x, c[1] - y);
+    if (dd <= bd) { bd = dd; best = c; }
+  }
+  return best;
+};
+
+// 100-vertex staircase square whose corners sit ±0.6 px off CAD endpoints.
+function staircase(): Point[] {
+  const out: Point[] = [];
+  for (let k = 0; k < 4; k++) {
+    const [ax, ay] = corners[k], [bx, by] = corners[(k + 1) % 4];
+    for (let t = 0; t < 25; t++) {
+      const u = t / 25;
+      const x = ax + (bx - ax) * u, y = ay + (by - ay) * u;
+      out.push(bx !== ax ? [x, y + (t % 2 ? 0.6 : -0.6)] : [x + (t % 2 ? 0.6 : -0.6), y]);
+    }
+  }
+  return out;
+}
+
+test("tidyRing collapses a staircase square to its CAD corners, axis-true", () => {
+  const r = tidyRing(staircase(), { nearest });
+  assert.equal(r.changed, true);
+  assert.ok(r.ring.length <= 8, `expected ≤8 verts, got ${r.ring.length}`);
+  assert.ok(Math.abs(Math.abs(ringArea(r.ring)) - 10000) / 10000 < 0.03, "area drifted");
+  for (const c of corners) {
+    assert.ok(r.ring.some((p) => Math.hypot(p[0] - c[0], p[1] - c[1]) < 0.01), `corner ${c} lost`);
+  }
+  for (let i = 0; i < r.ring.length; i++) {
+    const p = r.ring[i], q = r.ring[(i + 1) % r.ring.length];
+    assert.ok(Math.abs(p[0] - q[0]) < 1e-9 || Math.abs(p[1] - q[1]) < 1e-9, "wall not axis-true");
+  }
+});
+
+test("tidyRing leaves a genuinely angled wall alone and holds area", () => {
+  const angled: Point[] = [[0, 0], [100, 0], [100, 60], [40, 60], [0, 20]]; // 45° cut corner
+  const r = tidyRing(angled, { nearest: null });
+  const hasDiag = r.ring.some((p, i) => {
+    const q = r.ring[(i + 1) % r.ring.length];
+    return Math.abs(p[0] - q[0]) > 5 && Math.abs(p[1] - q[1]) > 5;
+  });
+  assert.ok(hasDiag, "45° wall was flattened");
+  const a0 = Math.abs(ringArea(angled));
+  assert.ok(Math.abs(Math.abs(ringArea(r.ring)) - a0) / a0 < 0.03, "area drifted");
+});
+
+test("tidyRing never returns something worse than the input", () => {
+  const tiny: Point[] = [[0, 0], [1, 0], [0, 1]];
+  const r = tidyRing(tiny, { nearest: null, minGapPx: 5 }); // collapse would degenerate it
+  assert.ok(r.ring.length >= 3);
+});
+
+test("axisLockPoint locks a near-vertical drag to the neighbor's x", () => {
+  const l = axisLockPoint([50.4, 80], [50, 0], null, 2);
+  assert.equal(l.locked, true);
+  assert.deepEqual(l.pt, [50, 80]);
+});
+
+test("axisLockPoint locks both axes near a square corner", () => {
+  const l = axisLockPoint([99.2, 0.7], [100, 50], [0, 0], 2);
+  assert.deepEqual(l.pt, [100, 0]);
+});
+
+test("axisLockPoint leaves a far point unlocked", () => {
+  assert.equal(axisLockPoint([70, 80], [50, 0], null, 2).locked, false);
+});
+
+test("anchorFlags flags only vertices within tolerance of an endpoint", () => {
+  const f = anchorFlags([[0, 0.5], [50, 50]], nearest);
+  assert.deepEqual(f, [true, false]);
+});


### PR DESCRIPTION
A mask-derived ring (One-Click, detect_rooms, raster trace) carries
dozens-hundreds of staircase vertices no hand can drag straight.

- web/src/lib/ringTidy.ts: pure shared pass — CAD-endpoint anchor
  detection (drifted vertices pull home), RDP consolidation BETWEEN
  anchors, Manhattan orthogonalize of near-axis walls (8 deg) with
  angled walls left alone, never-worse guardrail (area drift >3%
  returns the input). test/ringTidy.test.ts under node:test.
- Tidy shape in the Edit menu: one geom command = one undo, stamps
  edits.tidy on provenance; raster-traced shapes tidy anchor-free.
- Vertex drag under the 45 deg toggle locks the dragged point to its
  neighbors' axes; endpoint osnap wins; toggle off to escape.

Verified in the running app: One-Click WORKROOM trace -> Tidy squares
the ring, area holds; npm run check green (typecheck/lint/test/bench/
build).
