### PR TITLE
Bump nanoid 3.3.18 + brace-expansion 1.1.18: three dev-scope DoS advisories npm audit caught and Dependabot didn't

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2923,9 +2923,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3957,9 +3957,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Repo-health sweep finding: `npm audit` reports two highs on main that **Dependabot never alerted on** (it caught the same nanoid on spline-app but not here — don't trust the alerts tab alone).

- `nanoid` 3.3.16 → 3.3.18 — GHSA-2v37-7h3g-55p8, `customAlphabet`/`customRandom` spin forever at size 0.
- `brace-expansion` 1.1.16 → 1.1.18 — GHSA-mh99-v99m-4gvg + GHSA-rgw5-rvv9-x895, unbounded expansion → OOM DoS.

Both dev-scope transitives under the vite/build chain; neither appears in the shipped bundle. Lockfile-only, inside existing semver ranges, `npm run check` green, `npm audit` now reports zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)