### PR TITLE
docs: add self-hosting guide covering the nginx .mjs MIME gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,9 @@ npm run build      # → web/dist/  (static; host it anywhere)
 
 The repo ships a root `netlify.toml`, so the button is genuinely one-click. The same
 `web/dist/` works on **Vercel, GitHub Pages, Cloudflare Pages, S3** — anywhere that serves
-static files. Deployment notes and the optional AI backend:
+static files. Running your own reverse proxy (nginx, Docker, Tailscale, etc.)? Check
+[`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md) first — there's one MIME-type gotcha worth
+knowing about. Deployment notes and the optional AI backend:
 [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
 
 ## Build on top of it

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,39 @@
+# Self-hosting — the one gotcha
+
+OpenTakeoff's own production deploy is Netlify-only (see
+[`DEPLOYMENT.md`](DEPLOYMENT.md)), and Netlify's CDN gets content types right
+automatically. If you build `web/dist` yourself and serve it from your own
+reverse proxy instead — nginx behind Docker or Tailscale, for example — there's
+one gotcha worth knowing about before you hit it blind.
+
+## `.mjs` served as `application/octet-stream`
+
+`npm run build` emits some chunks as `.mjs` (ES modules). Stock nginx's
+default `mime.types` file has no entry for `.mjs` — only `.js` — so it falls
+back to `application/octet-stream`. Browsers enforce strict MIME checking on
+`<script type="module">`, so the module is silently refused and the app fails
+to load with no obvious error beyond the browser console.
+
+**Fix — if you control `mime.types`:** add `mjs` to the existing
+`application/javascript` line:
+
+```nginx
+# /etc/nginx/mime.types
+types {
+    application/javascript                          js mjs;
+    ...
+}
+```
+
+**Fix — if you're on a base image and don't want to fork `mime.types`**
+(e.g. a minimal `nginx:alpine` Docker image), override just this extension in
+your server block instead — this doesn't touch the rest of the type table:
+
+```nginx
+location ~* \.mjs$ {
+    default_type application/javascript;
+}
+```
+
+Confirmed against a real self-hosted deployment (Docker + nginx + Tailscale) —
+not hypothetical.


### PR DESCRIPTION
Production only deploys to Netlify, which handles content types
correctly, so this gap was invisible until a self-hoster hit it:
stock nginx has no mime.types entry for .mjs and serves it as
application/octet-stream, which browsers reject for module scripts.
