### PR TITLE
Scale gate, the missing half: an agent-set scale needs a human's confirmation

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -175,7 +175,10 @@ registers.
 Two rules carry over from the app unchanged:
 
 - **The scale gate.** No quantity leaves the server without a scale on that
-  sheet. A detected scale note is a suggestion the agent must adopt
+  sheet — and a scale the agent sets is **unconfirmed until a human confirms
+  it in the canvas** (`confirmed: false` on the reply,
+  `scale_unconfirmed` on the summary, `scale_confirmed` on the
+  export/report). A detected scale note is a suggestion the agent must adopt
   explicitly (`set_scale { use_detected: true }`); measuring tools refuse
   with the exact hint (`Set the scale for <sheet> first — use set_scale
   (detected: 1/4" = 1'-0").`), and a bare `one_click` returns px-only numbers

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -164,6 +164,10 @@ Change a sheet's scale after tracing and **every shape on that sheet re-prices t
 
 If the scale you set disagrees with the note printed on the sheet, the chip warns you: **≠ 1/4″ = 1′-0″** in amber, with the tooltip *"You set X, but the plan notes Y — double-check before tracing."*
 
+### Agent-set scales need your confirmation
+
+A scale that arrives from an agent takeoff (an MCP session's export, imported here) is **unconfirmed**: the Scale chip reads **⚠ 1/4″ = 1′-0″ — confirm** in amber, the gallery badge reads **scale ⚠ confirm**, and the Report's provenance footer marks the sheet *agent-set, UNCONFIRMED*. Quantities still compute — but they stand on a number no person has verified. Check a printed dimension (K) first, then pick **Confirm agent-set scale** from the Scale menu; any scale action of your own (a standard pick, plan-says, calibrate, or recalibrate) also counts as confirmation, because your act is the verification.
+
 ### Metric
 
 The **`ft` / `m`** toggle beside the Scale chip switches the whole display layer: readouts, shape chips, panels, the Report, CSV, and the Marked Set legend read in m² / m (the SY column retires), and Calibrate takes meters. It's display only — takeoffs are stored unit-agnostically, so flipping it never changes a measurement. Supporting-material coverage rates stay as entered.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -107,7 +107,7 @@ includes document text, shape vertices, or result payload content.
 |---|---|
 | `load_plan` | Open a plan PDF from disk. Default replaces the whole session; **`merge: true` ADDS the document to the working set** (#152) — plans + schedule + addenda as one takeoff, sheet graph spanning the whole set, marked set covering every worked sheet. Returns per-sheet dims, title-block `sheet_number`, and the detected drawn scale where present. |
 | `sheet_info` | One sheet's dims, vector segment count, scale status, detected suggestion, committed shape count. |
-| `set_scale` | Set a sheet's scale — exactly one of `label`, `upp`, `calibrate {p1, p2, feet}`, `use_detected`. |
+| `set_scale` | Set a sheet's scale — exactly one of `label`, `upp`, `calibrate {p1, p2, feet}`, `use_detected`. **Lands unconfirmed** (`confirmed: false`) until a human confirms in the canvas — see Scale rules. |
 | `one_click` | One-Click Area at (x, y): the sealed flood engine bounded by the plan linework, traced, vertices snapped — the SAME feet-true arguments the canvas passes at a click (gap sealing up to a door width, door-swing wedge inclusion, the half-foot minimum-passage rule), so an MCP trace and a canvas click at one seed measure the same square footage (pinned against the bench corpus goldens in `test/parity.test.ts`). Every trace carries the engine's account of itself: `confidence` 0–1 with `confidence_factors` naming each deduction (`gap_sealed_px`, `door_wedges`, `min_pass_delta`, …) — a review prioritizer, never a verification; a low score is a `view_sheet {overlay: true}` audit prompt, not a fact. On a SCANNED sheet (no usable linework) the flood falls back automatically to the rendered pixels — same engine as the canvas — with `raster_traced` disclosed on the reply and on the shape's origin (#154). Pass `condition` to commit (the full account stamps `origin` centrally at the commit); `role: "deduct"` subtracts. |
 | `detect_rooms` | Batch One-Click: reads every room-number label off the sheet's text layer and floods each — one call instead of `read_sheet_text` + reasoning + N `one_click` calls, through the SAME sealed engine per room (confidence + the engine account ride each room and its committed origin). Only cleanly-traced rooms come back; everything skipped is counted and reasoned in `withheld` (degenerate / duplicate / implausible / unresolved), never dropped silently. To commit: `assign_from_schedule: true` routes each room through its OWN room-finish schedule row and commits under the FLOOR finish that row states (rooms the schedule can't answer for return in `unresolved[]` with reasons and re-seedable coordinates); or pass `condition` to commit every room under one stated tag. |
 | `measure_polygon` | Area + perimeter of a polygon you supply (min 3 verts). Requires scale. |
@@ -216,6 +216,14 @@ space, which makes them usable directly as click targets.
 
 - A detected scale is a **suggestion** — it is never applied automatically.
   Adopting it is always an explicit `set_scale { use_detected: true }`.
+- **Agent proposes, human confirms.** `set_scale` is the agent surface, so a
+  scale set here lands **unconfirmed** (`confirmed: false` in the reply).
+  Quantities still flow — the gate is a flag, never a refusal — but
+  `takeoff_summary` names the affected sheets in
+  `scale_unconfirmed`, and the export/report carry `scale_confirmed` so the
+  canvas can ask the estimator to confirm (its scale menu grows a
+  **Confirm agent-set scale** row on import). Only a human act in the canvas
+  clears the flag.
 - `measure_polygon` and `measure_line` refuse without a scale:
   `Set the scale for <sheet> first — use set_scale (detected: <label>).`
 - `one_click` without a scale returns a **px-only preview**

--- a/mcp/src/importing.ts
+++ b/mcp/src/importing.ts
@@ -55,11 +55,15 @@ export async function importTakeoff(session: Session, filePath: string) {
   session.approvals = sanitizeApprovals(payload.approvals);
   // scales: mergeTakeoffImport already applied "the session's calibration wins
   // per sheet" — adopt the merged rows onto sheets this document actually has
-  for (const row of (payload.sheets as { sheet_id: string; units_per_px: number; scale_source?: string }[]) ?? []) {
+  for (const row of (payload.sheets as { sheet_id: string; units_per_px: number; scale_source?: string; scale_confirmed?: boolean }[]) ?? []) {
     const s = session.sheetOrNull(row.sheet_id);
     if (s && s.upp == null && row.units_per_px > 0) {
       s.upp = row.units_per_px;
       s.scaleSource = row.scale_source ?? "upp";
+      // scale gate — transport, not minting (the approvals rule): an
+      // unconfirmed agent scale arriving by file STAYS unconfirmed; absent
+      // means confirmed (a human-era payload, or one a human confirmed)
+      if (row.scale_confirmed === false) s.scaleConfirmed = false;
     }
   }
 

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -68,6 +68,7 @@ export const setScaleOutput = {
   upp: z.number().describe("Real feet per image px at render scale 2.0"),
   label: z.string().optional().describe("The standard scale label, when set by label or detected note"),
   source: z.enum(["label", "upp", "calibrate", "detected"]),
+  confirmed: z.boolean().describe("Always false here: set_scale is the agent surface, and an agent-set scale stays UNCONFIRMED until a human confirms it in the canvas — quantities still flow, wearing the caveat"),
   warning: z.string().optional().describe("Present when the sheet carries MULTIPLE distinct scale notes (#153) — enlarged plans/details likely; region measurements under a disagreeing note will warn"),
 };
 
@@ -275,6 +276,7 @@ export const takeoffSummaryOutput = {
     ea: z.number(),
     sy_net: z.number(),
   }).passthrough(),
+  scale_unconfirmed: z.array(z.string()).optional().describe("Sheets whose scale is agent-set and no human has confirmed — these totals stand on an unverified scale; verify against a stated dimension or confirm in the canvas"),
 };
 
 /** The app's exact save payload (opentakeoff.takeoff_canvas.v1). */

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -375,6 +375,11 @@ interface SheetState {
   /** how the scale was set — report provenance (export_report scale_source),
    * canvas vocabulary: "standard" | "upp" | "calibrated" | "detected" */
   scaleSource?: string;
+  /** scale gate — agent proposes, human confirms. set_scale is the AGENT
+   * surface, so a scale set here is false until a human confirms it in the
+   * canvas (the flag rides export/import). undefined = confirmed: a human's
+   * own canvas act, or a payload that predates the flag. */
+  scaleConfirmed?: boolean;
   text: { str: string; x: number; y: number }[];
   page: PageHandle;
   // lazy per-sheet caches (built once, reused by identity)
@@ -1029,8 +1034,13 @@ export class Session {
     // uses the canvas's report vocabulary so export_report's scale_source
     // reads the same as an app-side report.v1
     s.scaleSource = source === "label" ? "standard" : source === "calibrate" ? "calibrated" : source;
+    // Scale gate: this is the agent surface, so the scale lands UNCONFIRMED —
+    // quantities still flow (the gate is a flag, never a refusal), but every
+    // scaled reply carries the caveat and the canvas asks the estimator to
+    // confirm. Only a human act (canvas scale UI) clears it.
+    s.scaleConfirmed = false;
     return {
-      sheet: s.key, upp, ...(label ? { label } : {}), source,
+      sheet: s.key, upp, ...(label ? { label } : {}), source, confirmed: false,
       // #153 — several DISTINCT scale notes on one sheet means enlarged plans
       // or details are likely; region measurements will warn when a
       // disagreeing note sits inside them, but say it up front too
@@ -1050,6 +1060,11 @@ export class Session {
     }
     const region = expandForScaleNotes({ x0, y0, x1, y1 });
     const adoptedLabel = s.detected && Math.abs(s.detected.upp - s.upp) / s.upp <= 1e-6 ? s.detected.label : undefined;
+    // (scale gate: the unconfirmed flag deliberately does NOT ride every
+    // measure reply — the agent set the scale itself, so repeating it per
+    // quantity is noise. It surfaces where the numbers cross a boundary:
+    // set_scale's confirmed:false, takeoff_summary's scale_unconfirmed, the
+    // export/report scale_confirmed, and the canvas's confirm affordance.)
     return mixedScaleWarning(textItemsInRegion(s.page, region), s.page.viewport, s.upp, adoptedLabel);
   }
 
@@ -2480,7 +2495,10 @@ export class Session {
     const rows = conditionTotals(this.conditions, this.shapes, this.seamCtx()) as Record<string, unknown>[];
     // strip presentation fields for a compact agent-facing reply
     const lean = rows.map(({ color, fill, hatch, materials, ...rest }) => rest);
-    return { conditions: lean, totals: grandTotals(rows) };
+    // Scale gate: name every sheet whose scale is agent-set and unconfirmed —
+    // a totals reply must say what its numbers stand on
+    const unconfirmed = [...this.sheets.values()].filter((s) => s.upp != null && s.scaleConfirmed === false).map((s) => s.key);
+    return { conditions: lean, totals: grandTotals(rows), ...(unconfirmed.length ? { scale_unconfirmed: unconfirmed } : {}) };
   }
 
   deleteShape(id: string) {
@@ -3323,7 +3341,14 @@ export class Session {
       schema: ANN_SCHEMA,
       project_name: "",
       units: "imperial",
-      sheets: [...this.sheets.values()].filter((s) => s.upp != null).map((s) => ({ sheet_id: s.key, units_per_px: s.upp })),
+      sheets: [...this.sheets.values()].filter((s) => s.upp != null).map((s) => ({
+        sheet_id: s.key, units_per_px: s.upp,
+        // provenance rides the payload (it used to be dropped here): the canvas
+        // hydrates scale_source for its report and scale_confirmed for the
+        // scale gate's confirm affordance — absent = confirmed (pre-flag docs)
+        ...(s.scaleSource ? { scale_source: s.scaleSource } : {}),
+        ...(s.scaleConfirmed === false ? { scale_confirmed: false } : {}),
+      })),
       conditions: this.conditions,
       shapes: this.shapes,
       markups: this.markups,
@@ -3358,7 +3383,7 @@ export class Session {
       projectName,
       rows,
       bySheet: sheetTotals(this.conditions, this.shapes),
-      scaleInfo: [...this.sheets.values()].filter((s) => s.upp != null).map((s) => ({ sheet_id: s.key, scale_source: s.scaleSource ?? "unknown" })),
+      scaleInfo: [...this.sheets.values()].filter((s) => s.upp != null).map((s) => ({ sheet_id: s.key, scale_source: s.scaleSource ?? "unknown", scale_confirmed: s.scaleConfirmed !== false })),
       markups: this.markups,
       rfis: [],
       rollGoods: rollReportRows(byCond, rows),

--- a/mcp/test/conformance.test.ts
+++ b/mcp/test/conformance.test.ts
@@ -128,6 +128,9 @@ test("every tool: canonical valid call → schema-valid structuredContent mirror
   const scale = await callOk(client, "set_scale", { sheet: KEY, use_detected: true });
   assert.equal(scale.source, "detected");
   assert.ok(Math.abs(scale.upp - UPP) < 1e-12);
+  // scale gate: set_scale is the agent surface — the scale lands UNCONFIRMED
+  // and every downstream surface says so until a human confirms in the canvas
+  assert.equal(scale.confirmed, false);
 
   // measure-only batch detection: every returned room is scaled, nothing commits
   const rooms = await callOk(client, "detect_rooms", { sheet: KEY });
@@ -158,6 +161,7 @@ test("every tool: canonical valid call → schema-valid structuredContent mirror
 
   const summary = await callOk(client, "takeoff_summary");
   assert.equal(summary.conditions.length, 3);
+  assert.deepEqual(summary.scale_unconfirmed, [KEY], "totals name the sheets standing on an unconfirmed agent-set scale");
   const byTag = Object.fromEntries(summary.conditions.map((r: any) => [r.finish_tag, r]));
   assert.equal(byTag["VCT-1"].floor_sf, 100);
   assert.equal(byTag["RB-1"].lf, 20);
@@ -166,7 +170,9 @@ test("every tool: canonical valid call → schema-valid structuredContent mirror
 
   const exported = await callOk(client, "export_takeoff");
   assert.equal(exported.schema, "opentakeoff.takeoff_canvas.v1");
-  assert.deepEqual(exported.sheets, [{ sheet_id: KEY, units_per_px: UPP }]);
+  // scale gate: provenance rides the payload — scale_source for the report,
+  // scale_confirmed:false so the canvas asks the estimator to confirm on import
+  assert.deepEqual(exported.sheets, [{ sheet_id: KEY, units_per_px: UPP, scale_source: "detected", scale_confirmed: false }]);
   assert.equal(exported.conditions.length, 3);
   assert.equal(exported.shapes.length, 3);
   assert.deepEqual(exported.shapes.map((s: any) => s.measure_role), ["floor_area", "floor_area", "linear"]);
@@ -257,6 +263,7 @@ test("every tool: canonical valid call → schema-valid structuredContent mirror
   assert.equal(mLine.qty, Math.ceil(mLine.basis_qty / 300 - 1e-9), "order qty = basis ÷ coverage, rounded up to whole purchase units");
   assert.deepEqual(report.materials, [{ name: "Adhesive", unit: "gal", qty: mLine.qty }], "project-wide roll-up sums by (name, unit)");
   assert.ok(["standard", "upp", "calibrated", "detected"].includes(report.sheets[0].scale_source), "scale provenance rides the report");
+  assert.equal(report.sheets[0].scale_confirmed, false, "an MCP-set scale reports UNCONFIRMED until a human confirms it in the canvas");
   assert.ok(report.totals.total_sf_net > report.totals.total_sf, "grand totals carry waste");
   assert.equal(report.project_name, null, "a headless session has no project of its own — null, never ''");
   assert.deepEqual(report.roll_goods, [], "roll_goods (#136) always emitted — empty until a condition carries a roll_setup");

--- a/web/src/components/PlanNavigator.jsx
+++ b/web/src/components/PlanNavigator.jsx
@@ -50,7 +50,7 @@ export default function PlanNavigator({
   // presentation + exit
   canClose, onExit, initialMode = "plan", cloudMode,
   // plan-set (gallery) data
-  sheets, getDoc, scales, detectedScales, shapes, labels, onLabel, onDetect,
+  sheets, getDoc, scales, detectedScales, scaleUnconfirmed = {}, shapes, labels, onLabel, onDetect,
   thumbCacheRef, busyRef, openTabs, onOpen,
   onAddFiles, onClosePdf, onRemoveFromProject,
   onCloseProject, onBrowseProjects,
@@ -522,8 +522,9 @@ export default function PlanNavigator({
                   {levels[key] && <span title="Level" style={{ fontSize: 9.5, fontFamily: "var(--f-mono)", color: "var(--ink-muted)", border: "1px solid var(--ink-faint)", padding: "1px 5px" }}>{levels[key]}</span>}
                   {isOpenTab && <span title="Already open as a tab" style={{ fontSize: 9.5, fontFamily: "var(--f-mono)", color: "var(--cobalt)", textTransform: "uppercase", letterSpacing: "0.08em" }}>open</span>}
                   {cnt > 0 && <span style={{ fontFamily: "var(--f-mono)", fontSize: 10.5, color: "var(--ink-muted)" }}>{cnt}▦</span>}
-                  <span style={{ fontSize: 10, fontWeight: 600, whiteSpace: "nowrap", color: scales[key] ? "var(--c-positive)" : detectedScales[key] ? "var(--c-warning)" : "var(--c-danger)" }}>
-                    {scales[key] ? "scale ✓" : detectedScales[key] ? `plan: ${detectedScales[key].label}` : "no scale"}
+                  <span style={{ fontSize: 10, fontWeight: 600, whiteSpace: "nowrap", color: scales[key] ? (scaleUnconfirmed[key] === false ? "var(--c-warning)" : "var(--c-positive)") : detectedScales[key] ? "var(--c-warning)" : "var(--c-danger)" }}
+                    title={scales[key] && scaleUnconfirmed[key] === false ? "Scale set by an agent — no person has confirmed it. Open the sheet and confirm from the scale menu." : undefined}>
+                    {scales[key] ? (scaleUnconfirmed[key] === false ? "scale ⚠ confirm" : "scale ✓") : detectedScales[key] ? `plan: ${detectedScales[key].label}` : "no scale"}
                   </span>
                 </div>
               </div>

--- a/web/src/components/ReportPanel.jsx
+++ b/web/src/components/ReportPanel.jsx
@@ -658,7 +658,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
           {/* meta footer: scale provenance · attribution · disclaimer */}
           <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-muted)", lineHeight: 1.6, borderTop: "1px solid var(--ink-faint)", paddingTop: 6, marginBottom: 12 }}>
             {scaleInfo.map((si) => (
-              <div key={si.sheet_id}>{sheetLabel ? sheetLabel(si.sheet_id) : si.sheet_id} — {!si.scale_source || si.scale_source === "unknown" ? "scale set — provenance unrecorded" : si.scale_source}</div>
+              <div key={si.sheet_id}>{sheetLabel ? sheetLabel(si.sheet_id) : si.sheet_id} — {!si.scale_source || si.scale_source === "unknown" ? "scale set — provenance unrecorded" : si.scale_source}{si.scale_confirmed === false ? <span style={{ color: "var(--c-warning)", fontWeight: 700 }}> · agent-set, UNCONFIRMED</span> : null}</div>
             ))}
             <div>Generated {new Date().toLocaleDateString()}</div>
             <div>{DISCLAIMER}</div>

--- a/web/src/lib/totals.js
+++ b/web/src/lib/totals.js
@@ -466,7 +466,11 @@ export function reportJson({ projectName = "", rows = [], bySheet = [], scaleInf
     schema: "opentakeoff.report.v1",
     project_name: projectName || null,
     generated_with: "OpenTakeoff",
-    sheets: scaleInfo.map((si) => ({ sheet_id: si.sheet_id, sheet: label(si.sheet_id), scale_source: si.scale_source ?? si.source ?? "unknown" })),
+    // scale_confirmed (scale gate): false = an agent set this sheet's scale and
+    // no human confirmed it — the report's consumer should treat those sheets'
+    // quantities as standing on an unverified number. Absent input = true
+    // (human-era payloads predate the flag).
+    sheets: scaleInfo.map((si) => ({ sheet_id: si.sheet_id, sheet: label(si.sheet_id), scale_source: si.scale_source ?? si.source ?? "unknown", scale_confirmed: si.scale_confirmed !== false })),
     // custom-column values APPEND after materials (row key order otherwise
     // untouched). Iterating the DEFINED columns — never raw attrs — naturally
     // drops orphaned colIds; attrValue (the shared assigned-value rule) keeps

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -281,6 +281,12 @@ export default function TakeoffCanvas() {
 
   const [scales, setScales] = useState({});
   const [scaleSources, setScaleSources] = useState({}); // scale provenance for the report — typically "calibrated" | "standard" | "detected", but any string a newer build wrote is kept verbatim; sheets that predate the flag export "unknown"
+  // Scale gate — agent proposes, human confirms. A key mapped to false means an
+  // AGENT set this sheet's scale (MCP set_scale, arriving by import) and no
+  // human has confirmed it; absent = confirmed. Any human scale act
+  // (rescaleSheet) clears the flag — the act is the confirmation.
+  const [scaleUnconfirmed, setScaleUnconfirmed] = useState({});
+  const confirmScale = (key) => setScaleUnconfirmed((m) => { if (!(key in m)) return m; const n = { ...m }; delete n[key]; return n; });
   const [detectedScales, setDetectedScales] = useState({}); // { sheetKey: {upp,label,multi} } read off the plan text
   const [darkMode, setDarkMode] = useState(() => { try { return localStorage.getItem("opentakeoff_dark") === "1"; } catch { return false; } });
   useEffect(() => { try { localStorage.setItem("opentakeoff_dark", darkMode ? "1" : "0"); } catch { /* private mode */ } }, [darkMode]);
@@ -1283,6 +1289,7 @@ export default function TakeoffCanvas() {
     }
     const sc = {};
     const src = {};
+    const unconf = {};
     for (const s of a.sheets || []) if (s.sheet_id && s.units_per_px) {
       sc[s.sheet_id] = s.units_per_px;
       // provenance is additive — old projects lack it (report shows "unknown").
@@ -1290,9 +1297,11 @@ export default function TakeoffCanvas() {
       // whitelist would silently strip a future value on load and the next
       // autosave would persist the loss. Display already falls back safely.
       if (typeof s.scale_source === "string" && s.scale_source) src[s.sheet_id] = s.scale_source;
+      if (s.scale_confirmed === false) unconf[s.sheet_id] = false;   // scale gate: agent-set, awaiting a human
     }
     setScales(sc);
     setScaleSources(src);
+    setScaleUnconfirmed(unconf);
     // display units ride the payload (additive) — a metric project opens metric
     // on any machine; payloads without the field keep this browser's toggle
     if (a.units === "metric" || a.units === "imperial") setUnits(a.units);
@@ -1862,7 +1871,7 @@ export default function TakeoffCanvas() {
     // units is additive and diff-only (the sheet_levels convention): imperial —
     // the default — omits the key, so an old imperial project's payload is
     // byte-identical on round-trip; only a metric project carries the field.
-    return { project_name: projectName, ...(units === "metric" ? { units } : {}), ...(Object.values(clientInfo).some((v) => v && String(v).trim()) ? { client_info: clientInfo } : {}), sheets: Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px, ...(scaleSources[sheet_id] ? { scale_source: scaleSources[sheet_id] } : {}) })), conditions, ...(conditionColumns.length ? { condition_columns: conditionColumns } : {}), ...(shapeLabels.length ? { shape_labels: shapeLabels } : {}), ...(pinned.length ? { palette: pinned } : {}), shapes, markups, rfis, ...(approvals.length ? { approvals } : {}), ...(rules.length ? { rules } : {}), sheet_group: sheetGroup, last_group: lastGroup, sheet_tabs: openTabs, ...(stitches.length ? { stitches } : {}), ...(Object.keys(sheetLevels).length ? { sheet_levels: sheetLevels } : {}), ...(Object.keys(layerOverrides).length ? { layer_overrides: layerOverrides } : {}), ...(Object.keys(provCounters.shapes_deleted).length ? { provenance_counters: provCounters } : {}) };
+    return { project_name: projectName, ...(units === "metric" ? { units } : {}), ...(Object.values(clientInfo).some((v) => v && String(v).trim()) ? { client_info: clientInfo } : {}), sheets: Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px, ...(scaleSources[sheet_id] ? { scale_source: scaleSources[sheet_id] } : {}), ...(scaleUnconfirmed[sheet_id] === false ? { scale_confirmed: false } : {}) })), conditions, ...(conditionColumns.length ? { condition_columns: conditionColumns } : {}), ...(shapeLabels.length ? { shape_labels: shapeLabels } : {}), ...(pinned.length ? { palette: pinned } : {}), shapes, markups, rfis, ...(approvals.length ? { approvals } : {}), ...(rules.length ? { rules } : {}), sheet_group: sheetGroup, last_group: lastGroup, sheet_tabs: openTabs, ...(stitches.length ? { stitches } : {}), ...(Object.keys(sheetLevels).length ? { sheet_levels: sheetLevels } : {}), ...(Object.keys(layerOverrides).length ? { layer_overrides: layerOverrides } : {}), ...(Object.keys(provCounters.shapes_deleted).length ? { provenance_counters: provCounters } : {}) };
   };
   // Runtime restore of a saved payload — the Revisions panel's Restore lands
   // here. A runtime load (unlike mount) can interrupt work in
@@ -3056,6 +3065,7 @@ export default function TakeoffCanvas() {
       setPrevScale({ key, upp: prior, source: scaleSources[key] || "standard" });
     }
     setScales((s) => ({ ...s, [key]: upp }));
+    confirmScale(key);   // scale gate: a human scale act IS the confirmation
     // The vector mask bakes the scale in (its hatch-pitch cap and seal radii
     // are feet-true via mppf), so a recalibrated sheet must rebuild its masks
     // on next use — a mask built against the old calibration is exactly the
@@ -5918,16 +5928,30 @@ export default function TakeoffCanvas() {
   // plan notes a different scale than the one you picked
   const scaleDet = detectedScales[focusPanel.key];
   const scaleMismatch = !!(unitsPerPx && stdValue && scaleDet && Math.abs(scaleDet.upp - unitsPerPx) > 1e-9);
-  const scaleFace = !unitsPerPx ? "Set scale…" : `${scaleMismatch ? "≠" : "✓"} ${stdValue || "custom"}`;
+  // scale gate: an agent-set scale no human has confirmed wears the warning
+  // face until it's confirmed (menu row below) or replaced by a human act
+  const scaleNeedsConfirm = !!unitsPerPx && scaleUnconfirmed[focusPanel.key] === false;
+  const scaleFace = !unitsPerPx ? "Set scale…" : scaleNeedsConfirm ? `⚠ ${stdValue || "custom"} — confirm` : `${scaleMismatch ? "≠" : "✓"} ${stdValue || "custom"}`;
   const scaleFaceStyle = !unitsPerPx
     ? { border: "1px dashed var(--c-danger)", color: "var(--c-danger)" }
-    : scaleMismatch
+    : scaleMismatch || scaleNeedsConfirm
       ? { border: "1px solid var(--c-warning)", color: "var(--c-warning)" }
       : { border: "1px solid var(--c-positive)", color: "var(--c-positive)" };
-  const scaleTitle = scaleMismatch
-    ? `You set ${stdValue}, but the plan notes ${scaleDet.label} on ${labelFor(focusPanel)} — double-check before tracing.`
-    : `Set the scale for ${labelFor(focusPanel)} — remembered per sheet${groupKeys.length > 1 ? " (targets the sheet you last clicked)" : ""}`;
+  const scaleTitle = scaleNeedsConfirm
+    ? `An agent set this sheet's scale — no person has confirmed it. Check it against a printed dimension (K), then confirm from this menu; quantities stand on this number.`
+    : scaleMismatch
+      ? `You set ${stdValue}, but the plan notes ${scaleDet.label} on ${labelFor(focusPanel)} — double-check before tracing.`
+      : `Set the scale for ${labelFor(focusPanel)} — remembered per sheet${groupKeys.length > 1 ? " (targets the sheet you last clicked)" : ""}`;
   const scaleItems = [];
+  if (scaleNeedsConfirm) {
+    scaleItems.push({
+      id: "confirm-scale", icon: "check", tint: "var(--c-warning)",
+      label: "Confirm agent-set scale",
+      title: `This scale arrived from an agent takeoff and no person has verified it. Best practice: Check a dimension (K) against a printed dimension string first — a wrong scale poisons every quantity on the sheet.`,
+      onSelect: () => confirmScale(focusPanel.key),
+    });
+    scaleItems.push("divider");
+  }
   // one-step revert after a rescale that changed committed quantities on this
   // sheet — the oops-hatch for a mistyped recalibrate (ephemeral, one slot)
   if (prevScale && prevScale.key === focusPanel.key && scales[focusPanel.key] !== prevScale.upp) {
@@ -7598,7 +7622,7 @@ export default function TakeoffCanvas() {
           onExit={() => setView("canvas")}
           initialMode={view === "picker" ? "browse" : "plan"}
           cloudMode={cloudMode}
-          sheets={sheets} getDoc={docFor} scales={scales} detectedScales={detectedScales}
+          sheets={sheets} getDoc={docFor} scales={scales} detectedScales={detectedScales} scaleUnconfirmed={scaleUnconfirmed}
           shapes={shapes} labels={galleryLabels}
           onLabel={(k, lbl) => setGalleryLabels((m) => (m[k] === lbl ? m : { ...m, [k]: lbl }))}
           onDetect={(k, det) => setDetectedScales((d) => (d[k]?.label === det.label ? d : { ...d, [k]: det }))}
@@ -7648,7 +7672,7 @@ export default function TakeoffCanvas() {
           clientInfo={clientInfo} onClientInfo={setClientInfo} units={units}
           conditions={conditions} shapes={shapes} markups={markups} rfis={rfis}
           conditionColumns={conditionColumns} shapeLabels={shapeLabels}
-          scaleInfo={Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px, scale_source: scaleSources[sheet_id] || "unknown" }))}
+          scaleInfo={Object.entries(scales).map(([sheet_id, units_per_px]) => ({ sheet_id, units_per_px, scale_source: scaleSources[sheet_id] || "unknown", scale_confirmed: scaleUnconfirmed[sheet_id] !== false }))}
           rollByCond={rollByCond}
           provenanceCounters={provCounters}
           sheetLabel={(k) => tabLabel(k)}

--- a/web/test/totals.test.ts
+++ b/web/test/totals.test.ts
@@ -142,10 +142,12 @@ test("reportJson: v1 key set pinned — top level, sheets[], markups[], by_sheet
   assert.equal(j.rfis[0].linked_markups, 1);          // the mk-2 cloud links to rfi-1
   assert.deepEqual(j.rfis[0].linked_sheets, ["Sheet sh1"]);
   assert.equal(j.rfis[0].sheet, "Sheet sh1");
-  // sheets: provenance under scale_source (the persisted-payload key); NO
+  // sheets: provenance under scale_source (the persisted-payload key) +
+  // scale_confirmed (the scale gate — absent input = true, human-era); NO
   // units_per_px — that figure is internal (RENDER_SCALE-coupled)
-  assert.deepEqual(Object.keys(j.sheets[0]), ["sheet_id", "sheet", "scale_source"]);
+  assert.deepEqual(Object.keys(j.sheets[0]), ["sheet_id", "sheet", "scale_source", "scale_confirmed"]);
   assert.equal(j.sheets[0].scale_source, "calibrated");
+  assert.equal(j.sheets[0].scale_confirmed, true);
   assert.equal(j.sheets[0].sheet, "Sheet sh1");
   // id + rfi_id appended after the original four (additive-only v1 schema)
   // condition_id + condition APPEND after rfi_id (additive-only v1). `condition`
@@ -202,6 +204,15 @@ test("reportJson: unrecorded provenance exports as the literal 'unknown'", () =>
 test("reportJson: legacy 'source' key still read as a fallback", () => {
   const j = reportJson({ scaleInfo: [{ sheet_id: "s1", source: "detected" }] });
   assert.equal(j.sheets[0].scale_source, "detected");
+});
+
+test("reportJson: scale gate — agent-set unconfirmed rides through as false, absent = true", () => {
+  const j = reportJson({ scaleInfo: [
+    { sheet_id: "s1", scale_source: "detected", scale_confirmed: false },
+    { sheet_id: "s2", scale_source: "calibrated" },
+  ] });
+  assert.equal(j.sheets[0].scale_confirmed, false);
+  assert.equal(j.sheets[1].scale_confirmed, true);
 });
 
 test("reportJson: custom columns — definitions emitted; row values filter orphans/non-strings/empties", () => {


### PR DESCRIPTION
`set_scale` is the agent surface, but a scale set there was indistinguishable from one a person picked in the Scale menu — and a wrong scale is every number wrong at once. This adds the confirm half of the scale gate: **agent proposes, human confirms.**

- **MCP:** `set_scale` replies `confirmed: false` and the sheet stays unconfirmed until a human acts in the canvas. Quantities still flow — the gate is a flag, never a refusal — surfacing at the boundaries: `takeoff_summary.scale_unconfirmed`, `export_takeoff` sheets rows (which also stop dropping `scale_source`), `export_report` per-sheet provenance.
- **Import is transport, not minting** (the approvals rule): an unconfirmed scale arriving by file stays unconfirmed; absent = confirmed, so pre-flag payloads never nag.
- **Canvas:** amber `⚠ … — confirm` chip face, a leading **Confirm agent-set scale** menu row, `scale ⚠ confirm` gallery badge, and an `agent-set, UNCONFIRMED` marker in the Report's provenance footer. Any human scale act self-confirms — the act is the verification. `report.v1` `sheets[]` gains `scale_confirmed` (additive, always emitted).

Tested: conformance pins the reply flag, summary list, and export provenance; totals.test pins the report key; verified in the running app — import shows the amber chip, Confirm clears it, and the pre-existing `≠ plan says` mismatch warning then takes over.