### PR TITLE
chore(mcp): 0.9.39 — version bump the scale-confirm gate owed

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.38",
+      "version": "0.9.39",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.38",
+  "version": "0.9.39",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.38",
+      "version": "0.9.39",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.38",
+  "version": "0.9.39",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.38",
+      "version": "0.9.39",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
PR #235 changed mcp/src without the bump mcp-version-guard requires (that check was red at merge). This squares it: package.json, server.json (.version + .packages[0].version), and web/public/.well-known/mcp.json move to 0.9.39 together. Publish after merge: `git tag mcp-v0.9.39 && git push origin mcp-v0.9.39`.