### PR TITLE
UI overhaul 1/N: ice/HUD palette, instrument token scales, Z ladder, overlay collision fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,11 +76,12 @@ The tests cover the pure math (`web/test/geometry.test.ts`, `web/test/totals.tes
 
 ## Conventions
 
-- **SVG presentation attributes take literal colors** (CSS vars don't resolve there): cobalt `#1f3fc7`, danger `#b03a26`, positive `#1f6b4a`. DOM/HTML chrome may use `var(--…)` from `tokens.css`.
+- **SVG presentation attributes take literal colors** (CSS vars don't resolve there): cobalt `#1f3fc7`, danger `#b03a26`, positive `#1f6b4a` — centralized in `web/src/lib/ui.js` (`SVG`, with HUD-dark counterparts via `svgAccent(isDark)`). DOM/HTML chrome may use `var(--…)` from `tokens.css`.
 - Condition palettes (`PALETTE` in `web/src/components/hatches.jsx`, the seeded condition colors in `FLOORING_DEFAULTS` in `web/src/lib/canvasConstants.js`, and the mirrored copies in `mcp/src/session.ts`) are **user data** — don't re-theme them.
 - Waste applies only in the report (order quantities), never to live measured numbers.
 - Keyboard shortcuts are single letters registered on `window` (see `docs/USER_GUIDE.md` §15); toolbar menus pause them via `menuDepthRef`.
-- Brand voice: paper/ink/cobalt, drafting-table language. No vendor mimicry.
+- Brand voice: **precision instrument** (2026-08 overhaul). Light theme = "ice": bright white surfaces on a cool field, cool-slate neutrals, cobalt the one saturated thing. Dark theme = "HUD": true-black cockpit, electric blue `#3f8cff`, phosphor `--glow` on exactly five elements (active tool face, status verb, hero quantity, primary CTA, calibration dot). Square corners; the single sanctioned radius is `--r-1` on floating chrome. Mono tabular numerals on every readout. Drafting-table language stays. No vendor mimicry.
+- Layout/spacing/type come from the token scales in `tokens.css` (`--sp-*`, `--fs-*`, `--ctl-*`); zIndex comes from the `Z` ladder in `web/src/lib/ui.js`. No new magic numbers.
 
 ## Docs to keep in sync when you change behavior
 

--- a/web/src/components/UserGuide.jsx
+++ b/web/src/components/UserGuide.jsx
@@ -14,6 +14,7 @@
 // USER_GUIDE.md §15, which is itself maintained against the code — if a
 // shortcut changes, §15 and this table move together.
 import { useEffect } from "react";
+import { Z } from "../lib/ui.js";
 
 const GUIDE_URL = "https://github.com/Kentucky-ai/opentakeoff/blob/main/docs/USER_GUIDE.md";
 
@@ -118,7 +119,7 @@ export default function UserGuide({ onClose }) {
     <div
       onClick={onClose}
       style={{
-        position: "fixed", inset: 0, zIndex: 9000, background: "rgba(0,0,0,0.45)",
+        position: "fixed", inset: 0, zIndex: Z.modal, background: "var(--scrim)",
         display: "flex", alignItems: "flex-start", justifyContent: "center", padding: "5vh 16px", overflow: "auto",
       }}>
       <div
@@ -129,7 +130,7 @@ export default function UserGuide({ onClose }) {
         className="panel"
         style={{
           width: "min(760px, 100%)", background: "var(--paper-bright)", color: "var(--ink)",
-          border: "1px solid var(--ink-faint)", borderRadius: 12, padding: "22px 26px 26px",
+          border: "1px solid var(--ink-faint)", borderRadius: 0, padding: "22px 26px 26px",
           boxShadow: "var(--shadow-2)",
         }}>
         <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12, marginBottom: 4 }}>

--- a/web/src/lib/ui.js
+++ b/web/src/lib/ui.js
@@ -1,0 +1,119 @@
+// UI constants — the JS mirror of styles/tokens.css for the inline-style world.
+// tokens.css stays the single source of truth for anything CSS can resolve;
+// this module exists for the two places CSS variables can't reach:
+//   1. numeric zIndex values (the Z ladder)
+//   2. SVG presentation attributes, which don't resolve var() (AGENTS.md)
+// plus spreadable style fragments so a thousand inline objects converge on
+// one vocabulary without a class-name migration.
+
+/* Z ladder — every zIndex in the app comes from here. Replaces the ad-hoc
+   1..70 (+9000) spread. Grid-shell areas (topbar/rail/props/status) don't
+   stack at all and need no entry. */
+export const Z = {
+  stage: 0,      // canvas bitmap + SVG overlay
+  canvasUi: 10,  // crosshair, live readout, accept pill, voice chip, hint pill
+  popover: 20,   // menus, tooltips, tool flyouts
+  drawer: 30,    // docked/sliding panels (Takeoffs, Report, Layers…)
+  scrim: 40,
+  modal: 50,     // dialogs incl. the in-app guide
+  toast: 60,     // status toasts, banners that must beat modals
+  dragGhost: 70, // drag previews — always on top
+};
+
+/* Sanctioned SVG literals — CSS vars don't resolve in SVG presentation
+   attributes, so these are real hex values, centralized. Light values match
+   --cobalt / --c-danger / --c-positive; the DARK set matches the HUD theme.
+   Pick with svgAccent(isDark) at the callsite when the overlay is theme-aware. */
+export const SVG = {
+  cobalt: "#1f3fc7",
+  danger: "#b03a26",
+  positive: "#1f6b4a",
+  dark: {
+    cobalt: "#3f8cff",
+    danger: "#ff6b57",
+    positive: "#35d48f",
+  },
+};
+
+export function svgAccent(isDark) {
+  return isDark ? SVG.dark : SVG;
+}
+
+/* Spreadable style fragments — inline-style vocabulary. All values are
+   var() strings so themes keep working. Usage:
+     style={{ ...S.chip, marginLeft: "auto" }}                          */
+export const S = {
+  /* mono chip: calibration chip, scale chip, small pill controls */
+  chip: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    fontFamily: "var(--f-mono)",
+    fontSize: "var(--fs-xs)",
+    fontVariantNumeric: "tabular-nums",
+    background: "var(--surface-pop)",
+    border: "1px solid var(--ink-faint)",
+    borderRadius: "var(--r-1)",
+    padding: "3px 9px",
+    color: "var(--ink)",
+  },
+
+  /* tool-rail face */
+  toolTile: {
+    width: "var(--ctl-l)",
+    height: "var(--ctl-l)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: "var(--r-1)",
+    border: "1px solid transparent",
+    background: "none",
+    color: "var(--ink)",
+    cursor: "pointer",
+  },
+
+  /* uppercase mono micro-label (rail group headers, panel section heads) */
+  monoLabel: {
+    fontFamily: "var(--f-mono)",
+    fontSize: "var(--fs-2xs)",
+    letterSpacing: ".1em",
+    textTransform: "uppercase",
+    color: "var(--ink-muted)",
+    userSelect: "none",
+  },
+
+  /* numeric readout — always tabular */
+  monoReadout: {
+    fontFamily: "var(--f-mono)",
+    fontVariantNumeric: "tabular-nums",
+    fontSize: "var(--fs-s)",
+    color: "var(--ink)",
+  },
+
+  /* key/value row in the props panel */
+  kvRow: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: "var(--sp-1) 0",
+  },
+
+  /* panel section block */
+  panelSection: {
+    padding: "var(--sp-4)",
+    borderBottom: "1px solid var(--ink-faint)",
+  },
+
+  /* ink tooltip chip */
+  tooltip: {
+    background: "var(--ink)",
+    color: "var(--paper-bright)",
+    fontFamily: "var(--f-mono)",
+    fontSize: "var(--fs-xs)",
+    padding: "4px 8px",
+    borderRadius: "var(--r-1)",
+    whiteSpace: "nowrap",
+    boxShadow: "var(--shadow-2)",
+    zIndex: Z.popover,
+  },
+};

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -18,6 +18,7 @@ import { Link, useNavigate } from "react-router";
 import * as pdfjsLib from "pdfjs-dist";
 import workerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 import { store, isStaleTabError, STALE_TAB_MESSAGE, projectIdFromUrl } from "../lib/store.js";
+import { Z } from "../lib/ui.js";
 import { seedStampLibrary, instantiateStamp, markupToStampElement } from "../lib/stamps.js";
 import { extractSvgPrimitives, svgToStamp } from "../lib/svgImport.js";
 import { transformPath, svgPlacedBox } from "../lib/svgpath.js";
@@ -7387,19 +7388,24 @@ export default function TakeoffCanvas() {
           </div>
         </div>
 
+        {/* bottom-center stack: status line + correction-rule banner share one
+            flex column so they can never overlap, even when either wraps.
+            column-reverse keeps the status line pinned at the bottom with the
+            banner above it — a commitMsg never hides the decision. */}
+        {(commitMsg || ruleOffer || ruleStage) && (
+        <div style={{ position: "absolute", left: "50%", bottom: 14, transform: "translateX(-50%)", zIndex: Z.canvasUi, display: "flex", flexDirection: "column-reverse", alignItems: "center", gap: 8, maxWidth: "82%", pointerEvents: "none" }}>
         {/* status line — the transient message bar (was the right end of the old
             conditions bar): floats bottom-center over the canvas, never blocks input */}
         {commitMsg && (
-          <div style={{ position: "absolute", left: "50%", bottom: 14, transform: "translateX(-50%)", maxWidth: "70%", zIndex: 6, pointerEvents: "none", padding: "6px 12px", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", boxShadow: "var(--shadow-1)", fontSize: 12, color: isDangerMsg(commitMsg) ? "var(--c-danger)" : "var(--c-positive)" }}>
+          <div style={{ maxWidth: "85%", padding: "6px 12px", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", boxShadow: "var(--shadow-1)", fontSize: 12, color: isDangerMsg(commitMsg) ? "var(--c-danger)" : "var(--c-positive)" }}>
             {commitMsg}
           </div>
         )}
         {/* correction-rule banner (#88): offer after a qualifying Cut Out, then
-            the staged batch's Apply/Cancel. Sits above the status line so a
-            commitMsg never hides the decision. Dismiss/Cancel are always one
+            the staged batch's Apply/Cancel. Dismiss/Cancel are always one
             click — a rule is never applied silently. */}
         {(ruleOffer || ruleStage) && (
-          <div style={{ position: "absolute", left: "50%", bottom: 44, transform: "translateX(-50%)", zIndex: 7, display: "flex", alignItems: "center", gap: 10, padding: "8px 14px", background: "var(--paper-bright)", border: "1.5px dashed var(--c-danger)", boxShadow: "var(--shadow-1)", fontSize: 12.5, color: "var(--ink)", maxWidth: "82%" }}>
+          <div style={{ pointerEvents: "auto", display: "flex", alignItems: "center", gap: 10, padding: "8px 14px", background: "var(--paper-bright)", border: "1.5px dashed var(--c-danger)", boxShadow: "var(--shadow-1)", fontSize: 12.5, color: "var(--ink)", maxWidth: "100%" }}>
             {ruleOffer ? (<>
               <span>Make this a rule for all <b>{ruleOffer.tag}</b> rooms? Excludes enclosed regions under <b>{ruleOffer.seed.max_area_sf} SF</b>.</span>
               <button onClick={previewRule}
@@ -7419,31 +7425,39 @@ export default function TakeoffCanvas() {
             </>)}
           </div>
         )}
-        {/* live dictation chip (RFC #59 recognizer): top-center, fixed — NOT
-            cursor-following, the cursor is busy aiming for deixis. Shows the
-            hold state, decode state, and a brief flash of the heard transcript
-            (the receipt); outcomes land in the commitMsg bar like every command. */}
-        {voiceChip && (
-          <div style={{ position: "absolute", left: "50%", top: 14, transform: "translateX(-50%)", zIndex: 6, pointerEvents: "none", padding: "5px 12px", background: "var(--surface-pop)", border: `1px solid ${voiceChip.tone === "live" || voiceChip.tone === "offer" ? "var(--cobalt)" : "var(--ink-faint)"}`, boxShadow: "var(--shadow-1)", fontFamily: "var(--f-mono)", fontSize: 11.5, color: "var(--ink)", display: "flex", alignItems: "center", gap: 7, whiteSpace: "nowrap" }}>
-            {voiceChip.tone === "live" && <span className="pip" />}
-            {voiceChip.text}
-          </div>
+        </div>
         )}
-
+        {/* top-center stack: accept pill + dictation chip share one flex column
+            so simultaneous voice + pending proposals can never overlap. */}
+        {(voiceChip || pendingCommitted.length > 0) && (
+        <div style={{ position: "absolute", left: "50%", top: 12, transform: "translateX(-50%)", zIndex: Z.canvasUi, display: "flex", flexDirection: "column", alignItems: "center", gap: 6, pointerEvents: "none" }}>
         {/* accept pill — visible while committed-but-unreviewed shapes (an
             imported MCP takeoff) are on the visible sheets; they render dashed
             pencil until accepted. One click, one undo entry. */}
         {pendingCommitted.length > 0 && (
           <button onClick={acceptPendingShapes}
             title={`${pendingCommitted.length} machine-proposed shape${pendingCommitted.length === 1 ? "" : "s"} render${pendingCommitted.length === 1 ? "s" : ""} dashed pending your review. Accept makes them ink (⌘Z undoes); to reject one, select it and press Delete.`}
-            style={{ position: "absolute", left: "50%", top: 12, transform: "translateX(-50%)", zIndex: 6, padding: "6px 14px", background: "var(--paper-bright)", border: "1.5px dashed var(--cobalt)", boxShadow: "var(--shadow-1)", fontSize: 12.5, fontWeight: 600, color: "var(--cobalt)", cursor: "pointer" }}>
+            style={{ pointerEvents: "auto", padding: "6px 14px", background: "var(--paper-bright)", border: "1.5px dashed var(--cobalt)", boxShadow: "var(--shadow-1)", fontSize: 12.5, fontWeight: 600, color: "var(--cobalt)", cursor: "pointer" }}>
             Accept {pendingCommitted.length} proposed shape{pendingCommitted.length === 1 ? "" : "s"}
           </button>
         )}
+        {/* live dictation chip (RFC #59 recognizer): top-center, fixed — NOT
+            cursor-following, the cursor is busy aiming for deixis. Shows the
+            hold state, decode state, and a brief flash of the heard transcript
+            (the receipt); outcomes land in the commitMsg bar like every command. */}
+        {voiceChip && (
+          <div style={{ padding: "5px 12px", background: "var(--surface-pop)", border: `1px solid ${voiceChip.tone === "live" || voiceChip.tone === "offer" ? "var(--cobalt)" : "var(--ink-faint)"}`, boxShadow: "var(--shadow-1)", fontFamily: "var(--f-mono)", fontSize: 11.5, color: "var(--ink)", display: "flex", alignItems: "center", gap: 7, whiteSpace: "nowrap" }}>
+            {voiceChip.tone === "live" && <span className="pip" />}
+            {voiceChip.text}
+          </div>
+        )}
+        </div>
+        )}
 
-        {/* live readout — top-right. Height is capped short of the panel rail's centered
-            band (same right:14 column) so populated totals never cover the rail buttons. */}
-        <div style={{ position: "absolute", right: 14, top: 14, background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", borderRadius: 0, padding: "12px 16px", minWidth: 200, maxWidth: 260, maxHeight: "calc(50% - 110px)", overflowY: "auto", boxShadow: "0 4px 18px rgba(0,0,0,.12)", fontVariantNumeric: "tabular-nums", zIndex: 6 }}>
+        {/* live readout — top-right, at right:56 so it clears the panel rail's
+            column entirely (right:14, 34px wide — same clearance the zone panel
+            uses) instead of the old magic maxHeight tuned to the rail's height. */}
+        <div style={{ position: "absolute", right: 56, top: 14, background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", borderRadius: 0, padding: "12px 16px", minWidth: 200, maxWidth: 260, maxHeight: "calc(100% - 28px)", overflowY: "auto", boxShadow: "var(--shadow-pop)", fontVariantNumeric: "tabular-nums", zIndex: Z.canvasUi }}>
           <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.5, opacity: 0.55, marginBottom: 6, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{tool === "zone" ? "Zone check" : (aCond?.finish_tag || "No condition")}</div>
           {tool === "oneclick" && proposal?.regions.length ? (() => {
             const pos = proposal.regions.filter((r) => r.kind === "pos");

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,18 +1,22 @@
-/* OpenTakeoff design tokens — single source of truth. Change the look here. */
+/* OpenTakeoff design tokens — single source of truth. Change the look here.
+   Brand (2026-08): precision-instrument UI. Light = "ice" — bright white
+   surfaces on a cool field, cobalt the one saturated thing. Dark = "HUD" —
+   true-black cockpit, electric blue, phosphor glow on the active instrument. */
 
 @import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,500;12..96,600;12..96,700;12..96,800&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Space+Mono:wght@400;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
 
 :root {
-  /* paper substrates */
-  --paper-cream: #ece5d2;        /* default warm paper */
-  --paper-bright: #f4efe0;       /* brighter, money-paper alt */
-  --paper-shadow: #d8d1bd;       /* deeper fold tone */
+  /* surfaces — role names kept from the paper era: bright = base surface,
+     cream = raised card, shadow = hover/pressed */
+  --paper-cream: #ffffff;        /* raised card / panel */
+  --paper-bright: #fafcfe;       /* base surface / chrome */
+  --paper-shadow: #e3e9f1;       /* hover / pressed */
 
-  /* ink */
-  --ink:        #0e1a2e;         /* primary ink-navy */
-  --ink-soft:   #2a3346;
-  --ink-muted:  #6c6a5e;         /* mono labels */
-  --ink-faint:  #a39e8d;         /* hairlines */
+  /* ink — cool near-black */
+  --ink:        #0d1526;
+  --ink-soft:   #2a3a52;
+  --ink-muted:  #5c6b82;         /* mono labels */
+  --ink-faint:  #d8e0ec;         /* hairlines */
 
   /* primary accent */
   --cobalt:     #1f3fc7;
@@ -24,23 +28,23 @@
   --fleck-moss:  #1f6b4a;
   --fleck-blue:  #1f3fc7;
 
-  /* semantic */
+  /* semantic — values match the sanctioned SVG literals (lib/ui.js SVG.*) */
   --c-positive: #1f6b4a;
   --c-warning:  #c47a10;
   --c-danger:   #b03a26;
 
   /* chrome theming — novel colors pulled out of inline styles */
-  --ink-secondary: #5b544a;      /* secondary readout text */
-  --text-faint:    #a39e8d;      /* faint text/fills — --ink-faint stays hairline-only */
+  --ink-secondary: #4e5d73;      /* secondary readout text */
+  --text-faint:    #8b99ac;      /* faint text/fills — --ink-faint stays hairline-only */
   --tint-select:   #e8eefc;      /* checked-row cobalt tint */
-  --tint-active:   #f3f8f4;      /* active-row green tint */
+  --tint-active:   #edf6f1;      /* active-row green tint */
   --surface-pop:   #ffffff;      /* active chip / lifted fills */
   --well:          #ffffff;      /* media wells (PDF thumbs, stamp previews) — light in ALL themes */
   --accent-contrast: #ffffff;    /* text/rules on cobalt surfaces */
-  --hairline-warm: #f0d9c0;      /* calibration-prompt border */
-  --divider-soft:  #eee6d8;      /* readout divider fill */
-  --scrim:         rgba(14, 26, 46, .45);
-  --shadow-pop:    0 6px 22px rgba(0, 0, 0, .16);
+  --hairline-warm: #f0e2c8;      /* calibration-prompt border — stays amber-warm on purpose */
+  --divider-soft:  #e7ecf3;      /* readout divider fill */
+  --scrim:         rgba(13, 21, 38, .45);
+  --shadow-pop:    0 6px 22px rgba(13, 21, 38, .14);
   --grain-rgb:     0, 0, 0;      /* paper-grain channel triplet */
   --grain-inverse-rgb: 255, 255, 255;
 
@@ -55,69 +59,128 @@
   --rule-soft: 1px solid var(--ink-faint);
   --rule-thick: 2px solid var(--ink);
 
-  /* motion — sparing, editorial; the 1 transition already in the app uses .15s */
+  /* motion — sparing, precise; active states press with translateY(1px)
+     at --t-fast (the machined click), never scale/bounce */
   --t-fast: .12s;
   --t:      .2s;
   --t-slow: .35s;
   --ease:   cubic-bezier(.4, 0, .2, 1);
 
-  /* depth — kept subtle so it reads "paper", not "SaaS card" */
-  --shadow-1: 0 1px 2px rgba(14, 26, 46, .06), 0 2px 8px rgba(14, 26, 46, .06);
-  --shadow-2: 0 12px 36px rgba(14, 26, 46, .20);
+  /* depth — shadow-1 = resting chrome; shadow-2 = floating (sheet card,
+     popovers, modals). Nothing else. --shadow-pop is a legacy alias. */
+  --shadow-1: 0 1px 2px rgba(13, 21, 38, .05), 0 2px 8px rgba(13, 21, 38, .05);
+  --shadow-2: 0 12px 36px rgba(13, 21, 38, .16);
 
   /* focus ring — translucent cobalt, sits outside the border */
   --ring: 0 0 0 3px rgba(31, 63, 199, .18);
+
+  /* ── instrument scales (2026-08 overhaul) ─────────────────────────── */
+  /* spacing — strict 4px grid; 2px stays a literal for hairline nudges */
+  --sp-1: 4px;  --sp-2: 8px;  --sp-3: 12px; --sp-4: 16px;
+  --sp-5: 20px; --sp-6: 24px; --sp-8: 32px;
+
+  /* type scale — collapses the ad-hoc inline sizes to 7 stops.
+     Mapping: ≤9.5→2xs · 10–11→xs · 11.5–12→s · 12.5–13→m ·
+              14–15→l · 16–18→xl · 20+→2xl */
+  --fs-2xs: 9px;   /* badges, keycaps, rail group labels */
+  --fs-xs:  11px;  /* mono labels, chips, buttons, status bar */
+  --fs-s:   12px;  /* dense table/readout text */
+  --fs-m:   13px;  /* default UI text */
+  --fs-l:   15px;  /* section titles, inputs */
+  --fs-xl:  18px;  /* hero quantity readouts */
+  --fs-2xl: 22px;  /* display headings */
+
+  /* radius — square is the brand; ONE sanctioned radius for floating
+     chrome (chips, tooltips, keycaps, qty tags, rail tiles). Panels,
+     cards, buttons, inputs stay 0. */
+  --r-0: 0;
+  --r-1: 3px;
+
+  /* ergonomic control faces */
+  --ctl-s: 26px;   /* compact: zoom steppers, tab close */
+  --ctl-m: 32px;   /* standard buttons / inputs */
+  --ctl-l: 36px;   /* tool-rail faces — min comfortable hit target */
+
+  /* shell dimensions */
+  --topbar-h: 44px; --rail-w: 56px; --props-w: 264px; --status-h: 28px;
+
+  /* canvas stage — one step below chrome so sheets read as objects */
+  --stage: #edf1f7;
+
+  /* accent tints — hover / selected fills */
+  --tint-08: rgba(31, 63, 199, .07);
+  --tint-14: rgba(31, 63, 199, .13);
+
+  /* phosphor glow — HUD dark only; light is matte. Applied ONLY to:
+     active tool face, status verb, hero quantity, primary CTA, cal dot */
+  --glow: none;
+
+  /* status bar (instrument strip) — dark ink even in light theme */
+  --status-bg: #0d1526;
+  --status-fg: #e8eef8;
+  --status-acc: #8fb0f5;
 }
 
 /* ── themes ──────────────────────────────────────────────────────────────────
    Light values live in :root above; a theme is one override block keyed off
    <html data-theme="…"> (set pre-paint by the inline script in index.html).
-   Scoped to screen so print always resolves the light palette. Roles keep
-   their meaning across themes: paper-bright = base surface, paper-cream =
-   raised card, paper-shadow = hover/pressed (goes LIGHTER in dark). */
+   Scoped to screen so print always resolves the light palette.
+
+   HUD dark is a re-derivation, not a flip: true-black field, chrome barely
+   off black, electric blue (#3F8CFF — red pulled out so it can't go purple),
+   glow on the five sanctioned elements. Role meanings hold: paper-bright =
+   base surface, paper-cream = raised card, paper-shadow = hover/pressed
+   (goes LIGHTER in dark). */
 :root { color-scheme: light; }
 
 @media screen {
   :root[data-theme="dark"] {
     color-scheme: dark;
 
-    /* paper → dark drafting navy — deliberately warmer/lighter than the
-       canvas dark stage (#0b0e14) so an inverted sheet still reads as
-       "the work area" inside dark chrome */
-    --paper-bright: #121c2c;
-    --paper-cream:  #1a2536;
-    --paper-shadow: #263449;
+    /* cockpit surfaces */
+    --paper-bright: #030405;
+    --paper-cream:  #07090c;
+    --paper-shadow: #12161c;
 
-    /* ink → cream */
-    --ink:        #e9e3d1;
-    --ink-soft:   #c9c4b3;
-    --ink-muted:  #9d9a8c;
-    --ink-faint:  #3c4a63;     /* hairlines only — fails contrast as text */
-    --text-faint: #8a93a8;
+    /* ink → cool phosphor text */
+    --ink:        #d6e2f2;
+    --ink-soft:   #a9bbd2;
+    --ink-muted:  #566476;
+    --ink-faint:  #161c24;     /* hairlines only — fails contrast as text */
+    --text-faint: #7e8ca0;
 
-    /* accent, lifted for dark contrast */
-    --cobalt:      #6d87f2;
-    --cobalt-deep: #8ea4f6;
+    /* accent → true HUD blue */
+    --cobalt:      #3f8cff;
+    --cobalt-deep: #6fb4ff;
 
-    /* semantics, lifted (mirrors boostForDark's intent) */
-    --c-positive: #55b083;
-    --c-warning:  #e0a04a;
-    --c-danger:   #e0705c;
+    /* semantics, lifted for black */
+    --c-positive: #35d48f;
+    --c-warning:  #ffae42;
+    --c-danger:   #ff6b57;
 
-    --ink-secondary:   #aba490;
-    --tint-select:     #19243f;   /* dark enough that 11px cobalt/danger text clears 4.5:1 */
-    --tint-active:     #1b2f2a;
-    --surface-pop:     #253352;
+    --ink-secondary:   #8fa0b8;
+    --tint-select:     #0b1526;
+    --tint-active:     #0a1f18;
+    --surface-pop:     #0e1420;
     /* --well stays white: PDF thumbnails and stamp previews are light media */
-    --accent-contrast: #0e1a2e;
-    --hairline-warm:   #2e3c54;
-    --divider-soft:    #263449;
-    --scrim:           rgba(0, 0, 0, .55);
+    --accent-contrast: #000000;
+    --hairline-warm:   #3a2e14;
+    --divider-soft:    #12181f;
+    --scrim:           rgba(0, 0, 0, .65);
 
-    --shadow-1: 0 1px 2px rgba(0, 0, 0, .35), 0 2px 8px rgba(0, 0, 0, .35);
-    --shadow-2: 0 12px 36px rgba(0, 0, 0, .6);
-    --shadow-pop: 0 6px 22px rgba(0, 0, 0, .5);
-    --ring: 0 0 0 3px rgba(109, 135, 242, .7);   /* .3 blends to 1.6:1 on the dark page — the ring is the only focus indicator */
+    --shadow-1: 0 1px 2px rgba(0, 0, 0, .5), 0 2px 8px rgba(0, 0, 0, .5);
+    --shadow-2: 0 0 0 1px #161c24, 0 14px 44px rgba(0, 0, 0, .85);
+    --shadow-pop: 0 0 0 1px #161c24, 0 6px 22px rgba(0, 0, 0, .7);
+    --ring: 0 0 0 3px rgba(63, 140, 255, .7);   /* the ring is the only focus indicator */
+
+    --stage: #000000;
+    --tint-08: rgba(63, 140, 255, .10);
+    --tint-14: rgba(63, 140, 255, .20);
+    --glow: 0 0 9px rgba(63, 140, 255, .55);
+
+    --status-bg: #000000;
+    --status-fg: #a9c3e6;
+    --status-acc: #6fb4ff;
 
     --grain-rgb: 255, 255, 255;
     --grain-inverse-rgb: 0, 0, 0;
@@ -163,14 +226,22 @@
   background-size: 23px 23px, 31px 31px, 27px 27px, 19px 19px, 17px 17px, 29px 29px, 21px 21px, 25px 25px, 33px 33px, 15px 15px, 22px 22px;
 }
 
-/* ink panel */
+/* ink panel — the instrument strip (status bar, dark readouts) */
 .ink-panel {
-  background-color: var(--ink);
-  color: var(--paper-cream);
+  background-color: var(--status-bg);
+  color: var(--status-fg);
   background-image:
     radial-gradient(circle at 17% 23%, rgba(var(--grain-inverse-rgb), .025) 0, transparent 1.2px),
     radial-gradient(circle at 73% 81%, rgba(var(--grain-inverse-rgb), .02) 0, transparent 1px);
   background-size: 9px 9px, 13px 13px;
+}
+
+/* tick-mark hairline — status-bar top edge + calibration chip ONLY */
+.ticks {
+  background-image: repeating-linear-gradient(90deg, rgba(143, 176, 245, .18) 0 1px, transparent 1px 24px);
+  background-size: 100% 3px;
+  background-repeat: no-repeat;
+  background-position: top;
 }
 
 /* type helpers */
@@ -178,7 +249,7 @@
 .t-display-italic { font-family: var(--f-display); font-style: italic; font-weight: 700; letter-spacing: -0.025em; line-height: 0.9; }
 .t-body { font-family: var(--f-body); font-weight: 400; line-height: 1.45; }
 .t-mono { font-family: var(--f-mono); font-weight: 500; letter-spacing: 0.02em; text-transform: uppercase; }
-.t-mono-data { font-family: var(--f-mono); font-weight: 500; }
+.t-mono-data { font-family: var(--f-mono); font-weight: 500; font-variant-numeric: tabular-nums; }
 .t-label { font-family: var(--f-mono); font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; font-size: 10px; color: var(--ink-muted); }
 
 /* the blue square pip — replaces crosshair */


### PR DESCRIPTION
First slice of the precision-instrument UI overhaul (Festool/Stabila discipline, AI-native, approved via interactive palette mockup).

## What changed
- **tokens.css** — light theme re-skinned as **ice**: bright white surfaces on a cool field, cool-slate neutrals, cobalt the one saturated element. Dark theme re-derived (not flipped) as **HUD**: true-black `#000000` field, chrome `#030405`, panels `#07090c`, electric `#3f8cff` accent, phosphor `--glow` sanctioned on exactly five elements. New scales: `--sp-1..8`, `--fs-2xs..2xl`, `--r-1`, `--ctl-s/m/l`, shell dims, `--stage`, `--tint-08/14`, `--status-*`, `.ticks`.
- **new `lib/ui.js`** — `Z` ladder (replaces ad-hoc zIndex 1..70 + 9000), sanctioned SVG color literals with HUD-dark counterparts (`svgAccent`), spreadable style fragments (`S.*`).
- **TakeoffCanvas overlay collisions fixed** — status line + rule banner now share one bottom-center flex stack (previously `bottom:14` vs `bottom:44` collided when either wrapped); accept pill + voice chip share a top-center stack (both sat at `left:50%` z6); live readout moved to `right:56` clearing the panel rail column, retiring the `calc(50% - 110px)` magic height.
- **UserGuide** — joins the Z ladder (was `zIndex:9000`), `var(--scrim)`, square corners per radius policy.
- **AGENTS.md** — brand-voice section updated to the new direction, deliberately.

## Verified
- `npm run check` green on Node 24.
- Loaded at localhost and exercised both themes: ice light + HUD dark render correctly, condition colors (user data) untouched, readout clear of the rail.

Part of the OT+Spline UI overhaul program; Spline receives the same token system after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)