### PR TITLE
UI overhaul 3/N: flooring hatch set — 9 patterns from Spline

### DIFF
--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -65,7 +65,7 @@ const SNAP_TOL = 7;   // one-click vertex-snap tolerance, image px
 const PALETTE = ["#c96442", "#2f7d54", "#2563eb", "#9333ea", "#b8860b", "#0d9488", "#be185d", "#1f2937", "#dc2626", "#0891b2"];
 // (2026-07: dropped a drifted "fleur" entry that never existed in this app's
 // HATCHES, restoring "dots", and appended the signal-set ids.)
-const HATCH_IDS = ["solid", "diag", "diag2", "cross", "diagdense", "horiz", "vert", "grid", "brick", "plank", "herring", "basket", "checker", "wave", "dots", "speckle", "iso", "honeycomb", "scan", "plus", "circuit", "topo"];
+const HATCH_IDS = ["solid", "diag", "diag2", "cross", "diagdense", "horiz", "vert", "grid", "brick", "plank", "herring", "basket", "checker", "wave", "dots", "speckle", "iso", "honeycomb", "scan", "plus", "circuit", "topo", "woodgrain", "chevron", "pinwheel", "harlequin", "hexagon", "penny", "octagondot", "fleur", "concrete"];
 // uid mirrors web/src/lib/provenance.js mintUuid: crypto.randomUUID is a
 // global in Node 20+, with the same non-secure-context fallback the browser
 // build carries so the two sides mint identically-shaped ids.

--- a/web/src/components/hatches.jsx
+++ b/web/src/components/hatches.jsx
@@ -32,6 +32,18 @@ export const HATCHES = [
   { id: "plus", label: "Plus grid" },
   { id: "circuit", label: "Circuit / traces" },
   { id: "topo", label: "Contour / topo" },
+  // ── flooring set (2026-08, ported from the Spline sibling): real installed
+  // patterns an estimator recognizes on a finish plan. APPEND ONLY — hatch ids
+  // are user data riding saved conditions.
+  { id: "woodgrain", label: "Wood grain" },
+  { id: "chevron", label: "Chevron" },
+  { id: "pinwheel", label: "Pinwheel / hopscotch" },
+  { id: "harlequin", label: "Harlequin / diamond" },
+  { id: "hexagon", label: "Hex tile" },
+  { id: "penny", label: "Penny round" },
+  { id: "octagondot", label: "Octagon & dot" },
+  { id: "fleur", label: "Fleur-de-lis" },
+  { id: "concrete", label: "Concrete / stipple" },
 ];
 export const PALETTE = ["#c96442", "#2f7d54", "#2563eb", "#9333ea", "#b8860b", "#0d9488", "#be185d", "#1f2937", "#dc2626", "#0891b2"];
 export const NO_FILL = "none";
@@ -42,7 +54,8 @@ export function HatchPattern({ id, type, line, fill, dark }) {
   // dark mode legibility comes from brighter alphas baked into the pattern —
   // never a CSS filter over the shape overlay (that re-rasterizes the whole
   // layer on every sync)
-  const s = (d) => <path d={d} stroke={line} strokeWidth={sw} fill="none" />;
+  const s = (d, w) => <path d={d} stroke={line} strokeWidth={w || sw} fill="none" />;
+  const SW2 = 0.8;   // lighter weight for dual/dense patterns so none shouts
   const wrap = (kids, w = 10, h = 10) => (
     <pattern id={id} patternUnits="userSpaceOnUse" width={w} height={h}>
       {fill && fill !== NO_FILL ? <rect width={w} height={h} fill={fill} opacity={dark ? 0.32 : 0.18} /> : null}
@@ -84,6 +97,40 @@ export function HatchPattern({ id, type, line, fill, dark }) {
       <ellipse cx={12} cy={12} rx={8} ry={5} fill="none" stroke={line} strokeWidth={sw} transform="rotate(-18 12 12)" />
       <ellipse cx={12} cy={12} rx={4.6} ry={2.6} fill="none" stroke={line} strokeWidth={sw} transform="rotate(-18 12 12)" />
     </>, 24, 24);
+    // ── flooring set (2026-08, ported from the Spline sibling) ──
+    case "chevron": return wrap(s("M0,6 L4,2 L8,6 L12,2 L16,6"), 16, 8);
+    case "hexagon": {
+      // Flat-top hex, side 5 (larger read than honeycomb's side 4): tile 15 × 5√3.
+      const H = 8.6603, hx = (cx, cy) =>
+        s(`M${cx - 5},${cy} L${cx - 2.5},${cy - 4.3301} L${cx + 2.5},${cy - 4.3301} L${cx + 5},${cy} L${cx + 2.5},${cy + 4.3301} L${cx - 2.5},${cy + 4.3301} Z`, SW2);
+      return wrap(<>{hx(0, 0)}{hx(15, 0)}{hx(0, H)}{hx(15, H)}{hx(7.5, H / 2)}</>, 15, H);
+    }
+    case "penny": return wrap(<>{[[3.5, 3], [10.5, 3], [0, 9], [7, 9], [14, 9]].map(([x, y], i) =>
+      <circle key={i} cx={x} cy={y} r={3.2} fill="none" stroke={line} strokeWidth={SW2} />)}</>, 14, 12);
+    case "octagondot": return wrap(<>
+      {s("M4.5,0 L9.5,0 L14,4.5 L14,9.5 L9.5,14 L4.5,14 L0,9.5 L0,4.5 Z", SW2)}
+      {[[0, 0], [14, 0], [0, 14], [14, 14]].map(([x, y], i) =>
+        <path key={i} d={`M${x},${y - 1.8} L${x + 1.8},${y} L${x},${y + 1.8} L${x - 1.8},${y} Z`} fill={line} stroke="none" />)}
+    </>, 14, 14);
+    case "pinwheel": return wrap(s("M0,0 L16,0 M0,0 L0,16 M0,6 L10,6 M6,10 L16,10 M10,0 L10,10 M6,6 L6,16", SW2), 16, 16);
+    case "harlequin": return wrap(s("M5,0 L10,8 L5,16 L0,8 Z"), 10, 16);
+    case "woodgrain": return wrap(<>
+      {s("M0,4 C6,7 18,1 24,4", SW2)}{s("M0,9 C6,6.5 18,11.5 24,9", SW2)}{s("M0,14 C6,17 18,11 24,14", SW2)}
+      <ellipse cx={12} cy={9} rx={2.2} ry={1.2} fill="none" stroke={line} strokeWidth={SW2} />
+    </>, 24, 18);
+    case "concrete": return wrap(<>
+      {[[3, 4], [9, 2], [15, 6], [6, 10], [17, 13], [11, 16], [2, 15]].map(([x, y], i) =>
+        <circle key={i} cx={x} cy={y} r={0.9} fill={line} />)}
+      {s("M12,6.8 L13.6,9.4 L10.4,9.4 Z", SW2)}{s("M4,16.8 L5.7,19.4 L2.3,19.4 Z", SW2)}
+    </>, 20, 20);
+    case "fleur": return wrap(
+      <g fill={line} stroke="none">
+        <path d="M8 2.2 C6.7 4 6.7 6.2 8 8.2 C9.3 6.2 9.3 4 8 2.2 Z" />
+        <path d="M4.6 4.8 C3 5.9 2.9 8.2 4.9 8.7 C4.6 7.4 4.7 6 4.6 4.8 Z" />
+        <path d="M11.4 4.8 C13 5.9 13.1 8.2 11.1 8.7 C11.4 7.4 11.3 6 11.4 4.8 Z" />
+        <rect x="5.4" y="9.3" width="5.2" height="1.2" />
+        <path d="M8 10.9 C7.1 11.9 7.1 12.9 8 13.8 C8.9 12.9 8.9 11.9 8 10.9 Z" />
+      </g>, 16, 16);
     default: return wrap(null);  // solid: only the fill bg
   }
 }


### PR DESCRIPTION
Port from the Spline sibling: woodgrain, chevron, pinwheel/hopscotch, harlequin/diamond, hex tile, penny round, octagon-&-dot, fleur-de-lis, concrete/stipple — real installed patterns an estimator recognizes on a finish plan.

Append-only per the user-data rule (saved conditions ride hatch ids); OT's existing 22 including the signal set are untouched. `mcp/src/session.ts` HATCH_IDS mirror extended to match.

Verified: web `npm run check` green; mcp suite 161 pass 0 fail (includes the parity test); picker renders all 31 swatches distinctly at localhost (screenshot-checked in HUD dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)