### PR TITLE
docs: state the stitch/align human-only boundary for humans and agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-14 — stitching is human-only, in writing
+
+### Docs
+- **The stitch/align boundary is now documented as design intent, not a gap** — for humans and agents both. Aligning a match line means judging that two drawn wall junctions are the same point, and a subtly sloppy join silently skews every quantity that crosses the seam — so no MCP verb creates, aligns, or addresses a stitch, and none is staged for later. `docs/MCP.md` states the doctrine (the scale gate taken one step further: the agent doesn't even propose), `mcp/README.md` Limits adds the stance plus the round-trip caveat (the server doesn't read the `stitches` payload field, so `import_takeoff` → `export_takeoff` drops stitches — the app's own save is the one to keep), and `docs/USER_GUIDE.md` tells the human driving an agent to stitch and align first, or have the agent measure member sheets individually.
+
 ## 2026-08-13 — the tool surface grows as the takeoff does (opt-in)
 
 ### Added

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -210,6 +210,17 @@ Two rules carry over from the app unchanged:
   fields appear on the tool replies, so an agent can triage before it
   commits.
 
+And one capability deliberately does **not** carry over: **stitching**. The
+canvas can join sheets split at a match line into one composite surface, but
+there is no agent verb for it — aligning the match line means clicking the
+same drawn wall junction on both halves, a human-judgment act whose failure
+mode (a subtly sloppy join) silently skews every quantity that crosses the
+seam. Same doctrine as the scale gate, taken one step further: here the agent
+doesn't even propose. A human stitches and aligns in the canvas; an agent
+works the member sheets individually and leaves seam-crossing rooms to the
+person at the screen. See the Limits section of
+[`mcp/README.md`](../mcp/README.md) for the round-trip caveat that follows.
+
 ## An example session
 
 An agent asked to *"take off the carpet on this floor plan"* — tool calls

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -79,6 +79,8 @@ Large floors often arrive cut across sheets at a **match line** — half the bui
 
 Notes: align the match line **before** tracing — once takeoffs live on a stitch it won't re-align (their coordinates ride the composite). Deleting a stitch is refused while takeoffs or markups live on it; reopen one anytime from its tab or the gallery's **Stitched surfaces** strip. The Marked Set PDF burns a stitch in as one composite page — members placed at their aligned offsets, each showing its own half up to the seam, shapes drawn once in the frame you measured them in — stamped as a stitched composite so nobody mistakes it for a sheet the architect issued.
 
+Stitching and aligning are yours alone — an AI agent driving OpenTakeoff [over MCP](MCP.md) has no stitch verb, on purpose: judging that two wall junctions are the same drawn point is human work, and a sloppy join quietly skews everything measured across the seam. If an agent will be doing the takeoff on a split floor, do the stitch and align yourself first, or have the agent measure the member sheets individually.
+
 ### Levels (multi-floor sets)
 
 In the gallery, select sheets and hit **Assign level…** (`"L1"`, `"Level 2"`, `"Garage"` — empty clears). The gallery groups by level with unassigned sheets last, cards wear their level chip, and tabs plus the page picker carry the label. Levels save with the project.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -311,6 +311,19 @@ sheet number (`A-101`) wherever a sheet is named.
   has nothing for `detect_rooms`/`sheet_graph`/`resolve_tag` to read: seeds
   come from you (`view_sheet`, then `one_click`). The raster path needs the
   same optional `@napi-rs/canvas` as `view_sheet`.
+- **Stitching is human-only — deliberately, not a gap.** The canvas can join
+  2–4 sheets split at a match line into one composite surface (#200), but no
+  MCP verb creates, aligns, or addresses a stitch. Joining the match line
+  means clicking the same drawn wall junction on both halves — a judgment
+  call with a worse blast radius than a bad scale, because a sloppy align
+  silently skews every quantity that crosses the seam. That stays behind
+  human eyes; it is not staged for later exposure. For a split floor: a
+  human stitches and aligns in the canvas, and over MCP you work each member
+  sheet as its own surface — a seam-crossing room belongs to the canvas.
+  This server also doesn't read the app's additive `stitches` payload field,
+  so a stitched takeoff round-tripped through `import_takeoff` →
+  `export_takeoff` comes back without its stitches — when a stitch is in
+  play, the app's own save is the one to keep.
 - `load_plan` replaces the session by default; `merge: true` builds a multi-document working set (#152). Reloading a merged file is refused — reload = replace, deliberately.
 - The takeoff lives in memory. `export_takeoff` (the app's exact save payload,
   nothing lost in translation) and `export_marked_pdf` (the reviewable marked

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.39",
+  "version": "0.9.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.39",
+      "version": "0.9.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.40",
+  "version": "0.9.41",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.40",
+      "version": "0.9.41",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.40",
+  "version": "0.9.41",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.40",
+      "version": "0.9.41",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Aligning a match line is a human-judgment act whose failure mode silently
skews every seam-crossing quantity, so no MCP verb touches stitches and
none is staged. Documents the stance in docs/MCP.md, the Limits entry and
stitches round-trip caveat in mcp/README.md, the do-it-yourself-first note
in docs/USER_GUIDE.md, and a CHANGELOG entry.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
