### PR TITLE
mobile: survive phone-class devices without touching the desktop engine

### DIFF
--- a/web/src/components/TakeoffsPanel.jsx
+++ b/web/src/components/TakeoffsPanel.jsx
@@ -37,6 +37,7 @@ import { materialKind, MATERIAL_PRESETS, GROUT_DEFAULTS, groutDerivedFields, sho
 import { draftCommitValue, blurCommitValue, blurCommitNonNegative } from "../lib/draftInput.js";
 import { ROLL_FLOORING_TYPES } from "../lib/rollgoods.js";
 import { hasRollSetup, mintRollSetup } from "../lib/rollTakeoff.js";
+import { Z } from "../lib/ui.js";
 import { ftIn } from "../lib/units";
 
 export const PANEL_MIN_W = 240;
@@ -653,7 +654,7 @@ function TransitionsAction({ cond: c, sources, draft, setDraft, result, setResul
 }
 
 function TakeoffsPanel({
-  open, width, multiSheet, units = "imperial",
+  open, width, overlay = false, multiSheet, units = "imperial",
   conditions, activeCond, visRowById, projRowById = new Map(), conditionColumns, shapeLabels = [], templates, palette = [], rollByCond = null,
   transitionSources = [],
   matLib, matLibById, linkedCountById,
@@ -976,11 +977,17 @@ function TakeoffsPanel({
 
   if (!open) return null;
   return (
-    <div ref={rootRef} style={{ width, flexShrink: 0, display: "flex", background: "var(--paper-bright)", borderLeft: "1px solid var(--ink-faint)", fontSize: 12.5 }}>
-      <div onPointerDown={onResizeDown} onPointerMove={onResizeMove} onPointerUp={onResizeEnd}
+    // Narrow screens (`overlay`): the panel slides OVER the canvas instead of
+    // docking beside it — a docked 240px+ column plus the canvas doesn't fit a
+    // phone (the panel was covering the whole screen). Desktop docked layout
+    // is unchanged. The header's » collapse button is the close affordance.
+    <div ref={rootRef} style={overlay
+      ? { position: "absolute", top: 0, right: 0, bottom: 0, width: "min(100%, 420px)", zIndex: Z.drawer, boxShadow: "var(--shadow-pop)", display: "flex", background: "var(--paper-bright)", borderLeft: "1px solid var(--ink-faint)", fontSize: 12.5 }
+      : { width, flexShrink: 0, display: "flex", background: "var(--paper-bright)", borderLeft: "1px solid var(--ink-faint)", fontSize: 12.5 }}>
+      {!overlay && <div onPointerDown={onResizeDown} onPointerMove={onResizeMove} onPointerUp={onResizeEnd}
         onPointerCancel={onResizeEnd} onLostPointerCapture={onResizeEnd}
         title="Drag to resize"
-        style={{ width: 5, flexShrink: 0, cursor: "col-resize", touchAction: "none", background: "transparent", borderRight: "1px solid var(--ink-faint)" }} />
+        style={{ width: 5, flexShrink: 0, cursor: "col-resize", touchAction: "none", background: "transparent", borderRight: "1px solid var(--ink-faint)" }} />}
       <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, padding: "7px 12px", background: "var(--ink)", color: "var(--paper-cream)", flexShrink: 0 }}>
           <span style={{ display: "inline-flex", gap: 2 }}>

--- a/web/src/lib/deviceClass.ts
+++ b/web/src/lib/deviceClass.ts
@@ -1,0 +1,19 @@
+// Phone-class device detection — the ONE switch the mobile-survival paths key
+// off (tilePool pool size + crash recovery, tileCompositor bitmap budget).
+// Deliberately conservative: a false NEGATIVE just means desktop behavior,
+// which is the well-tested path. Desktop behavior is byte-for-byte unchanged
+// when this is false — that's the contract, not an optimization note.
+//
+// Signals, any one of which marks the device low-memory:
+// - navigator.deviceMemory ≤ 4 (Chrome/Android expose it; Safari never does)
+// - iPhone/iPad/Android UA
+// - iPadOS masquerading as macOS: "Macintosh" UA + real multi-touch
+export const LOW_MEMORY_DEVICE: boolean = (() => {
+  if (typeof navigator === "undefined") return false;
+  const dm = (navigator as { deviceMemory?: number }).deviceMemory;
+  if (typeof dm === "number" && dm <= 4) return true;
+  const ua = navigator.userAgent || "";
+  if (/iPhone|iPad|iPod|Android/i.test(ua)) return true;
+  if (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1) return true;
+  return false;
+})();

--- a/web/src/lib/tileCompositor.ts
+++ b/web/src/lib/tileCompositor.ts
@@ -49,13 +49,17 @@
 // mode while looking at the same tiles) for zero main-thread pixel work.
 
 import { RENDER_SCALE } from "./sheets";
+import { LOW_MEMORY_DEVICE } from "./deviceClass";
 import { createTilePool } from "./tilePool";
 import { TileLRU, buildLevels, pickLevel, levelDims, visibleTiles, visibleTilesAtDensity, fitDensity, BASE_LEVEL, tileKey as rawTileKey, TILE_SIZE } from "./tiles";
 
 // ~450MB shared across every open sheet/panel — the old per-group ceiling
 // ("4-up ≈ 450MB" per canvasConstants.js), now a BUDGET instead of a floor
 // that individual panels could each independently blow past.
-const BYTE_BUDGET = 450 * 1024 * 1024;
+// Phone-class devices get a far smaller bitmap cache — mobile Safari's
+// per-tab budget is a fraction of desktop's, and blowing it gets the render
+// workers jetsam-killed (see tilePool.ts). Desktop budget is unchanged.
+const BYTE_BUDGET = (LOW_MEMORY_DEVICE ? 120 : 450) * 1024 * 1024;
 // The base layer's phase-2 target — deliberately the SAME number as the old
 // codebase's MAX_PANEL_AREA (canvasConstants.js), not a new tuning constant.
 // The goal isn't a new budget, it's parity with the raster quality that

--- a/web/src/lib/tilePool.ts
+++ b/web/src/lib/tilePool.ts
@@ -16,6 +16,8 @@
 // the same (typically sub-few-MB) plan sheet, which is cheap next to what it
 // buys: pdf.js parse time was never the bottleneck here, per-tile RENDER
 // time was, and that's exactly what this parallelizes.
+import { LOW_MEMORY_DEVICE } from "./deviceClass";
+
 export interface TileRequest {
   sheetKey: string;
   scale: number;               // pdf.js render scale (RENDER_SCALE * density)
@@ -31,7 +33,14 @@ type OutMsg =
   | { type: "tile"; reqId: number; sheetKey: string; w: number; h: number; bitmap: ImageBitmap }
   | { type: "tileError"; reqId: number; sheetKey: string; message: string };
 
-const POOL_SIZE = Math.max(1, Math.min(3, (typeof navigator !== "undefined" ? navigator.hardwareConcurrency : 4) - 1 || 2));
+// Phone-class devices get a pool of ONE: the broadcast design means every
+// worker holds its own copy of the PDF bytes plus its own nested pdf.js parse,
+// and on an iPhone that 3× footprint is what got the workers jetsam-killed
+// (reported live 2026-08-15: "worker failed", planset stuck half-rendered).
+// Desktop pool sizing is unchanged.
+const POOL_SIZE = LOW_MEMORY_DEVICE
+  ? 1
+  : Math.max(1, Math.min(3, (typeof navigator !== "undefined" ? navigator.hardwareConcurrency : 4) - 1 || 2));
 
 interface SheetOpenState {
   promise: Promise<void>;
@@ -44,15 +53,43 @@ interface SheetOpenState {
 export function createTilePool(size = POOL_SIZE) {
   const workers: Worker[] = [];
   const sheetOpen = new Map<string, SheetOpenState>();
-  const pending = new Map<number, { resolve: (r: TileResult) => void; reject: (e: Error) => void; workerIdx: number }>();
+  const pending = new Map<number, { resolve: (r: TileResult) => void; reject: (e: Error) => void; workerIdx: number; timer?: ReturnType<typeof setTimeout> }>();
   let nextReqId = 1;
   let rrCounter = 0; // round-robins tile requests across the whole pool
   let disposed = false;
+
+  // Phone-only crash recovery. Mobile Safari terminates workers under memory
+  // pressure with nothing but an error event — without this, every tile the
+  // dead worker owed stays pending forever and the sheet is stuck
+  // half-rendered (the bug this exists for). Bytes are retained per open
+  // sheet so a respawned worker can be re-fed; that retention cost is why the
+  // whole path is gated on LOW_MEMORY_DEVICE — desktop behavior is unchanged.
+  const sheetBytes = LOW_MEMORY_DEVICE ? new Map<string, { pageNum: number; data: ArrayBuffer }>() : null;
+
+  function onWorkerDeath(i: number, err: unknown) {
+    const dead = workers[i];
+    if (!dead) return;
+    workers[i] = undefined as unknown as Worker;
+    try { dead.terminate(); } catch { /* already gone */ }
+    console.warn(`[tiles] render worker ${i} died — respawning:`, err);
+    for (const [reqId, p] of pending) {
+      if (p.workerIdx === i) { if (p.timer) clearTimeout(p.timer); p.reject(new Error("render worker crashed")); pending.delete(reqId); }
+    }
+    if (disposed || !sheetBytes) return;
+    // Respawn and re-feed every open sheet; settled-state bookkeeping in
+    // onMessage already ignores duplicate sheetReady after settle.
+    const w = ensureWorker(i);
+    for (const [sheetKey, { pageNum, data }] of sheetBytes) {
+      const copy = data.slice(0);
+      w.postMessage({ type: "openSheet", sheetKey, pageNum, data: copy }, [copy]);
+    }
+  }
 
   function ensureWorker(i: number): Worker {
     if (!workers[i]) {
       const w = new Worker(new URL("../pdfTile.worker.ts", import.meta.url), { type: "module" });
       w.onmessage = (e: MessageEvent<OutMsg>) => onMessage(e.data);
+      if (sheetBytes) w.onerror = (e) => onWorkerDeath(i, e?.message || e);
       workers[i] = w;
     }
     return workers[i];
@@ -72,8 +109,8 @@ export function createTilePool(size = POOL_SIZE) {
       st.settled = true; st.reject(new Error(m.message));
       return;
     }
-    if (m.type === "tile") { pending.get(m.reqId)?.resolve({ w: m.w, h: m.h, bitmap: m.bitmap }); pending.delete(m.reqId); return; }
-    if (m.type === "tileError") { pending.get(m.reqId)?.reject(new Error(m.message)); pending.delete(m.reqId); return; }
+    if (m.type === "tile") { const p = pending.get(m.reqId); if (p) { if (p.timer) clearTimeout(p.timer); p.resolve({ w: m.w, h: m.h, bitmap: m.bitmap }); } pending.delete(m.reqId); return; }
+    if (m.type === "tileError") { const p = pending.get(m.reqId); if (p) { if (p.timer) clearTimeout(p.timer); p.reject(new Error(m.message)); } pending.delete(m.reqId); return; }
   }
 
   /** Idempotent — calling twice for the same sheetKey is a no-op after the
@@ -89,6 +126,7 @@ export function createTilePool(size = POOL_SIZE) {
     const promise = new Promise<void>((res, rej) => { resolve = res; reject = rej; });
     const st: SheetOpenState = { promise, resolve, reject, settled: false, readyCount: 0 };
     sheetOpen.set(sheetKey, st);
+    sheetBytes?.set(sheetKey, { pageNum, data }); // pool owns `data` — retained (phone only) so a respawned worker can be re-fed
     for (let i = 0; i < size; i++) {
       const copy = data.slice(0); // independent transferable per worker
       ensureWorker(i).postMessage({ type: "openSheet", sheetKey, pageNum, data: copy }, [copy]);
@@ -101,23 +139,31 @@ export function createTilePool(size = POOL_SIZE) {
     const workerIdx = rrCounter++ % size;
     const w = ensureWorker(workerIdx);
     const promise = new Promise<TileResult>((resolve, reject) => {
-      pending.set(reqId, { resolve, reject, workerIdx });
+      // Phone-only watchdog: mobile Safari can jetsam-kill a worker with NO
+      // error event, leaving this promise pending forever. A tile this small
+      // pool renders takes seconds; 30s of silence means the worker is gone.
+      const timer = sheetBytes
+        ? setTimeout(() => { const p = pending.get(reqId); if (p) onWorkerDeath(p.workerIdx, "tile timed out — treating the worker as killed"); }, 30_000)
+        : undefined;
+      pending.set(reqId, { resolve, reject, workerIdx, timer });
       w.postMessage({ type: "renderTile", reqId, sheetKey: req.sheetKey, scale: req.scale, rect: req.rect, dark: req.dark });
     });
-    const cancel = () => { pending.delete(reqId); w.postMessage({ type: "cancel", reqId }); };
+    const cancel = () => { const p = pending.get(reqId); if (p?.timer) clearTimeout(p.timer); pending.delete(reqId); w.postMessage({ type: "cancel", reqId }); };
     return { promise, reqId, cancel };
   }
 
   function closeSheet(sheetKey: string) {
     for (let i = 0; i < size; i++) ensureWorker(i).postMessage({ type: "closeSheet", sheetKey });
     sheetOpen.delete(sheetKey);
+    sheetBytes?.delete(sheetKey);
   }
 
   function dispose() {
     disposed = true;
     for (const w of workers) w?.terminate();
     workers.length = 0;
-    sheetOpen.clear(); pending.clear();
+    for (const [, p] of pending) if (p.timer) clearTimeout(p.timer);
+    sheetOpen.clear(); pending.clear(); sheetBytes?.clear();
   }
 
   return { openSheet, requestTile, closeSheet, dispose };

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -180,6 +180,22 @@ const PANEL_PREFS_KEY = "opentakeoff_panel";
 // choice being honored). An explicit COLLAPSE made under the old default is
 // preserved; any later toggle re-persists normally.
 const PANEL_DEFAULTS = { w: 320, collapsed: true, strip: false, az: false, group: false };
+
+// Narrow-viewport switch (phones). Everything it gates is layout-only — the
+// Takeoffs panel presents as an overlay instead of docking (a 240px+ dock
+// covers a phone screen), and the live readout drops to a bottom strip.
+// ≥701px is byte-for-byte the existing desktop layout.
+const NARROW_MQ = "(max-width: 700px)";
+function useIsNarrow() {
+  const [narrow, setNarrow] = useState(() => typeof window !== "undefined" && window.matchMedia(NARROW_MQ).matches);
+  useEffect(() => {
+    const mq = window.matchMedia(NARROW_MQ);
+    const on = () => setNarrow(mq.matches);
+    mq.addEventListener("change", on);
+    return () => mq.removeEventListener("change", on);
+  }, []);
+  return narrow;
+}
 // Top-bar quick-access condition palette: a curated handful (≤9) of pinned
 // conditions for one-click activation without leaving the canvas. Palette holds
 // condition ids (workspace-scoped), so it persists with the annotation payload,
@@ -303,6 +319,7 @@ export default function TakeoffCanvas() {
   const [scaleUnconfirmed, setScaleUnconfirmed] = useState({});
   const confirmScale = (key) => setScaleUnconfirmed((m) => { if (!(key in m)) return m; const n = { ...m }; delete n[key]; return n; });
   const [detectedScales, setDetectedScales] = useState({}); // { sheetKey: {upp,label,multi} } read off the plan text
+  const isNarrow = useIsNarrow();
   const [darkMode, setDarkMode] = useState(() => { try { return localStorage.getItem("opentakeoff_dark") === "1"; } catch { return false; } });
   useEffect(() => { try { localStorage.setItem("opentakeoff_dark", darkMode ? "1" : "0"); } catch { /* private mode */ } }, [darkMode]);
   // App chrome theme (light/dark tokens) — independent of the canvas ☾ invert
@@ -6538,7 +6555,7 @@ export default function TakeoffCanvas() {
       )}
 
       {/* canvas + issue desk */}
-      <div style={{ flex: 1, display: "flex", overflow: "hidden", minHeight: 0 }}>
+      <div style={{ flex: 1, display: "flex", overflow: "hidden", minHeight: 0, position: "relative" /* anchors the narrow-screen panel overlay */ }}>
        {/* tool rail — machined faces grouped by MCP module (the concept shell).
            Individual tiles replace deck 2's Measure/Cut Out menus; Markup keeps
            its variety flyout on one tile (five markup kinds don't earn five
@@ -7479,7 +7496,12 @@ export default function TakeoffCanvas() {
         {/* live readout — top-right, at right:56 so it clears the panel rail's
             column entirely (right:14, 34px wide — same clearance the zone panel
             uses) instead of the old magic maxHeight tuned to the rail's height. */}
-        <div style={{ position: "absolute", right: 56, top: 14, background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", borderRadius: 0, padding: "12px 16px", minWidth: 200, maxWidth: 260, maxHeight: "calc(100% - 28px)", overflowY: "auto", boxShadow: "var(--shadow-pop)", fontVariantNumeric: "tabular-nums", zIndex: Z.canvasUi }}>
+        <div style={{ position: "absolute", ...(isNarrow
+          // phones: a bottom strip — the top-right box plus the panel rail was
+          // covering the entire screen. bottom:64 clears the bottom-center toast.
+          ? { left: 10, right: 10, bottom: 64, maxHeight: "36%", padding: "8px 12px" }
+          : { right: 56, top: 14, minWidth: 200, maxWidth: 260, maxHeight: "calc(100% - 28px)", padding: "12px 16px" }),
+          background: "var(--paper-bright)", border: "1px solid var(--ink-faint)", borderRadius: 0, overflowY: "auto", boxShadow: "var(--shadow-pop)", fontVariantNumeric: "tabular-nums", zIndex: Z.canvasUi }}>
           <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.5, opacity: 0.55, marginBottom: 6, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{tool === "zone" ? "Zone check" : (aCond?.finish_tag || "No condition")}</div>
           {tool === "oneclick" && proposal?.regions.length ? (() => {
             const pos = proposal.regions.filter((r) => r.kind === "pos");
@@ -7698,6 +7720,7 @@ export default function TakeoffCanvas() {
         <TakeoffsPanel
           open={takeoffsOpen}
           width={panelW}
+          overlay={isNarrow}
           multiSheet={groupKeys.length > 1}
           units={units}
           conditions={conditions}


### PR DESCRIPTION
Reported live on a phone: 'worker failed' + a planset stuck half-rendered,
and the Takeoffs panel covering the entire screen.

- tilePool: on LOW_MEMORY_DEVICE only — pool of 1 (the 3-worker broadcast
  triples PDF bytes + nested pdf.js parses, which is what got workers
  jetsam-killed), retained sheet bytes, and crash recovery (onerror +
  30s tile watchdog -> respawn, re-feed sheets, reject stuck tiles).
- tileCompositor: 120MB bitmap budget on phones (450MB desktop, unchanged).
- TakeoffsPanel: presents as a right-side overlay under 700px instead of
  docking (a 240px+ dock covers a phone); header » closes it. Live readout
  drops to a bottom strip under 700px.

Desktop (>700px, non-phone) behavior is byte-for-byte unchanged - every
new path is gated on LOW_MEMORY_DEVICE or the narrow media query.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
