### PR TITLE
sheetgraph: read the sheet's own cell alignment (#87 phase 4b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-16 — a wider corpus, and the shapes it exposed; opentakeoff-mcp 0.9.47
+
+The eval corpus grows to a fourth general contractor and a fourth building typology — a municipal treatment plant drawn in a hand-lettered CAD font, which broke the parser in two new ways.
+
+### Fixed
+- **Cell alignment is READ, not assumed.** Some schedules left-align their cells and some centre them; it is a property of the sheet. On a centred set a long value (`PNT-1, FRP-1`) starts far to the left of a short one (`PNT-1`) in the same column, so left-edge banding pushed it into the column before it and BASE read `RB-1 PNT-1, FRP-1`. Both alignments are now derived and **scored by how well they explain the data**; the better fit wins, left wins a near tie, and a map that fits *badly* is discarded rather than trusted — a mediocre map looks authoritative and quietly merges a column into its neighbour, where falling back to nearest-anchor reads the table correctly. Measured across real sets: a true alignment scores 0.82–0.90, a wrong one 0.54.
+- **A header cell naming two vocabulary words gives up the second.** `ROOM #` and `ROOM NAME` both lead with ROOM, so the name column was deduped away, lost its anchor, and every room name merged into the finish column beside it (`FLOOR` read `CHEM FEED SC-1`). A cell now falls through to its next vocabulary word when the first is taken — after parent-naming has had its chance, so `FLOOR FINISH` / `CEILING FINISH` still resolve as before.
+- **Casework columns are vocabulary.** `CASEWORK`, `CABINET`, `COUNTER`, `COUNTERTOP` anchor their own columns instead of spilling into WALL.
+- **`graph-render.mjs` keeps the page number** in its output names — every sheet of a combined single-file set was overwriting the last — and skips sheets with no tables unless `--all` is passed.
+
+### Measured
+Four real sets, four general contractors, four typologies (two gyms, retail, municipal), keys read independently off the renders: **cell precision 1.000 / recall 1.000 (434 cells, 0 wrong, 0 missed)** and **tag precision 1.000 / recall 1.000 (86 rooms, 0 non-rooms reported)**.
+
 ## 2026-08-16 — the sheet graph gets a ruler; opentakeoff-mcp 0.9.46
 
 A scored evaluation loop against **real bid sets**, and the parser changes it forced. Every fix below was found by measuring, not by reading code — and each ships with a fixture reproducing the real failure.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.46",
+  "version": "0.9.47",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/scripts/graph-eval.mjs
+++ b/mcp/scripts/graph-eval.mjs
@@ -100,7 +100,7 @@ const f1 = (p, r) => (p + r ? (2 * p * r) / (p + r) : 0);
 // ── run one set ─────────────────────────────────────────────────────────────
 async function evalSet(set) {
   const s = new Session();
-  const files = set.files.map((f) => join(spec.root, f));
+  const files = set.files.map((f) => join(set.root ?? spec.root, f));
   for (let i = 0; i < files.length; i++) await s.loadPlan(files[i], { merge: i > 0 });
   const g = await s.sheetGraph();
 

--- a/mcp/scripts/graph-render.mjs
+++ b/mcp/scripts/graph-render.mjs
@@ -28,11 +28,17 @@ const outDir = join(corpus, "renders");
 mkdirSync(outDir, { recursive: true });
 
 const s = new Session();
-for (let i = 0; i < set.files.length; i++) await s.loadPlan(join(spec.root, set.files[i]), { merge: i > 0 });
+for (let i = 0; i < set.files.length; i++) await s.loadPlan(join(set.root ?? spec.root, set.files[i]), { merge: i > 0 });
 const g = await s.sheetGraph();
 
 const sheetOf = (key) => s.sheet(key);
-const slug = (k) => k.replace(/\.pdf.*$/i, "").replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(-28);
+const slug = (k) => {
+  // keep the PAGE: a combined single-file set has every sheet under one file
+  // name, and dropping the "#N" made every render overwrite the last.
+  const page = /#(\d+)$/.exec(k)?.[1] ?? "1";
+  const base = k.replace(/#\d+$/, "").replace(/\.pdf$/i, "").replace(/[^A-Za-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(-24);
+  return `${base}-p${page}`;
+};
 
 // every table region the graph found, per sheet
 const regions = new Map();
@@ -48,6 +54,7 @@ for (const sh of g.sheets) {
   const page = sheetOf(sh.sheet).page;
   const tables = regions.get(sh.sheet) ?? [];
   if (!tables.length) {
+    if (!process.argv.includes("--all")) continue;
     // no table found here — render the WHOLE sheet, because "the graph saw
     // nothing" is exactly the case a label needs to check
     const png = await page.renderPng(0.5);

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.46",
+  "version": "0.9.47",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.46",
+  "version": "0.9.47",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.46",
+      "version": "0.9.47",
       "transport": {
         "type": "stdio"
       }

--- a/web/src/lib/sheetgraph.ts
+++ b/web/src/lib/sheetgraph.ts
@@ -296,7 +296,7 @@ export interface ScheduleTable {
 
 /** Columns that ARE a surface in their own right — never renamed by a parent. */
 const SURFACE_WORDS = new Set(["FLOOR", "BASE", "WALL", "WALLS", "CEILING", "NORTH", "SOUTH", "EAST", "WEST", "WAINSCOT"]);
-const ROOM_HEADERS = ["ROOM", "NO", "NUMBER", "NAME", "MARK", "LOCATION", "FLOOR", "BASE", "WALL", "WALLS", "NORTH", "SOUTH", "EAST", "WEST", "CEILING", "WAINSCOT", "REMARKS", "CLG", "HT", "HEIGHT", "FINISH", "BLDG", "BUILDING"];
+const ROOM_HEADERS = ["ROOM", "NO", "NUMBER", "NAME", "MARK", "LOCATION", "FLOOR", "BASE", "WALL", "WALLS", "NORTH", "SOUTH", "EAST", "WEST", "CEILING", "WAINSCOT", "REMARKS", "CLG", "HT", "HEIGHT", "FINISH", "CASEWORK", "CABINET", "COUNTER", "COUNTERTOP", "BLDG", "BUILDING"];
 const FINISH_HEADERS = ["CODE", "MARK", "SYMBOL", "MATERIAL", "MANUFACTURER", "PRODUCT", "STYLE", "COLOR", "SIZE", "REMARKS", "DESCRIPTION", "PATTERN", "COMMENTS"];
 // A header CELL is often a multi-word span ("FLOOR FINISH", "CEILING FINISH")
 // — the vocabulary word inside it names the column.
@@ -307,9 +307,16 @@ const FINISH_HEADERS = ["CODE", "MARK", "SYMBOL", "MATERIAL", "MANUFACTURER", "P
  * column when BASE is narrow and the wall column is wide. */
 type Anchor = { label: string; x: number; x0?: number; x1?: number };
 
-const headerLabel = (s: string, vocab: string[]): string | null => {
-  for (const w of norm(s).split(/[^A-Z]+/)) if (w && vocab.includes(w)) return w;
-  return null;
+const headerLabel = (s: string, vocab: string[]): string | null => headerLabels(s, vocab)[0] ?? null;
+/** EVERY vocabulary word in a header cell, in order. A cell can name more than
+ * one column's worth of vocabulary — "ROOM #" and "ROOM NAME" both lead with
+ * ROOM — so the anchor builder falls through to the next word when the first
+ * is already taken. Without that, the NAME column loses its anchor and the
+ * room name merges into the finish column beside it. */
+const headerLabels = (s: string, vocab: string[]): string[] => {
+  const out: string[] = [];
+  for (const w of norm(s).split(/[^A-Z]+/)) if (w && vocab.includes(w) && !out.includes(w)) out.push(w);
+  return out;
 };
 
 /** The vocabulary labels a row carries, in x order (duplicates kept — two
@@ -368,10 +375,19 @@ function findHeaderRow(rows: GraphSpan[][], vocab: string[], required: string[],
     for (let j = 0; j < hits.length; j++) {
       const h = hits[j];
       let label = h.label;
+      // An ambiguous label takes its parent's name first (two FINISH columns
+      // become FLOOR FINISH and CEILING FINISH) …
       if (dup.has(h.label) && !SURFACE_WORDS.has(h.label)) {
         const hi = j + 1 < hits.length ? hits[j + 1].span.x : Infinity;
         const parent = parentLabelOver(rows, idx, i, h.span.x, hi, vocab);
         if (parent && parent !== h.label) label = `${parent} ${h.label}`;
+      }
+      // … and failing that, a cell naming more than one vocabulary word falls
+      // through to its next one: "ROOM #" and "ROOM NAME" both lead with ROOM,
+      // and the second must become NAME rather than lose its column.
+      if (used.has(label)) {
+        const alt = headerLabels(h.span.str, vocab).find((w) => !used.has(w));
+        if (alt) label = alt;
       }
       if (used.has(label)) continue;
       used.add(label);
@@ -587,26 +603,31 @@ const numOf = (key: string): string => key.match(QUALIFIED_KEY_RE)?.[2] ?? key;
 
 const centerX = (t: GraphSpan) => t.x + (t.w || 0) / 2;
 
-/** Column starts read off the DATA. Left edges of in-band tokens cluster on
- * the column rule lines, because cells are left-aligned even where headers
- * are centered. Each cluster is then NAMED by the anchor whose header center
- * falls inside it. Returns null — and banding falls back to nearest-anchor —
- * unless every anchor ends up owning a column, so a table this does not fit
- * is never mangled by a half-built column map. */
-function columnStarts(
+/** Column starts read off the DATA, plus WHICH edge of a token to band by.
+ * Some schedules left-align their cells and some centre them; the alignment
+ * is a property of the sheet, not something to assume. Both are tried and the
+ * one that actually explains the data — the tighter clustering — wins. A map
+ * is returned only when every anchor ends up owning a column, in the anchors'
+ * own order; otherwise banding falls back to nearest-anchor, so a table this
+ * does not fit is never mangled by a half-built column map. */
+type ColumnMap = { coord: "left" | "center"; cols: Array<{ start: number; label: string }>; score: number };
+
+function columnMapFor(
   rows: GraphSpan[][],
   anchors: Anchor[],
   cfg: { fromIdx: number; belowY: number },
   x0: number,
   x1: number,
-): Array<{ start: number; label: string }> | null {
+  coord: "left" | "center",
+): ColumnMap | null {
+  const at = (t: GraphSpan) => (coord === "left" ? t.x : t.x + (t.w || 0) / 2);
   const xs: number[] = [];
   const hs: number[] = [];
   for (let i = Math.max(cfg.fromIdx, 0); i < rows.length; i++) {
     if (rowY(rows[i]) <= cfg.belowY) continue;
     for (const t of rows[i]) {
       if (t.x < x0 || t.x > x1 || revisionOf(t.str) != null) continue;
-      xs.push(t.x);
+      xs.push(at(t));
       hs.push(t.h || 8);
     }
   }
@@ -620,19 +641,9 @@ function columnStarts(
     if (last && x - last.start <= tol) { last.n++; continue; }
     clusters.push({ start: x, n: 1 });
   }
-  // A real column start appears on nearly every data row; a cell split into
-  // several spans makes a weaker cluster part-way across its own column.
-  // Threshold against the STRONGEST cluster rather than a row count — the
-  // clustered rows span the whole sheet, not just this table, so counting
-  // them sets the bar far too high and throws the map away.
   const maxN = Math.max(...clusters.map((c) => c.n));
   const kept = clusters.filter((c) => c.n >= Math.max(2, maxN * 0.25));
   if (kept.length < anchors.length) return null;
-  // Assign each cluster to the FIRST anchor whose header center sits at or
-  // right of it — a column's cells start left of the header centered over
-  // them — then take the LEFTMOST cluster per anchor as that column's start.
-  // Taking anything else lets the first token of every cell fall into the
-  // column before it, which is how this went wrong the first time.
   const byLabel = new Map<string, number>();
   for (const c of kept) {
     const own = anchors.find((a) => a.x >= c.start);
@@ -641,24 +652,39 @@ function columnStarts(
     if (cur == null || c.start < cur) byLabel.set(own.label, c.start);
   }
   if (byLabel.size !== anchors.length) return null;
-  const named = [...byLabel.entries()].map(([label, start]) => ({ label, start })).sort((a, b) => a.start - b.start);
-  // starts must stay in the anchors' own order, or the map is not this table
-  const order = anchors.map((a) => a.label).join("|");
-  if (named.map((n) => n.label).join("|") !== order) return null;
-  return named;
+  const cols = [...byLabel.entries()].map(([label, start]) => ({ label, start })).sort((a, b) => a.start - b.start);
+  if (cols.map((c) => c.label).join("|") !== anchors.map((a) => a.label).join("|")) return null;
+  // how well this alignment explains the data: the share of tokens sitting on
+  // a column start rather than scattered between them
+  const starts = kept.map((c) => c.start);
+  let on = 0;
+  for (const x of xs) if (starts.some((st) => Math.abs(x - st) <= tol)) on++;
+  return { coord, cols, score: on / xs.length };
 }
 
-// Band clustered rows to column anchors — shared by extractTable and the
-// title-only continuation path. Phase-3 hardening lives here:
-//   - a revision marker never bands: a delta left of the key column used to
-//     strip to its digit and mint a room ("Δ2" → key "2"), and a delta beside
-//     a cell corrupted its text. Markers attach to the nearest keyed row
-//     within the repair radius as that row's `revision` instead;
-//   - a keyless in-band fragment (a baseline-offset remark span, the wrapped
-//     second line of a wide REMARKS cell) within 0.6× the table's median row
-//     pitch of a keyed row is that row's own ink and merges into its cells —
-//     beyond the radius it is left alone (a NOTES block under the table is
-//     not a remark), exactly as before.
+function columnStarts(
+  rows: GraphSpan[][],
+  anchors: Anchor[],
+  cfg: { fromIdx: number; belowY: number },
+  x0: number,
+  x1: number,
+): ColumnMap | null {
+  // A map has to FIT before it is trusted. A mediocre fit is worse than none:
+  // it looks authoritative and quietly merges a column into its neighbour,
+  // where falling back to nearest-anchor reads the table correctly. Measured
+  // on real sets, a true alignment scores ~0.82–0.90 and a wrong one ~0.54.
+  const FIT_FLOOR = 0.7;
+  const fits = (m: ColumnMap | null) => (m && m.score >= FIT_FLOOR ? m : null);
+  const left = fits(columnMapFor(rows, anchors, cfg, x0, x1, "left"));
+  const center = fits(columnMapFor(rows, anchors, cfg, x0, x1, "center"));
+  if (!left) return center;
+  if (!center) return left;
+  // Left alignment is the common case; centring has to EARN the switch. On a
+  // near tie both modes score well and picking the wrong one merges a column
+  // into its neighbour, so only a clearly better centred fit wins.
+  return center.score > left.score + 0.05 ? center : left;
+}
+
 function bandDataRows(
   rows: GraphSpan[][],
   anchors: Anchor[],
@@ -679,7 +705,7 @@ function bandDataRows(
   // A key belongs to the key column when it sits nearer that column's start
   // than the next column's — sized from the table's own pitch, not from text
   // height, so a wider key ("139A") or a hair of indent still counts.
-  const keyTol = cols && cols.length > 1 ? Math.max(8, (cols[1].start - cols[0].start) * 0.5) : 40;
+  const keyTol = cols && cols.cols.length > 1 ? Math.max(8, (cols.cols[1].start - cols.cols[0].start) * 0.5) : 40;
   const out: TableRow[] = [];
   const outY: number[] = [];
   let region: Bbox | null = null;
@@ -688,8 +714,9 @@ function bandDataRows(
    * reading of its center. */
   const columnOf = (t: GraphSpan): string => {
     if (!cols) return nearestAnchor(centerX(t), anchors);
-    let label = cols[0].label;
-    for (const c of cols) { if (t.x + 1 >= c.start) label = c.label; else break; }
+    const at = cols.coord === "left" ? t.x : centerX(t);
+    let label = cols.cols[0].label;
+    for (const c of cols.cols) { if (at + 1 >= c.start) label = c.label; else break; }
     return label;
   };
   const add = (row: TableRow, toks: GraphSpan[]) => {
@@ -724,7 +751,7 @@ function bandDataRows(
     // clustered across the whole sheet, so a keyed-looking row belonging to
     // something else — a legend, a room tag drawn beside the schedule —
     // otherwise joins the table and shows up as a duplicate key.
-    if (cols && Math.abs(banded[0].x - cols[0].start) > keyTol) continue;
+    if (cols && Math.abs((cols.coord === "left" ? banded[0].x : centerX(banded[0])) - cols.cols[0].start) > keyTol) continue;
     // continuation adoption: a keyed row whose key column does not line up
     // with the base's belongs to some OTHER structure — skipped, never merged
     if (cfg.keyAlign && Math.abs(centerX(banded[0]) - cfg.keyAlign.x) > cfg.keyAlign.tol) continue;

--- a/web/test/sheetgraph.test.ts
+++ b/web/test/sheetgraph.test.ts
@@ -1024,3 +1024,60 @@ test("corroboration: a keynote legend row never becomes a room, and the reason s
   // and the disclosure still cites the ink, so a genuinely omitted room is findable
   assert.ok(g.unmatched_tags.every((u) => u.sheet && u.bbox));
 });
+
+test("cell alignment is READ, not assumed: a schedule that CENTRES its cells bands correctly", () => {
+  // Field-found on a municipal set drawn in a hand-lettered CAD font: cells
+  // are centred, not left-aligned, so a long value ("PNT-1, FRP-1") starts
+  // far left of a short one ("PNT-1") in the same column and left-edge
+  // banding pushed it into the column before it.
+  const centred: SheetSpans = {
+    key: "ctr.pdf#1", sheet_number: "A-624",
+    spans: [
+      sp("ROOM FINISH SCHEDULE", 100, 20),
+      { str: "ROOM #", x: 96, y: 60, w: 60, h: 8 },
+      { str: "ROOM NAME", x: 200, y: 60, w: 90, h: 8 },
+      { str: "FLOOR", x: 380, y: 60, w: 60, h: 8 },
+      { str: "BASE", x: 540, y: 60, w: 50, h: 8 },
+      { str: "WALL", x: 700, y: 60, w: 50, h: 8 },
+      // every cell CENTRED on its column: 126 / 245 / 410 / 565 / 725
+      { str: "100", x: 111, y: 85, w: 30, h: 8 }, { str: "CHEM FEED", x: 200, y: 85, w: 90, h: 8 },
+      { str: "SC-1", x: 390, y: 85, w: 40, h: 8 }, { str: "RB-1", x: 545, y: 85, w: 40, h: 8 },
+      { str: "PNT-1", x: 700, y: 85, w: 50, h: 8 },
+      { str: "102", x: 111, y: 105, w: 30, h: 8 }, { str: "MECH./JAN.", x: 197, y: 105, w: 96, h: 8 },
+      { str: "SC-1", x: 390, y: 105, w: 40, h: 8 }, { str: "RB-1", x: 545, y: 105, w: 40, h: 8 },
+      // the long one: centred, so it STARTS left of the short values above
+      { str: "PNT-1, FRP-1", x: 665, y: 105, w: 120, h: 8 },
+      { str: "104", x: 111, y: 125, w: 30, h: 8 }, { str: "TLT/SHWR", x: 202, y: 125, w: 86, h: 8 },
+      { str: "HTF-1", x: 387, y: 125, w: 46, h: 8 }, { str: "HTB-1", x: 542, y: 125, w: 46, h: 8 },
+      { str: "PNT-1", x: 700, y: 125, w: 50, h: 8 },
+    ],
+  };
+  const tab = extractTable(centred, "room-finish")!;
+  assert.deepEqual(tab.rows.map((r) => r.key), ["100", "102", "104"]);
+  const r102 = tab.rows.find((r) => r.key === "102")!;
+  assert.equal(r102.cells.BASE.text, "RB-1", "the long wall value did not spill into BASE");
+  assert.equal(r102.cells.WALL.text, "PNT-1, FRP-1");
+  assert.equal(tab.rows.find((r) => r.key === "104")!.cells.FLOOR.text, "HTF-1");
+});
+
+test("a header cell naming two vocabulary words gives up the second: ROOM # | ROOM NAME", () => {
+  // Both cells lead with ROOM. Deduping on the leading word alone left the
+  // NAME column with no anchor, and the room name merged into FLOOR.
+  const sched: SheetSpans = {
+    key: "rn.pdf#1", sheet_number: "A-625",
+    spans: [
+      sp("ROOM FINISH SCHEDULE", 100, 20),
+      sp("ROOM #", 100, 60), sp("ROOM NAME", 200, 60), sp("FLOOR", 400, 60), sp("BASE", 520, 60), sp("WALL", 640, 60),
+      sp("100", 100, 85), sp("CHEM FEED", 200, 85), sp("SC-1", 400, 85), sp("RB-1", 520, 85), sp("PNT-1", 640, 85),
+      sp("101", 100, 105), sp("LAB", 200, 105), sp("SC-1", 400, 105), sp("RB-1", 520, 105), sp("PNT-1", 640, 105),
+      sp("102", 100, 125), sp("CONTROL RM", 200, 125), sp("HTF-1", 400, 125), sp("HTB-1", 520, 125), sp("PNT-1", 640, 125),
+    ],
+  };
+  const tab = extractTable(sched, "room-finish")!;
+  assert.ok(tab.headers.includes("NAME"), `the name column keeps an anchor: ${tab.headers.join(" | ")}`);
+  for (const r of tab.rows) {
+    assert.ok(!/CHEM FEED|LAB|CONTROL RM/.test(r.cells.FLOOR.text), `room name leaked into FLOOR on ${r.key}: "${r.cells.FLOOR.text}"`);
+  }
+  assert.equal(tab.rows.find((r) => r.key === "100")!.cells.FLOOR.text, "SC-1");
+  assert.equal(tab.rows.find((r) => r.key === "102")!.cells.BASE.text, "HTB-1");
+});


### PR DESCRIPTION
Widening the eval corpus to a **fourth general contractor and a fourth building typology** — a municipal treatment plant drawn in a hand-lettered CAD font — broke the parser in two new ways. Both fixed, both with fixtures.

## Cell alignment is READ, not assumed

Some schedules left-align their cells; some centre them. It's a property of the sheet, and assuming either one is wrong half the time.

On the centred set, a long value (`PNT-1, FRP-1`) starts far to the *left* of a short one (`PNT-1`) in the same column — so left-edge banding pushed it into the column before it and BASE read `RB-1 PNT-1, FRP-1`. Both alignments are now derived and **scored by how well they explain the data**.

The part worth stating: a map that fits *badly* is now **discarded rather than trusted**. My first cut kept the best-scoring map unconditionally, which silently broke the demo set's MATERIAL SCHEDULE — a 0.541-scoring centred map merged MATERIAL into CODE, where falling back to nearest-anchor had read it correctly. A mediocre map looks authoritative and quietly merges a column into its neighbour. Measured across real sets: a true alignment scores **0.82–0.90**, a wrong one **0.54**, so the floor sits at 0.70.

## A header cell naming two vocabulary words gives up the second

`ROOM #` and `ROOM NAME` both lead with ROOM. The name column was deduped away, lost its anchor, and every room name merged into the finish column beside it — `FLOOR` read `CHEM FEED SC-1`. A cell now falls through to its next vocabulary word when the first is taken. Ordering matters and cost a round-trip: fall-through has to run *after* parent-naming, or the two-FINISH case stops resolving to `FLOOR FINISH` / `CEILING FINISH`.

## Also

- `CASEWORK` / `CABINET` / `COUNTER` / `COUNTERTOP` are vocabulary, so casework columns stop spilling into WALL.
- `graph-render.mjs` keeps the page number in output names — every sheet of a combined single-file set was overwriting the last — and skips table-less sheets unless `--all`.

## Measured

Four real sets, four general contractors, four typologies (two gyms, retail, municipal), keys read independently off the renders:

| | cell P / R | tag P / R |
|---|---|---|
| NNI · Crunch Mishawaka | 1.000 / 1.000 | 1.000 / 1.000 |
| Forte · Planet Fitness New Castle | 1.000 / 1.000 | 1.000 / 1.000 |
| Elder-Jones · Ulta Bowling Green | 1.000 / 1.000 | 1.000 / 1.000 |
| Grassland STP (municipal) | 1.000 / 1.000 | 1.000 / 1.000 |
| **corpus** | **1.000 / 1.000** | **1.000 / 1.000** |

**434 cells, 0 wrong, 0 missed. 86 room tags, 0 non-rooms reported.** 32 lib tests, 166 MCP tests green.

Ships as opentakeoff-mcp **0.9.47**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)