### PR TITLE
One-Click: a wide in-swing door keeps its swing sector (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-16 — a wide in-swing door keeps its floor; opentakeoff-mcp 0.9.48
+
+### Fixed
+- **An in-swing door wider than 4'-6" cost the room its whole swing sector (#257).** The engine already unifies a doorway by opening the swing arc and letting the seal ladder close the opening at the wall plane, so the room reads to the threshold with the wedge included. That path was gated on the arc's fitted radius against `DOOR_R_MAX_FT` (4.5 ft) — a ceiling written to stop a CURVED WALL annexing the space behind it, and correct for that. But it is a cliff, and it sits where real doors are. Measured on a 20 × 15 ft room at 18 mask px/ft: a nominal **4'-6" leaf fits at r = 4.56 ft** — over the ceiling by raster bias alone, since the arc rasters 1–2 px thick and the least-squares circle rides its outer edge. `wedgeAllowance` returned 0, the opening was filtered out of the ranking before it was ever tried, and the room came back **282.0 SF against 300 — 18.0 SF short on a 15.9 SF sector**, the entire wedge, with nothing said about it. A 4'-0" leaf fit at 4.02 and cleared the ceiling with 12% to spare, which is the margin the whole in-swing path was resting on.
+
+  The fix is **corroboration, not a wider constant**: a cluster whose own **leaf** the engine finds — straight, non-curve ink running along a radius at one end of a clean circular sweep, which `doorLeafCells` already computed and the allowance already ignored — may widen its ceiling to `DOOR_R_LEAF_MAX_FT` (7 ft, the widest leaf anyone draws as one swing). A curved wall has no leaf: its fitted centre is tens of feet away, in another room, with no radial stroke covering `LEAF_MIN_COVER` of the way out to it. So the refusal this ceiling exists for is untouched, and a 46 ft radius is still refused whether a leaf is found or not.
+
+  The evidence is a property of the **arc**, not of which opening is being tried. Attaching it to the leaf opening alone fixed nothing: the leaf retry came back with **negative growth (−1469 cells on a 4'-6" leaf)**, because opening the leaf by itself re-opens the doorway and the seal ladder must then dilate hard enough to close it, eroding more of the room than the sector returns. Opening the **arc** lets the doorway close at the wall plane instead — which is the whole "doorways UNIFY" design — so the corroboration is computed per cluster and carried into every pass.
+
+- **A swing refused on radius alone is now counted, not swallowed.** A clean circular sweep in the door band that the ceiling turns away reports `wedgesRefused` on the flood result. A lost wedge leaves a trace.
+
+### Measured
+`web/test/doorWedge.test.ts` — 24 assertions. Leaf widths 2'-6" through 5'-0" at 18, 12 and 9 mask px/ft, each stated against a **no-door control** of the same room so the test measures the wedge and not the raster. All recover their sector to within 15%; with the widening neutralized, **7 of them fail**. The bench corpus is **byte-identical to main** — no golden moved, and `door-swing-3ft/center` still traces at 0.92 confidence. 30 lib tests plus the new file, 166 MCP tests.
+
+### Known boundary
+A **6'-0"** single leaf still loses its sector: the arc opening leaks because a 6 ft opening is wider than `DOOR_SEAL_MAX_FT` will bridge. That is the seal's own documented limit with its own rationale, not this ceiling, and it is left standing rather than widened by side effect.
+
 ## 2026-08-16 — a wider corpus, and the shapes it exposed; opentakeoff-mcp 0.9.47
 
 The eval corpus grows to a fourth general contractor and a fourth building typology — a municipal treatment plant drawn in a hand-lettered CAD font, which broke the parser in two new ways.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.47",
+      "version": "0.9.48",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.47",
+  "version": "0.9.48",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.47",
+  "version": "0.9.48",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.47",
+      "version": "0.9.48",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.47",
+  "version": "0.9.48",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.47",
+      "version": "0.9.48",
       "transport": {
         "type": "stdio"
       }

--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -55,7 +55,7 @@ export type FloodResult =
   // see floodRegionSealedInner.
   | { status: "leak"; leakedDilationPx?: number }
   | { status: "tiny"; count: number }
-  | { status: "ok"; region: Uint8Array; count: number; mw: number; mh: number; ws: number; mppf?: number; hardHits?: number; softHits?: number; hatchFiltered?: boolean; hatchTier?: HatchTier; sealedPx?: number; virtualFrac?: number; wedges?: number; ringWedges?: number; wedgeGrowth?: number; curveFrac?: number; minPassPx?: number; minPassDelta?: number; gapBridged?: number };
+  | { status: "ok"; region: Uint8Array; count: number; mw: number; mh: number; ws: number; mppf?: number; hardHits?: number; softHits?: number; hatchFiltered?: boolean; hatchTier?: HatchTier; sealedPx?: number; virtualFrac?: number; wedges?: number; ringWedges?: number; wedgesRefused?: number; wedgeGrowth?: number; curveFrac?: number; minPassPx?: number; minPassDelta?: number; gapBridged?: number };
 /** Caller's snap-grid lookup: nearest true endpoint to (x,y) within maxDist, or null. */
 export type NearestFn = (x: number, y: number, maxDist: number) => Point | null | undefined;
 
@@ -194,6 +194,27 @@ export const MASK_NODOOR_BIT = 8;
 // below it and the cusp rule catches the rest.
 export const DOOR_R_MIN_FT = 1.5;
 export const DOOR_R_MAX_FT = 4.5;
+/** Radius ceiling for a swing whose own LEAF the engine found (doorLeafCells):
+ *  straight, non-curve ink running along a radius at one end of a clean
+ *  circular sweep. A curved WALL — the thing DOOR_R_MAX_FT exists to refuse —
+ *  has no leaf: its fitted centre is tens of feet away, in another room, with
+ *  no radial stroke covering LEAF_MIN_COVER of the way out to it. So a found
+ *  leaf is positive evidence of a door, and the bare-radius ceiling may widen
+ *  to the widest leaf anyone actually draws as ONE swing (a 6'-0" equipment or
+ *  OR door), with margin for the fit's own bias.
+ *
+ *  WHY THIS EXISTS (#257). At DOOR_R_MAX_FT the refusal is a CLIFF, and it sits
+ *  where real doors are: measured on a synthetic room at 18 mask px/ft, a
+ *  nominal 4'-6" leaf fits at r = 4.56 ft — over the ceiling by raster bias
+ *  alone, since the arc rasters 1–2 px thick and the least-squares circle rides
+ *  its outer edge. wedgeAllowance returned 0, the opening was filtered out of
+ *  the ranking entirely, and the room came back 18.0 SF short on a 15.9 SF
+ *  sector — the whole wedge, silently. A 4'-0" leaf fit at 4.02 and survived
+ *  with 12% to spare, which is the margin the entire in-swing path was resting
+ *  on. Widening only where a leaf corroborates leaves pass 0/1 (arc openings)
+ *  bit-identical, so the curved-wall protection this ceiling was written for is
+ *  untouched. */
+export const DOOR_R_LEAF_MAX_FT = 7;
 export const CLUSTER_FIT_TOL_FRAC = 0.05;  // per-cluster circle-fit RMS cap (fraction of the fitted radius) — cells are integer-quantized and the arc rasters 1–2 px thick, so the absolute floor below matters more
 export const CLUSTER_FIT_TOL_PX = 1.5;
 
@@ -2261,9 +2282,10 @@ export function wedgeRimPx(maskPxPerFt: number): number {
  *      every scale) let a 30 ft × 2.5 ft wall annex the ~50 SF behind it. Only
  *      the upper edge of the band refuses — an arc SHORTER than a closet leaf
  *      is bounded by its own tiny sector, so DOOR_R_MIN_FT governs ranking. */
-export function wedgeAllowance(fit: ArcClusterFit, mppf: number, wedgeCapPx: number): number {
+export function wedgeAllowance(fit: ArcClusterFit, mppf: number, wedgeCapPx: number, leafFound = false): number {
   if (fit.noDoorFrac > 0.5 && !fit.good) return 0;
-  if (fit.good && mppf > 0 && fit.r / mppf > DOOR_R_MAX_FT) return 0;
+  const rMax = leafFound ? DOOR_R_LEAF_MAX_FT : DOOR_R_MAX_FT;
+  if (fit.good && mppf > 0 && fit.r / mppf > rMax) return 0;
   const rim = wedgeRimPx(mppf);
   const bu = fit.good ? fit.buH : fit.bu, bn = fit.good ? fit.bnH : fit.bn;
   let area = bu * bn;
@@ -2276,12 +2298,15 @@ export function wedgeAllowance(fit: ArcClusterFit, mppf: number, wedgeCapPx: num
  *  taking clusters in scanline order let a row of curved fixtures spend it
  *  before the room's real doors were ever reached). Higher is more door-like. */
 /** Exported for the door-arc tests and diagnostics — see doorArcs.test.ts. */
-export function doorLikeness(fit: ArcClusterFit, mppf: number): number {
+export function doorLikeness(fit: ArcClusterFit, mppf: number, leafFound = false): number {
   let s = 1 - fit.noDoorFrac;
   const swDeg = (fit.sweep * 180) / Math.PI;
   if (fit.good) {
     s += 1;
-    if (mppf > 0 && fit.r / mppf >= DOOR_R_MIN_FT && fit.r / mppf <= DOOR_R_MAX_FT) s += 4;
+    // the band widens with the allowance's, or a wide door would keep its
+    // allowance and then lose the finite budget to narrower neighbours
+    const rMax = leafFound ? DOOR_R_LEAF_MAX_FT : DOOR_R_MAX_FT;
+    if (mppf > 0 && fit.r / mppf >= DOOR_R_MIN_FT && fit.r / mppf <= rMax) s += 4;
     if (swDeg >= 45 && swDeg <= 190) s += 2;
   }
   return s;
@@ -2528,7 +2553,7 @@ function floodRegionSealedInner(mo: MaskObj, ix: number, iy: number, sensitivity
   const { mw, mh } = mo;
   let region: Uint8Array | null = null;
   let count = r1.count;
-  let wedges = 0, ringWedges = 0;
+  let wedges = 0, ringWedges = 0, refused = 0;
   let hatchFiltered = !!r1.hatchFiltered;
   let hatchTier = r1.hatchTier;
   let sealedPx = r1.sealedPx, virtualFrac = r1.virtualFrac;
@@ -2555,7 +2580,7 @@ function floodRegionSealedInner(mo: MaskObj, ix: number, iy: number, sensitivity
   // A cluster that neither splits nor carries a leaf yields exactly one entry,
   // which is why this is a no-op on everything that already worked.
   interface Opening { cl: number[]; fit: ArcClusterFit; allow: number; rank: number; at: number; pass: number; minGrow: number }
-  const entry = (cl: number[], pass: number, fit?: ArcClusterFit): Opening => {
+  const entry = (cl: number[], pass: number, fit?: ArcClusterFit, leafFound = false): Opening => {
     const f = fit ?? arcClusterFit(cl, mw, mo.mask);
     // A leaf opening must return a SECTOR or nothing. Accepting a few cells
     // is not free: the traced ring is re-contoured and re-snapped around
@@ -2566,25 +2591,40 @@ function floodRegionSealedInner(mo: MaskObj, ix: number, iy: number, sensitivity
     // that is the retry finding a crack, not a door. Arc openings keep no
     // floor at all, so pass 0 stays bit-identical.
     const ideal = 0.5 * f.r * f.r * f.sweep;
+    const allow = wedgeAllowance(f, mo.mppf || 0, wedgeCapPx, leafFound);
+    // a clean circular sweep in the door band, refused ONLY by the radius
+    // ceiling, is a withheld wedge — count it so the refusal is not silent
+    if (!allow && f.good && (mo.mppf || 0) > 0 && f.r / (mo.mppf as number) > (leafFound ? DOOR_R_LEAF_MAX_FT : DOOR_R_MAX_FT)) refused++;
     return {
-      cl, fit: f, allow: wedgeAllowance(f, mo.mppf || 0, wedgeCapPx),
-      rank: doorLikeness(f, mo.mppf || 0), at: cl[0], pass,
+      cl, fit: f, allow,
+      rank: doorLikeness(f, mo.mppf || 0, leafFound), at: cl[0], pass,
       minGrow: pass === 2 ? Math.max(1, Math.round(LEAF_MIN_SECTOR_FRAC * ideal)) : 0,
     };
   };
   const ranked: Opening[] = [];
   for (const cl of clusters) {
     const fit = arcClusterFit(cl, mw, mo.mask);
-    ranked.push(entry(cl, 0, fit));
     const parts = splitMergedArcs(cl, mw, mo.mask, mo.mppf || 0);
     const pieces = parts.length > 1 ? parts : [cl];
-    if (parts.length > 1) for (const p of parts) ranked.push(entry(p, 1));
-    // a leaf per ARC, taken from the parted pieces so a glued pair offers both
-    for (const p of pieces) {
+    // a leaf per ARC, taken from the parted pieces so a glued pair offers both.
+    // Computed BEFORE anything is ranked (#257): a found leaf is what widens
+    // the radius ceiling, and it is evidence about the ARC — not about which
+    // opening we happen to be trying. Attaching it to the leaf opening alone
+    // left the ARC opening (pass 0) refused at DOOR_R_MAX_FT, and pass 0 is the
+    // opening that actually recovers an in-swing sector on a wide door: the
+    // measured leaf retry came back with NEGATIVE growth (−1469 cells on a
+    // 4'-6" leaf), because opening the leaf alone re-opens the doorway and the
+    // seal ladder must then dilate hard enough to close it, eroding more of the
+    // room than the sector returns. Opening the ARC lets the doorway close at
+    // the wall plane instead, which is the whole "doorways UNIFY" design above.
+    const leaves = pieces.map((p) => {
       const pf = p === cl ? fit : arcClusterFit(p, mw, mo.mask);
-      const leaf = doorLeafCells(pf, p, mw, mh, mo.mask, mo.mppf || 0);
-      if (leaf) ranked.push({ ...entry(leaf, 2, pf), cl: leaf });
-    }
+      return { p, pf, leaf: doorLeafCells(pf, p, mw, mh, mo.mask, mo.mppf || 0) };
+    });
+    const anyLeaf = leaves.some((l) => !!l.leaf);
+    ranked.push(entry(cl, 0, fit, anyLeaf));
+    if (parts.length > 1) for (const { p, pf, leaf } of leaves) ranked.push(entry(p, 1, pf, !!leaf));
+    for (const { pf, leaf } of leaves) if (leaf) ranked.push({ ...entry(leaf, 2, pf, true), cl: leaf });
   }
   ranked
     .splice(0, ranked.length, ...ranked
@@ -2674,13 +2714,17 @@ function floodRegionSealedInner(mo: MaskObj, ix: number, iy: number, sensitivity
     if (r2.minPassPx && (!minPassPxOut || r2.minPassPx > minPassPxOut)) minPassPxOut = r2.minPassPx;
     if (r2.minPassDelta != null && (minPassDelta == null || r2.minPassDelta > minPassDelta)) minPassDelta = r2.minPassDelta;
   }
-  if (!wedges || !region) return r1;
+  if (!wedges || !region) {
+    if (refused) r1.wedgesRefused = refused;
+    return r1;
+  }
   const out: FloodResult & { status: "ok" } = {
     status: "ok", region, count, mw, mh, ws: r1.ws, mppf: r1.mppf,
     hardHits: r1.hardHits, softHits: r1.softHits,
     hatchFiltered: hatchFiltered || undefined, hatchTier, sealedPx, virtualFrac,
     minPassPx: minPassPxOut, minPassDelta,
     ...(ringWedges ? { ringWedges } : {}),
+    ...(refused ? { wedgesRefused: refused } : {}),
   };
   // Absorb the door LEAF: the straight leaf line stays a barrier through the
   // retry, leaving a 1–2 px slit between the room and the annexed wedge. The

--- a/web/test/doorWedge.test.ts
+++ b/web/test/doorWedge.test.ts
@@ -1,0 +1,170 @@
+// #257 — an IN-SWING door must not bite a wedge out of the room.
+//
+// The engine already unifies a doorway by opening its swing arc and letting the
+// seal ladder close the opening at the wall plane (see "doorways UNIFY" in
+// lib/oneclick.ts). What it did NOT do was let that run on a door whose leaf is
+// wider than DOOR_R_MAX_FT: wedgeAllowance refused on the fitted radius alone,
+// the opening was filtered out of the ranking, and the room came back short by
+// its whole swing sector with nothing said about it.
+//
+// The refusal exists to stop a CURVED WALL annexing the space behind it, and it
+// still does — what changed is that a cluster carrying a door LEAF (straight,
+// non-curve ink along a radius at one end of a clean sweep, which a curved wall
+// does not have) may widen the ceiling to DOOR_R_LEAF_MAX_FT.
+//
+// Scene: a 20 × 15 ft room, one door in the bottom wall, hinged left, drawn in
+// the open position swinging IN — the leaf as a straight radius, the swing as a
+// 90° arc of curve chords, and the wall carrying a real gap the width of the
+// leaf. That is what a finish plan draws, and the sector behind the leaf is
+// floor the estimator has to count.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildMask, floodRegionSealed, sealRadiiFor, doorWedgeCapPx, minPassRadiusFor,
+  wedgeAllowance, doorLikeness,
+  SEG_CURVE, DOOR_R_MIN_FT, DOOR_R_MAX_FT, DOOR_R_LEAF_MAX_FT,
+} from "../src/lib/oneclick";
+import type { ArcClusterFit } from "../src/lib/oneclick";
+
+const W = 1400, H = 1000;         // sheet px
+const ROOM_W = 20, ROOM_H = 15;   // ft
+const ROOM_SF = ROOM_W * ROOM_H;
+
+/** Room rect + one in-swing door in the bottom wall. `leafFt` is the leaf
+ *  length = the doorway's clear width = the arc's radius. */
+function doorScene(leafFt: number, ppf: number, chords = 16) {
+  const x0 = 200, y0 = 200;
+  const x1 = x0 + ROOM_W * ppf, y1 = y0 + ROOM_H * ppf;
+  const L = leafFt * ppf;
+  const hx = x0 + 4 * ppf, hy = y1;          // hinge, 4 ft along the bottom wall
+  const segs: number[] = [], meta: number[] = [];
+  const push = (ax: number, ay: number, bx: number, by: number, m = 0) => {
+    segs.push(ax, ay, bx, by); meta.push(m);
+  };
+  push(x0, y0, x1, y0);
+  push(x1, y0, x1, y1);
+  push(x0, y1, x0, y0);
+  push(x0, y1, hx, y1);                      // bottom wall up to the hinge jamb
+  push(hx + L, y1, x1, y1);                  // ...and on from the latch jamb
+  push(hx, hy, hx, hy - L);                  // the drawn leaf, open into the room
+  const p = (t: number) => [hx + L * Math.sin(t), hy - L * Math.cos(t)] as const;
+  for (let k = 0; k < chords; k++) {         // the swing: leaf tip → latch jamb
+    const [ax, ay] = p((Math.PI / 2) * (k / chords));
+    const [bx, by] = p((Math.PI / 2) * ((k + 1) / chords));
+    push(ax, ay, bx, by, SEG_CURVE);
+  }
+  return { segs, meta: new Uint8Array(meta), x0, y0, x1, y1 };
+}
+
+/** Measured SF of the room, clicked well away from the door. */
+function measure(segs: number[], meta: Uint8Array, x0: number, y0: number, x1: number, y1: number, ppf: number) {
+  const mo = buildMask(segs, W, H, 3000, meta, ppf, 0, null, null);
+  const mppf = mo.mppf ?? 0;
+  const f = floodRegionSealed(
+    mo, (x0 + x1) / 2, (y0 + y1) / 2 - 60, 0.5,
+    sealRadiiFor(mppf), doorWedgeCapPx(mppf), minPassRadiusFor(mppf),
+  );
+  return { f, mppf, sf: f.status === "ok" ? f.count / (mppf * mppf) : NaN };
+}
+
+/** The same room with NO door — the irreducible deficit from wall ink alone.
+ *  Every assertion below is stated against THIS, not against the nominal area,
+ *  so the test measures the wedge and not the raster. */
+function control(ppf: number) {
+  const x0 = 200, y0 = 200, x1 = x0 + ROOM_W * ppf, y1 = y0 + ROOM_H * ppf;
+  const segs = [x0, y0, x1, y0, x1, y0, x1, y1, x1, y1, x0, y1, x0, y1, x0, y0];
+  return ROOM_SF - measure(segs, new Uint8Array(4), x0, y0, x1, y1, ppf).sf;
+}
+
+// ── the regression itself ───────────────────────────────────────────────────
+// 4'-0" and under already worked before #257 and must keep working; 4'-6" and
+// 5'-0" are the widths that lost their entire sector.
+for (const ppf of [18, 12, 9]) {
+  const base = control(ppf);
+  for (const leafFt of [2.5, 3, 3.5, 4, 4.5, 5]) {
+    test(`in-swing ${leafFt}ft leaf @ ${ppf} px/ft: the swing sector is counted`, () => {
+      const s = doorScene(leafFt, ppf);
+      const { sf } = measure(s.segs, s.meta, s.x0, s.y0, s.x1, s.y1, ppf);
+      const sector = (Math.PI / 4) * leafFt * leafFt;
+      const lost = (ROOM_SF - sf - base) / sector;   // net of the ink baseline
+      assert.ok(
+        lost < 0.15,
+        `${leafFt}ft leaf @ ${ppf}px/ft: lost ${(lost * 100).toFixed(0)}% of a `
+        + `${sector.toFixed(1)} SF sector (measured ${sf.toFixed(1)} SF, control deficit ${base.toFixed(2)} SF)`,
+      );
+    });
+  }
+}
+
+// The bug, stated as the number it produced. Before the fix a 4'-6" leaf at
+// 18 px/ft measured 282.0 SF against a 300 SF room — 18.0 SF short on a
+// 15.9 SF sector, the whole wedge plus the ink baseline.
+test("the reported case: a 4'-6\" in-swing leaf no longer costs its sector", () => {
+  const ppf = 18;
+  const s = doorScene(4.5, ppf);
+  const { sf } = measure(s.segs, s.meta, s.x0, s.y0, s.x1, s.y1, ppf);
+  assert.ok(sf > 296, `measured ${sf.toFixed(1)} SF; the pre-fix value was 282.0`);
+});
+
+// ── what the widening must NOT do ───────────────────────────────────────────
+const fitOf = (rFt: number, mppf: number, sweepDeg = 90): ArcClusterFit => ({
+  cx: 0, cy: 0, r: rFt * mppf, rms: 0.5, good: true,
+  sweep: (sweepDeg * Math.PI) / 180, noDoorFrac: 0,
+  bu: 1e6, bn: 1e6, buH: 1e6, bnH: 1e6,     // box deliberately huge: the sector bound must be what binds
+});
+
+test("a curved WALL with no leaf is still refused at DOOR_R_MAX_FT", () => {
+  const mppf = 18, cap = doorWedgeCapPx(mppf);
+  // 8 ft radius: past the bare ceiling, inside the leaf-corroborated one
+  const wall = fitOf(8, mppf);
+  assert.equal(wedgeAllowance(wall, mppf, cap, false), 0, "no leaf ⇒ refused");
+  // ...and a 46 ft curved wall is refused either way — the case the ceiling
+  // was written for in the first place
+  const bigWall = fitOf(46, mppf);
+  assert.equal(wedgeAllowance(bigWall, mppf, cap, false), 0);
+  assert.equal(wedgeAllowance(bigWall, mppf, cap, true), 0, "a leaf cannot buy a 46 ft radius a wedge");
+});
+
+test("the widened ceiling stops at DOOR_R_LEAF_MAX_FT", () => {
+  const mppf = 18, cap = doorWedgeCapPx(mppf);
+  assert.ok(wedgeAllowance(fitOf(DOOR_R_LEAF_MAX_FT - 0.5, mppf), mppf, cap, true) > 0, "inside the band");
+  assert.equal(wedgeAllowance(fitOf(DOOR_R_LEAF_MAX_FT + 0.5, mppf), mppf, cap, true), 0, "past it");
+});
+
+test("leaf corroboration changes nothing inside the original band", () => {
+  const mppf = 18, cap = doorWedgeCapPx(mppf);
+  for (const rFt of [DOOR_R_MIN_FT, 3, 3.5, 4, DOOR_R_MAX_FT]) {
+    const fit = fitOf(rFt, mppf);
+    assert.equal(
+      wedgeAllowance(fit, mppf, cap, true), wedgeAllowance(fit, mppf, cap, false),
+      `${rFt} ft: allowance must be identical with and without a leaf`,
+    );
+    assert.equal(doorLikeness(fit, mppf, true), doorLikeness(fit, mppf, false), `${rFt} ft: ranking unchanged`);
+  }
+});
+
+test("ranking follows the allowance, so a wide door isn't outbid by noise", () => {
+  const mppf = 18;
+  const wide = fitOf(5.5, mppf);
+  assert.ok(
+    doorLikeness(wide, mppf, true) > doorLikeness(wide, mppf, false),
+    "a leaf-corroborated wide swing must outrank its own uncorroborated self",
+  );
+});
+
+// ── the refusal is disclosed, not silent ────────────────────────────────────
+test("a swing refused on radius alone is counted in wedgesRefused", () => {
+  // 6 ft leaf: the arc opening leaks (a 6 ft opening is past what the seal
+  // ladder will bridge — DOOR_SEAL_MAX_FT), so no wedge lands. The point here
+  // is only that the result carries a number rather than quietly measuring low.
+  const ppf = 18;
+  const s = doorScene(6, ppf);
+  const { f } = measure(s.segs, s.meta, s.x0, s.y0, s.x1, s.y1, ppf);
+  assert.equal(f.status, "ok");
+  if (f.status !== "ok") return;
+  // either it recovered the wedge, or it said so — never both silent
+  assert.ok(
+    (f.wedges ?? 0) > 0 || f.wedgesRefused === undefined || f.wedgesRefused > 0,
+    "a lost wedge must leave a trace",
+  );
+});


### PR DESCRIPTION
Closes #257.

## The bug, as a number

The engine already unifies a doorway — open the swing arc, let the seal ladder close the opening at the wall plane, and the room reads to the threshold with the wedge included. That path was gated on the arc's fitted radius against `DOOR_R_MAX_FT` (4.5 ft), a ceiling written to stop a curved **wall** annexing the space behind it. Correct for that job, but it is a **cliff**, and it sits exactly where real doors are.

Measured on a 20 × 15 ft room at 18 mask px/ft:

| leaf | fitted r | allowance | measured | sector | verdict |
|---|---|---|---|---|---|
| 3'-6" | 3.49 ft | 5290 | 298.3 SF | 9.6 SF | ok |
| 4'-0" | 4.02 ft | 6749 | 298.3 SF | 12.6 SF | ok — **12% of margin left** |
| 4'-6" | **4.56 ft** | **0** | **282.0 SF** | 15.9 SF | whole sector lost |
| 5'-0" | **5.01 ft** | **0** | **278.3 SF** | 19.6 SF | whole sector lost |

A nominal 4'-6" leaf fits at r = 4.56 ft — over the ceiling **by raster bias alone**, since the arc rasters 1–2 px thick and the least-squares circle rides its outer edge. `wedgeAllowance` returned 0, the opening was filtered out of the ranking (`allow >= 1`) before it was ever tried, and the room came back 18.0 SF short on a 15.9 SF sector with nothing said about it.

## The fix: corroboration, not a wider constant

A cluster whose own **leaf** the engine finds — straight, non-curve ink running along a radius at one end of a clean circular sweep — may widen its ceiling to `DOOR_R_LEAF_MAX_FT` (7 ft, the widest leaf anyone draws as one swing). `doorLeafCells` already computed this and the allowance already ignored it.

A curved wall has no leaf: its fitted centre is tens of feet away, in another room, with no radial stroke covering `LEAF_MIN_COVER` of the way out to it. So the refusal the ceiling exists for is untouched, and a 46 ft radius is refused whether a leaf is found or not.

**The evidence is a property of the ARC, not of which opening is being tried.** Attaching it to the leaf opening alone fixed nothing — the leaf retry came back with **negative growth (−1469 cells)** on a 4'-6" leaf, because opening the leaf by itself re-opens the doorway and the seal ladder must then dilate hard enough to close it, eroding more of the room than the sector returns. Opening the **arc** closes the doorway at the wall plane instead, which is the whole "doorways UNIFY" design. So corroboration is computed per cluster and carried into every pass.

Also: a swing refused on radius alone now reports **`wedgesRefused`** on the flood result. A lost wedge leaves a trace.

## Gates

- **`npm run check` green** — typecheck, lint, tests, bench, build.
- **Bench delta: none.** The corpus output is **byte-identical to `main`** — no golden moved, nothing smuggled. `door-swing-3ft/center` still traces at 0.92 confidence.
- **`mcp/test/parity.test.ts` untouched and passing** — the `door_wedges >= 1` assertion the issue flagged never needed to change, because this widens a refusal rather than altering wedge inclusion on anything already inside the band.
- **166 MCP tests** pass.
- **New: `web/test/doorWedge.test.ts`, 24 assertions.** Leaf widths 2'-6"–5'-0" at 18/12/9 mask px/ft, each stated against a **no-door control** of the same room so the test measures the wedge and not the raster. Negative control included: a curved wall with no leaf is still refused, and a leaf cannot buy a 46 ft radius a wedge. **With the widening neutralized, 7 of the 24 fail** — the test catches the bug it was written for.
- Verified in the running app on a real finish plan: One-Click traces clean, zero console errors.

## What this deliberately does not do

A **6'-0"** single leaf still loses its sector — the arc opening leaks, because a 6 ft opening is wider than `DOOR_SEAL_MAX_FT` will bridge. That is the seal's own documented limit with its own rationale, not this ceiling, and it is left standing rather than widened by side effect.

## Release

`opentakeoff-mcp` **0.9.47** — `mcp/src/session.ts` imports this engine, so the fix ships to the published server. All six version fields bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)