### PR TITLE
seo: Google Search Console ownership verification for the canonical host

### DIFF
--- a/web/public/googlec4381fb3b0fbe628.html
+++ b/web/public/googlec4381fb3b0fbe628.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec4381fb3b0fbe628.html


### PR DESCRIPTION
Google is the **#2 referrer** to this repo (144 unique referrers / 423 views in the trailing 14 days) with zero SEO work behind it. `sitemap.xml` and `robots.txt` have been live and correct since 08-03 — but the Search Console property was never claimed, so none of that traffic is measurable and the sitemap has never been submitted for crawling.

This adds the URL-prefix verification token for `https://opentakeoff.kentucky-ai.com/`.

**Why URL-prefix and not Domain verification:** Domain properties require a DNS TXT record at the registrar. URL-prefix ships through the same deploy path as the rest of the site, and the canonical host is the only one that matters — `netlify.toml` already 301s `opentakeoff.netlify.app` into it.

**Why it serves:** the SPA catch-all in `netlify.toml` is a non-forced `200` rewrite, so a real static asset at this path wins over it. (The `.netlify.app` redirect above it needs `force = true` precisely because it does *not* want that behaviour — same mechanism, opposite intent.)

Google requires the file to stay in place permanently; removing it silently unverifies the property.

After merge + deploy: verify in Search Console, then submit `sitemap.xml`.