### PR TITLE
container: a .dockerignore, and a base image that isn't EOL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Docker build context — keep it to what the build actually needs.
+#
+# Both Dockerfiles COPY the repo root, because mcp/ bundles the takeoff engine
+# out of web/src/lib at build time. Without this file that COPY also ships the
+# git history and every local artifact: ~109 MB of .git and, on a developer's
+# machine, ~1.1 GB of node_modules, dist output and the fetched voice model —
+# none of which the build reads. Tracked sources are ~22 MB.
+#
+# This is not only a speed fix. A remote builder (Glama's, among others) pays
+# for that context on every build, and a build that fails for being too big or
+# too slow looks exactly like a build that fails for being broken.
+
+.git
+.github
+.gitignore
+
+# Installed trees — every stage runs its own `npm ci`.
+**/node_modules
+
+# Build output — regenerated in the build stage.
+**/dist
+mcp/*.mcpb
+
+# Fetched at deploy time by web/scripts/fetch-voice-model.mjs (~44 MB), never
+# read by the MCP server.
+web/public/models
+
+# Docs, media and fixtures: nothing in the bundle imports them.
+docs
+demo
+web/public/demo
+web/test
+web/bench
+capture
+server
+*.md
+!mcp/README.md
+
+# Local noise.
+.DS_Store
+**/.DS_Store
+.env
+.env.*
+*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,21 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          if git diff --quiet "$BASE" HEAD -- mcp/; then
-            echo "mcp/ untouched — nothing to check."
+          # Container-only files are excluded from the trigger. The guard exists
+          # because a change to the PUBLISHED server must ship, and the npm
+          # tarball is exactly four entries — dist/, README.md, package.json
+          # ("files": ["dist","README.md"]). mcp/Dockerfile is not one of them:
+          # it is how Glama and other registries build an image, never something
+          # a user installs. Demanding a version bump for it would publish a
+          # release whose tarball is byte-identical to the one before it, and a
+          # version number that means nothing is worse than one nobody bumped.
+          PUBLISHED=(mcp/ ':(exclude)mcp/Dockerfile')
+          if git diff --quiet "$BASE" HEAD -- "${PUBLISHED[@]}"; then
+            echo "no change to published mcp/ files — nothing to check."
             exit 0
           fi
-          echo "mcp/ changed in this PR:"
-          git diff --name-only "$BASE" HEAD -- mcp/ | sed 's/^/  /'
+          echo "published mcp/ files changed in this PR:"
+          git diff --name-only "$BASE" HEAD -- "${PUBLISHED[@]}" | sed 's/^/  /'
 
           PKG=$(jq -r .version mcp/package.json)
           SRV=$(jq -r .version mcp/server.json)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #   docker run --rm -i opentakeoff-mcp        # -i: MCP speaks JSON-RPC over stdio
 
 # ---- build stage: bundle server.ts (+ web/src/lib) into dist/ ----------------
-FROM node:20-bookworm-slim AS build
+FROM node:24-bookworm-slim AS build
 WORKDIR /app
 COPY . .
 WORKDIR /app/mcp
@@ -16,7 +16,7 @@ RUN npm ci
 RUN npm run build
 
 # ---- runtime stage: prod deps + the bundled server only ----------------------
-FROM node:20-bookworm-slim AS runtime
+FROM node:24-bookworm-slim AS runtime
 ENV NODE_ENV=production
 WORKDIR /app/mcp
 

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -7,7 +7,7 @@
 #   docker run --rm -i opentakeoff-mcp        # -i: MCP speaks JSON-RPC over stdio
 
 # ---- build stage: bundle server.ts (+ web/src/lib) into dist/ ----------------
-FROM node:20-bookworm-slim AS build
+FROM node:24-bookworm-slim AS build
 WORKDIR /app
 # Bring the whole tree so the ../../web relative imports resolve during bundling.
 COPY . .
@@ -16,7 +16,7 @@ RUN npm ci
 RUN npm run build
 
 # ---- runtime stage: prod deps + the bundled server only ----------------------
-FROM node:20-bookworm-slim AS runtime
+FROM node:24-bookworm-slim AS runtime
 ENV NODE_ENV=production
 WORKDIR /app/mcp
 


### PR DESCRIPTION
Glama's container build has been failing since **2026-08-14**; the two builds before it (0.9.39, Aug 11) succeeded, and it has not rebuilt since — so the listing's last known state is red.

### What I could and couldn't establish

I could not reproduce a code fault. Simulating the Dockerfile faithfully — clean clone, `npm ci` in `mcp/` **only** (no web deps, which is the one place the container diverges from CI), then `npm run build` — succeeds at the exact commit that was HEAD when the build failed, on both node 20 and node 24. The resulting server answers `initialize` and lists all 40 tools.

The obvious suspect was lockfile skew: at that commit `mcp/package.json` was `0.9.40` against a `0.9.39` lock. **It is not the cause** — `npm ci` accepts that under both npm 10 (what `node:20` ships) and npm 11. Tested directly rather than assumed.

So this PR fixes the two things that are genuinely wrong with the container instead of claiming a root cause. Reading the actual build log needs a Glama login.

### 1. There was no `.dockerignore`

Both Dockerfiles `COPY` the repository root — they have to, because `mcp/` bundles the takeoff engine out of `web/src/lib` at build time. So the build context was the whole clone: **~109 MB of `.git`** plus, on a developer's machine, ~1.1 GB of `node_modules`, `dist` output and the fetched voice model. None of it is read by the build.

| | context |
|---|---|
| before | ~130 MB (clone) / ~1.1 GB (local) |
| after | **4.2 MB** |

The bundle produced from the reduced context is identical in size (542.7 kb), verified by materialising the post-ignore context and building from it.

This is not only a speed fix: a remote builder pays for that context on every build, and a build that dies for being too large or too slow looks exactly like a build that dies for being broken.

### 2. `node:20` is end-of-life

Node 20 hit EOL in April 2026, and `.nvmrc` has said `24` for a while — so the container ran a node the project no longer targets, on a base image no longer receiving security updates. Glama runs automated safety/quality checks on the image it builds, which makes an EOL base with an open CVE feed a plausible way a previously-green build turns red with no commit to blame.

Both Dockerfiles now track `.nvmrc`.

`engines` stays at `>=20` deliberately — that's a compatibility promise to people running the server over `npx`, not a statement about our container.

### After merge
Trigger a rebuild from the Glama admin page and read the log if it's still red.