### PR TITLE
docs: split the manuals by audience — an agent manual, an estimator's working order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,11 +99,34 @@ you got them all:
    decision tree every client receives before its first call. A new *verb* does
    not belong here; a new *step in the standard finish* does.
 6. `mcp/README.md` (the tool table) and `docs/MCP.md` (the reach-for-it ordering,
-   the example session, and the tool count in its opening line).
+   the example session, and the tool count in its opening line). A new tool also
+   needs a row in `mcp/src/staging.ts`'s `TOOL_STAGES` — the four lists must
+   partition the tool set exactly, and a test fails CI if one doesn't. If the
+   change alters *doctrine* rather than adding a verb — what withholds, what
+   refuses, what has no agent verb — it belongs in `docs/AGENT_GUIDE.md` too,
+   and the tool count appears there and in `docs/USER_GUIDE.md` §14.
 7. **Version, on three surfaces that must agree**: `mcp/package.json`,
    `mcp/server.json`, `web/public/.well-known/mcp.json`. They have drifted
    before (#171, and again at 0.9.28). Check `git show HEAD:mcp/package.json`
    before bumping — a concurrent branch may already have claimed the number.
 
 Architecture rather than behavior — what MCP is versus what the `/ai` sandbox
-is, and why the server is in-process — lives in `docs/MCP_AND_API.md`.
+is, and why the server imports the web engine in-process — lives at the end of
+[`docs/MCP.md`](docs/MCP.md) ("Where this sits") and in
+[`server/README.md`](server/README.md).
+
+## The doc set, and who each one is for
+
+Four documents carry the product, and they're deliberately split by audience —
+don't answer an estimator's question in the agent manual or vice versa:
+
+| Document | Audience | What belongs in it |
+|---|---|---|
+| [`README.md`](README.md) | everyone, ~60 seconds | what this is, the three doors, what's in the box |
+| [`docs/USER_GUIDE.md`](docs/USER_GUIDE.md) | the estimator at the canvas | every shipped UI behavior, the working order on a real bid, the glossary |
+| [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md) | an agent driving the engine | the operating model, the standard finish, withheld doctrine, staging, refusal→next-move |
+| [`mcp/README.md`](mcp/README.md) | an agent's integrator | tool-by-tool reference, resources, coordinate contract, limits |
+
+[`AGENT_BRIEF.md`](AGENT_BRIEF.md) is the one-page orientation that routes to
+all four. A behavior change usually touches two of them; a new MCP tool touches
+three plus this file's sync list above.

--- a/AGENT_BRIEF.md
+++ b/AGENT_BRIEF.md
@@ -1,127 +1,99 @@
 # OpenTakeoff — Agent Brief
 
-**Project:** Open-source browser-based construction takeoff tool for flooring.
+The one-pager. If you're an agent about to work *on* this repo, read
+[`AGENTS.md`](AGENTS.md) next. If you're an agent about to *drive the takeoff engine*, read
+[`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md) instead — that's your manual, this is orientation.
 
-**Live demo:** https://opentakeoff.kentucky-ai.com
-
-**Repo:** https://github.com/Kentucky-ai/opentakeoff
-
----
-
-## What It Does
-
-Users drag in a floor plan (PDF/image), set the scale, trace rooms/areas with simple clicks, define finishes, add materials, then export quantities and a buy list. Everything runs in the browser — no server, no account.
+**Repo:** <https://github.com/Kentucky-ai/opentakeoff> · **Live:**
+<https://opentakeoff.kentucky-ai.com> · **License:** Apache-2.0
 
 ---
 
-## Why It Matters
+## What it is
 
-- **First open-source takeoff tool for flooring** (before this, only paid SaaS)
-- **Real production engine** (carved from a commercial estimating app, not a demo)
-- **One-Click Area** is the headline: click inside a room → auto-traces the boundary
-- Given to the flooring community (Apache 2.0)
+A takeoff is the act of measuring quantities off a construction drawing — how much floor, how
+much wall, how many fixtures, at what scale, on which sheet. OpenTakeoff is an open-source
+engine for doing that, with two front ends over identical geometry:
 
----
+- **A stdio MCP server** (`npx -y opentakeoff-mcp`) — 40 tools plus browsable sheet resources.
+  An agent opens a plan, reads the title block, sets the scale, floods the rooms, checks its own
+  work on a rendered overlay, and hands back a marked-up planset.
+- **A browser canvas** — client-only React. An estimator drags in a plan set and traces it. No
+  backend, no database, no account, no upload.
 
-## The Tech
+Neither wraps the other. `mcp/` imports `web/src/lib/{oneclick,sheets,geometry,totals}` directly,
+so a shape committed by an agent is field-identical to one committed by a hand at the canvas —
+same flood mask, same corner snap, same waste math, same refusal messages.
 
-- **Frontend:** React 18 + Vite, HTML5 Canvas + SVG
-- **Geometry:** TypeScript (`oneclick.ts`, `sheets.ts`) — pure, tested math
-- **PDF:** pdf.js (Mozilla)
-- **Storage:** IndexedDB + localStorage (client-only)
-- **Optional Backend:** FastAPI + Python (pluggable AI adapter for scale/room detection/finish classification)
-- **No paid dependencies**
+## Why it exists
 
----
+Two reasons, and the second is the load-bearing one.
 
-## Key Files to Know
+1. **There was no open-source takeoff engine at all** — web-based or otherwise — and nothing an
+   autonomous agent could call. Agents are first-class users here, not an integration bolted on
+   the side.
+2. **Every shape records how it was made**: the scale it was measured at, the method (vector
+   flood, raster trace, hand-drawn, agent-proposed), whether a human corrected it, and the
+   machine's original boundary frozen beside the correction. Downstream that's an audit trail.
+   Upstream it's a labeled *(geometry → finish)* pair — the training signal takeoff models have
+   never had at scale. See the README's [data layer](README.md#the-data-layer--why-this-engine-exists).
 
-### Core Geometry (This is the Gold)
-- `web/src/lib/oneclick.ts` — Flood-fill room detection. Pure TypeScript, tested.
-- `web/src/lib/sheets.ts` — Scale math, coordinate transforms, polygon area. Pure TypeScript, tested.
-- `web/src/lib/totals.js` — Materials math, report calculation, rounding logic.
+## The rules that shape the code
 
-### UI & State
-- `web/src/pages/TakeoffCanvas.jsx` — Main canvas component (plan display, tool dispatch).
-- `web/src/components/` — Condition editor, supporting-materials editor, report, file upload, etc.
-- `web/src/lib/store.js` — Persistence (IndexedDB + localStorage).
+Change anything here and you'll hit these. They are deliberate, and they hold identically on both
+front ends:
 
-### Optional AI Backend
-- `server/adapters/base.py` — Interface for custom models.
-- `server/adapters/heuristic.py` — Default (no model, transparent fallback).
-- `server/adapters/ollama.py` — Example Ollama integration.
-- **Endpoints:** `POST /ai/suggest-scale`, `POST /ai/detect-rooms`, `POST /ai/classify-finish`
+- **Scale is a gate, not a default.** A detected scale note is a suggestion; adopting it is an
+  explicit act. Measuring an unscaled sheet refuses.
+- **The engine traces; the model doesn't invent.** No path accepts a polygon a model imagined
+  and counts it.
+- **Machine work is pencil until a person inks it.** The green `APPROVED` seal has exactly one
+  code path — the toolbar button under a human hand.
+- **Withholding is an answer.** Tools that can't answer say why, with coordinates to look at,
+  rather than returning a plausible number.
+- **Waste applies only in the report's order quantity**, never to the live measured number.
 
----
+## The stack
 
-## Visibility Goals
+React 18 + Vite 6 (plain JSX) · raw HTML5 Canvas + SVG, no drawing frameworks · pure, unit-tested
+TypeScript geometry (`oneclick.ts`, `sheets.ts`) · pdf.js · IndexedDB + localStorage ·
+TypeScript stdio MCP server · `node --test` + `tsx` · no paid dependencies.
 
-**Current state:** Great README, live demo, solid codebase. But agents need more structure.
+An optional FastAPI adapter interface lives in `server/` for plugging your own vision model under
+the canvas's suggestion endpoints. The app is fully functional without it.
 
-**Quick wins:**
+## Where the value is concentrated
 
-1. ✅ **Add GitHub Topics** → `flooring`, `takeoff`, `construction-takeoff`, `estimating`, `measurement`, `open-source`, `construction`, `react`, `pdf-tools`
+| What | Where |
+|---|---|
+| Flood fill, face extraction, corner snap, raster fallback | `web/src/lib/oneclick.ts` — pure TS, tested |
+| Scale detection, sheet helpers, polygon area | `web/src/lib/sheets.ts` — pure TS, tested |
+| Waste, square-yard, coverage → order quantity | `web/src/lib/totals.js` |
+| Roll-goods lane and seam layout | `web/src/lib/rollgoods.js` — pure, tested |
+| The canvas (one large component, ~90% of the app) | `web/src/pages/TakeoffCanvas.jsx` |
+| MCP server (imports the same libs) | `mcp/src/` |
 
-2. ✅ **Add FEATURES.md** → Map all capabilities to code files (so agents know what's buildable)
+The geometry libraries are React-free and DOM-free on purpose — lift them straight out.
 
-3. ✅ **Add JSDoc blocks** to core geometry (`oneclick.ts`, `sheets.ts`) → Pure functions are easier for agents to reuse
-
-4. **Update repo description** → Include keywords: "browser-based construction takeoff tool, flooring estimating, open-source, React"
-
-5. **Add ROADMAP.md** → What's planned, what's wanted, how to contribute
-
----
-
-## What an Agent Should Be Able to Do
-
-- [ ] Understand the full measurement engine (area, linear, count, etc.)
-- [ ] Find and reuse the geometry math (oneclick, polygon calculation)
-- [ ] Extend supporting materials with new material types or cost logic
-- [ ] Wire a custom AI model to the backend
-- [ ] Add new export formats (XLSX, JSON, etc.)
-- [ ] Understand the scale detection and calibration flow
-- [ ] Fork it and customize for a specific trade (drywall, paint, concrete, etc.)
-
----
-
-## Quick Start (For Agents)
+## Run it
 
 ```bash
-# Run it
-cd web
-npm install
-npm run dev        # http://localhost:5173
-
-# Test the geometry
-npm test           # oneclick and sheets tests
-
-# Build it
-npm run build      # → web/dist/ (static, host anywhere)
-
-# Optional: Run the AI backend
-cd ../server
-pip install -r requirements.txt
-uvicorn app:app --reload --port 8000
+cd web && npm install && npm run dev     # http://localhost:5173
+npm run check                            # typecheck + lint + test + build — exactly what CI runs
 ```
 
----
+## The doc set
 
-## Success Metrics
-
-- [ ] Agents can find and understand the project in <5 min
-- [ ] Agents can locate and reuse specific modules (geometry, materials math)
-- [ ] Agents can extend or fork it without asking questions
-- [ ] Issues/PRs show agents building on top (custom finishes, cost calcs, integrations)
-
----
-
-## Resources
-
-- **User Guide:** `docs/USER_GUIDE.md`
-- **Contributing:** `CONTRIBUTING.md`
-- **Features Deep Dive:** `FEATURES.md`
-- **License:** Apache 2.0 (use it, fork it, ship it)
+| Document | For |
+|---|---|
+| [`README.md`](README.md) | The project, all audiences |
+| [`docs/USER_GUIDE.md`](docs/USER_GUIDE.md) | The estimator at the canvas |
+| [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md) | The agent driving the engine over MCP |
+| [`mcp/README.md`](mcp/README.md) | Tool-by-tool MCP reference |
+| [`AGENTS.md`](AGENTS.md) | Working *on* this repo — map, conventions, ship discipline |
+| [`FEATURES.md`](FEATURES.md) | Capability → the code that implements it |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Ground rules, and the open RFCs |
 
 ---
 
-*One-pager by Kentucky Ai — give this to agents, let them explore.*
+*Kentucky AI — the measuring engine, given to anyone who needs to read a building.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-16 — the docs split by audience: an agent manual, and an estimator's working order
+
+### Docs
+- **`docs/AGENT_GUIDE.md` — the agent's manual, the counterpart to the user manual.** The MCP docs were a setup page and a tool reference, which between them told an agent what every verb *does* and nothing about how a takeoff is *run*. The doctrine that decides whether the numbers are any good lived only in the server's `initialize` instructions, where no human reads it. It's now a document: the operating model in six facts (one coordinate frame, the scale gate, unconfirmed-until-a-human-confirms, the engine traces and the model doesn't invent, provenance on every commit, pencil until a person inks it), the five-step standard finish, the **withheld-is-the-answer** table naming what each of the four withholding tools withholds and what to do about it, what has no agent verb and why (stitching, the `APPROVED` seal, confirming a scale, minting a rule, touching human-affirmed work), staged tool exposure and when it's the right call, a worked session, and a refusal → next-move table.
+- **The user manual gained the two things an estimator asks for that a feature tour doesn't answer.** *The working order on a real bid* (§1) — the ten-step sequence for a forty-sheet set rather than the five-minute path on one sample sheet, each step linked to its section, ending on the honest note that steps 8–10 are the ones skipped under time pressure and the ones that decide whether a disputed quantity is a conversation or a re-takeoff. And **§18, a glossary** of the 23 terms that mean something specific here — condition, twin, proposal, pencil/ink, provenance, *reported never counted*, basis, figured seam LF, stitch, unconfirmed scale, and the rest.
+- **`README.md` routes by audience up front.** A three-row *Start here* table (estimator / agent / developer) above the fold, and the canvas section now opens with a seven-step plain-language account of what a real bid looks like on it, before the feature prose. The agent section points at the new manual.
+- **`AGENT_BRIEF.md` rewritten.** It had drifted into an internal to-do list — "Visibility Goals", "Quick wins", "Success Metrics" with checkboxes, and no mention of the MCP server at all — on a public repo. It's a genuine one-page orientation now: what this is, why it exists, the five rules that shape the code, the stack, where the value is concentrated, and a routing table to the four real documents.
+- **`AGENTS.md`** states the doc set and who each document is for, so a change lands in the right one; the MCP sync list now names `mcp/src/staging.ts`'s stage table and the doctrine/tool-count surfaces. Fixed a dangling reference to `docs/MCP_AND_API.md`, which does not exist — the architecture note it meant is the end of `docs/MCP.md`.
+- **Corrected the tool count in `docs/USER_GUIDE.md` §14**: 38 → 40, with `cut_out`, `apply_rules`, `duplicate_condition`, and `split_condition` added to the table they'd been missing from. `mcp/src/tools.ts` registers 40.
+
 ## 2026-08-16 — how the sheet graph is tested, written down; opentakeoff-mcp 0.9.49
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
-## 2026-08-16 — the docs split by audience: an agent manual, and an estimator's working order
+## 2026-08-16 — the docs split by audience: an agent manual, and an estimator's working order; opentakeoff-mcp 0.9.50
 
 ### Docs
 - **`docs/AGENT_GUIDE.md` — the agent's manual, the counterpart to the user manual.** The MCP docs were a setup page and a tool reference, which between them told an agent what every verb *does* and nothing about how a takeoff is *run*. The doctrine that decides whether the numbers are any good lived only in the server's `initialize` instructions, where no human reads it. It's now a document: the operating model in six facts (one coordinate frame, the scale gate, unconfirmed-until-a-human-confirms, the engine traces and the model doesn't invent, provenance on every commit, pencil until a person inks it), the five-step standard finish, the **withheld-is-the-answer** table naming what each of the four withholding tools withholds and what to do about it, what has no agent verb and why (stitching, the `APPROVED` seal, confirming a scale, minting a rule, touching human-affirmed work), staged tool exposure and when it's the right call, a worked session, and a refusal → next-move table.
@@ -11,6 +11,7 @@ All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 - **`AGENT_BRIEF.md` rewritten.** It had drifted into an internal to-do list — "Visibility Goals", "Quick wins", "Success Metrics" with checkboxes, and no mention of the MCP server at all — on a public repo. It's a genuine one-page orientation now: what this is, why it exists, the five rules that shape the code, the stack, where the value is concentrated, and a routing table to the four real documents.
 - **`AGENTS.md`** states the doc set and who each document is for, so a change lands in the right one; the MCP sync list now names `mcp/src/staging.ts`'s stage table and the doctrine/tool-count surfaces. Fixed a dangling reference to `docs/MCP_AND_API.md`, which does not exist — the architecture note it meant is the end of `docs/MCP.md`.
 - **Corrected the tool count in `docs/USER_GUIDE.md` §14**: 38 → 40, with `cut_out`, `apply_rules`, `duplicate_condition`, and `split_condition` added to the table they'd been missing from. `mcp/src/tools.ts` registers 40.
+- **`mcp/README.md` opens by routing to the agent manual**, since that page is the npm/Glama/Smithery front door and a reference is the wrong first read. `README.md` ships in the npm tarball, so this is `opentakeoff-mcp` **0.9.50** — a docs-only release; no tool signature moved, so the Smithery bundle needs no rebuild.
 
 ## 2026-08-16 — how the sheet graph is tested, written down; opentakeoff-mcp 0.9.49
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ what makes it training data.
 
 [**For agents**](#for-agents--start-here) · [**Try the canvas**](https://opentakeoff.kentucky-ai.com) · [The engine's contract](#the-contract-that-makes-it-drivable) · [For the person at the canvas](#for-the-person-at-the-canvas) · [The data layer](#the-data-layer--why-this-engine-exists) · [Research](#the-research-program) · [Build on it](#build-on-top-of-it) · [Contribute](#contributing)
 
+**The two manuals:** [agent manual](docs/AGENT_GUIDE.md) · [user manual](docs/USER_GUIDE.md)
+
 **Read this in:** [日本語](README.ja.md) · [한국어](README.ko.md) · [简体中文](README.zh-Hans.md)
 
 **Watch it:** [an autonomous agent runs a takeoff, live, no cuts (2:47)](https://youtu.be/e--kXxSGv7Y) · [hospital finish plan → report in about a minute (1:14)](https://youtu.be/cNDpPkTLY1k) · [canvas walkthrough (1:10)](https://youtu.be/aHiW8H2TSBs) · [One-Click Area (0:51)](https://youtu.be/YIjWZ-BAhLE)
@@ -31,6 +33,14 @@ what makes it training data.
 </div>
 
 ---
+
+## Start here
+
+| You are | Go here |
+|---|---|
+| **An estimator with a bid due** | [Open the canvas](https://opentakeoff.kentucky-ai.com) — drag in a plan, no account, nothing uploads. The [**user manual**](docs/USER_GUIDE.md) gets you from a blank tab to an exported takeoff in five minutes, and its [working order](docs/USER_GUIDE.md#the-working-order-on-a-real-bid) is the sequence to run on a real bid set. |
+| **An AI agent** — or the person wiring one up | `npx -y opentakeoff-mcp`, then the [**agent manual**](docs/AGENT_GUIDE.md): the operating model, the standard finish every takeoff ends with, what the engine refuses to guess, and why. Tool-by-tool reference is [`mcp/README.md`](mcp/README.md). |
+| **A developer building on the engine** | [`AGENTS.md`](AGENTS.md) is the repo map and the ship discipline; [`FEATURES.md`](FEATURES.md) maps every capability to the code that does it. Apache-2.0 — fork it. |
 
 ## What this is
 
@@ -152,7 +162,11 @@ conditions, or shapes — the sheet graph then spans the whole set, so a room ta
 resolves to a schedule row in another. `edit_condition` reaches the waste %, the ×N multiplier,
 and `roll_setup`, so an agent's takeoff doesn't ship with net === gross.
 
-Setup, the coordinate contract, and a full annotated transcript: [`docs/MCP.md`](docs/MCP.md).
+**The agent's manual is [`docs/AGENT_GUIDE.md`](docs/AGENT_GUIDE.md)** — the counterpart to the
+estimator's: the operating model in six facts, the standard finish every takeoff ends with, the
+withheld-is-the-answer doctrine, what has no agent verb and why, and a refusal-to-next-move table.
+Tool-by-tool reference: [`mcp/README.md`](mcp/README.md). The same surface in prose, with the
+sheet-graph and sweep behavior in depth: [`docs/MCP.md`](docs/MCP.md).
 
 ### The contract that makes it drivable
 
@@ -217,6 +231,24 @@ click inside a room. Open **Report** for the breakdown and the exports. That who
 video: [walkthrough (1:10)](https://youtu.be/aHiW8H2TSBs) ·
 [One-Click Area (0:51)](https://youtu.be/YIjWZ-BAhLE). The complete
 zero-to-exported walkthrough is the [**user manual**](docs/USER_GUIDE.md).
+
+**What a real bid looks like on it**, in the order an estimator works one:
+
+1. Drag in the whole `.zip` off the bid platform — plans, finish schedule, addenda.
+2. Set the scale on every sheet you'll measure, and **check a dimension** (`K`) on each. Ten
+   seconds a sheet, and it's the only mistake that gets every number at once.
+3. Pull your conditions off the architect's finish schedule instead of typing them, and set waste
+   and materials *before* you trace.
+4. Stitch anything split at a match line, align it, and only then start measuring.
+5. **One-Click** the floors room by room. Derive base and transitions off the rooms you just
+   traced rather than measuring them a second time — and read what the derivation *reports and
+   never counts*, because those are doorway thresholds you still owe.
+6. Walk the set and look at what landed, fix with the grips, save a **revision**.
+7. Export both: the Report for pricing, the **Marked set** PDF for whoever has to check you.
+
+The full version of that sequence, with the section for each step, is the manual's
+[working order](docs/USER_GUIDE.md#the-working-order-on-a-real-bid). What every term above means
+is in its [glossary](docs/USER_GUIDE.md#18-glossary--what-the-words-mean-here).
 
 ### Open anything, instantly
 A plan **PDF**, an **image** (scan, screenshot, photo), or a whole **`.zip` plan set** straight

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,0 +1,266 @@
+# OpenTakeoff — The Agent Manual
+
+The counterpart to the [user manual](USER_GUIDE.md). That one is written for the estimator at
+the canvas; this one is written for the agent driving the same engine over
+[MCP](https://modelcontextprotocol.io), and for the person wiring one up.
+
+Everything an estimator does with a mouse, an agent does with a tool call, against identical
+geometry: the server imports `web/src/lib/{oneclick,sheets,geometry,totals}` directly, so a room
+you flood over stdio measures the same square footage as the same click on the canvas. There is
+no second implementation to drift.
+
+**Contents**
+
+1. [Connect in 60 seconds](#1-connect-in-60-seconds)
+2. [The operating model — six facts before your first call](#2-the-operating-model--six-facts-before-your-first-call)
+3. [The standard finish — how a takeoff ends](#3-the-standard-finish--how-a-takeoff-ends)
+4. [Withheld is not a failure — it is the answer](#4-withheld-is-not-a-failure--it-is-the-answer)
+5. [What has no agent verb, and why](#5-what-has-no-agent-verb-and-why)
+6. [Staged tool exposure](#6-staged-tool-exposure)
+7. [A worked session](#7-a-worked-session)
+8. [Refusals, and the move that answers each one](#8-refusals-and-the-move-that-answers-each-one)
+9. [Where to look next](#9-where-to-look-next)
+
+---
+
+## 1. Connect in 60 seconds
+
+Node 20+. No clone, no build:
+
+```json
+{
+  "mcpServers": {
+    "opentakeoff": {
+      "command": "npx",
+      "args": ["-y", "opentakeoff-mcp"]
+    }
+  }
+}
+```
+
+Claude Code: `claude mcp add opentakeoff -- npx -y opentakeoff-mcp`. Claude Desktop: double-click
+the `opentakeoff-mcp.mcpb` bundle from the
+[latest release](https://github.com/Kentucky-ai/opentakeoff/releases). Docker, a local clone, and
+the debugging trace flag are in [`mcp/README.md`](../mcp/README.md).
+
+Confirm you're live by reading the `takeoff://sheets` resource before any plan loads — it answers
+with what it is and points at `load_plan`, which is a cheaper handshake than a failed tool call.
+
+## 2. The operating model — six facts before your first call
+
+**One coordinate frame, stated everywhere.** Image pixels at render scale 2.0 — PDF points × 2,
+origin top-left, y down. That is the browser canvas's native space, so a coordinate round-trips
+1:1 with the app. Every sheet payload carries dims in px *and* pt. Text positions from
+`read_sheet_text` come back in the same space, which makes a room label directly usable as a
+`one_click` seed. No tool takes a coordinate in units it has to infer.
+
+**Scale is a gate, not a default.** The drawn scale note is read off the sheet and handed to you
+as a suggestion; adopting it is always an explicit `set_scale { use_detected: true }`. Measuring
+tools refuse an unscaled sheet, and a bare `one_click` returns px-only numbers with a warning
+rather than fabricating square feet. Pixels × a wrong scale² is every number on the bid wrong at
+once, which is why the engine would rather stop than guess.
+
+**The scale you set is unconfirmed until a human confirms it.** `set_scale` returns
+`confirmed: false`, `takeoff_summary` names those sheets in `scale_unconfirmed`, and the exports
+carry `scale_confirmed` so the canvas can ask the estimator. Quantities still flow — the flag is
+disclosure, not a second refusal — but say so when you hand the work over.
+
+**The engine traces; you don't invent.** `one_click` returns the ring the flood fill produced
+from the seed point you named. There is no tool that accepts a polygon you imagined and counts
+it. `measure_polygon` exists for geometry you can defend, and everything it commits is stamped
+with how it was made.
+
+**Every commit carries provenance.** Method, normalized seed, whether hatch filtering engaged,
+`raster_traced` when the boundary came from scan pixels instead of vector linework, and
+`confidence` 0–1 with `confidence_factors` naming each deduction (`gap_sealed_px`, `door_wedges`,
+`min_pass_delta`, …). Read confidence as a review prioritizer, never a verification: 1.0 means
+every signal the engine can see came back clean, not that the trace is right. A low score is a
+`view_sheet { overlay: true }` prompt.
+
+**Your work is pencil until a person inks it.** Everything you commit lands in the canvas as a
+dashed proposal. `mark_verdict` lets you sign work you checked as a graphite `AGENT` diamond; the
+green `APPROVED` seal has exactly one code path and it is the toolbar button under a human hand.
+`edit_shape` refuses a shape a human already affirmed, and self-revision bumps
+`origin.agent_edits` rather than touching the human-correction fields — merging those would
+corrupt the one signal that measures whether the machine is getting better.
+
+## 3. The standard finish — how a takeoff ends
+
+These five steps are served to every client in the `initialize` instructions, so they are the
+contract rather than a suggestion. **A takeoff's deliverable is the marked-up planset, not a
+numbers report.**
+
+1. **Open and scale.** `load_plan`, then `set_scale` on each sheet you intend to measure. Use
+   `load_plan { merge: true }` to add the schedule sheet and the addenda — a bid set is plans
+   *plus* schedule *plus* addenda, and merging leaves existing scales, conditions, and shapes
+   alone.
+2. **Commit shapes under finish-tag conditions.** `one_click` / `detect_rooms` /
+   `measure_polygon` / `measure_line` with `condition`. When the set carries a room-finish
+   schedule, prefer `detect_rooms { assign_from_schedule: true }` so each room commits under its
+   *own* row instead of one tag you picked for all of them.
+3. **Derive what follows from the rooms.** `derive_base` for base LF (each room's perimeter minus
+   the door openings *you state* — the tool never guesses a door), `derive_transitions` for the
+   line where two finishes meet. Both read committed floor shapes, so they come after step 2, and
+   their output gets audited in step 4 like anything else.
+4. **Look at what landed.** `view_sheet { overlay: true }` and fix misses with `edit_shape` before
+   trusting a total. Crop the work region tight — a full-sheet render downsamples too far to
+   audit a ring. Solid outlines are human-affirmed, dashed are unreviewed.
+5. **Write the planset.** `export_marked_pdf`, and give the user the file path. `export_report`
+   alongside it for the numbers. Never end a takeoff with numbers alone: a takeoff nobody can
+   check is not a takeoff.
+
+Between steps 3 and 4, `list_shapes` is the cheap inventory — ids, sheets, conditions,
+quantities, room labels, review state, and where each finish tag came from (`schedule` vs.
+`asserted`) — without pulling a whole `export_takeoff` payload.
+
+## 4. Withheld is not a failure — it is the answer
+
+Four tools measure things they then decline to commit, and say why. The arrays they hand back are
+the most valuable output on the call, because each one is a question an estimator would have
+asked.
+
+| Tool | What it withholds | What it means | Your move |
+|---|---|---|---|
+| `detect_rooms` | rooms in `withheld` (degenerate, duplicate, implausible) and `unresolved[]` | the flood failed, or the schedule can't answer for that room | re-seed the coordinates it hands back, or state the condition yourself and say you did |
+| `symbol_sweep` | matches scoring 0.75–0.92 | a near-match the fingerprint can't call | `view_sheet` the coordinates; commit the real ones by hand |
+| `sweep_schedule_row` | `excluded` (labeled with a sibling key), `withheld` (unlabeled), `text_only` (a tag with no marker) | drafting reuses one bubble shape across many marks, so geometry alone would over-count | look at each; the exclusions are usually right and the unlabeled ones are usually yours |
+| `derive_transitions` | wall-separated runs, in `withheld` with a length, a gap in inches, and an `at` point | the two rooms are adjacent across a partition, so the real transition is a threshold in a doorway that nothing in the trace record locates | measure the threshold at the door with `measure_line`, or hand the run to the estimator |
+
+`withheld_lf` is never folded into `total_lf`. A withheld item you ignore is a hole in the bid;
+one you never mention is worse. Report them in your summary even when you can't resolve them.
+
+The reason `derive_transitions` behaves this way is worth carrying into every judgment you make
+here: **flood-traced rooms do not share edges.** A trace fills to the wall linework, so two rooms
+across a partition sit four to eight inches apart. Committing 34 LF of threshold because two
+rooms share 34 LF of wall would be a wrong number with a machine's confidence behind it.
+
+## 5. What has no agent verb, and why
+
+- **Stitching.** The canvas joins 2–4 sheets split at a match line into one composite surface. No
+  MCP verb creates, aligns, or addresses a stitch, and this is not staged for later exposure.
+  Aligning a match line means clicking the same drawn wall junction on both halves — judgment
+  whose failure mode is a subtly sloppy join that silently skews every quantity crossing the seam.
+  On a split floor: measure each member sheet as its own surface, and tell the user a
+  seam-crossing room needs their stitch in the app. Never approximate one by combining sheets
+  yourself. (A stitched takeoff round-tripped through `import_takeoff` → `export_takeoff` comes
+  back without its stitches; when a stitch is in play, the app's own save is the one to keep.)
+- **The estimator's `APPROVED` seal.** `mark_verdict` takes no actor argument, so there is no
+  input to misuse; `delete_verdict` refuses a human seal outright.
+- **Confirming a scale.** Only a human act in the canvas clears `confirmed: false`.
+- **Minting a correction rule.** `apply_rules` re-runs the rules an estimator taught the canvas,
+  and rules arrive only via `import_takeoff`. A rule *is* an estimator's correction, so minting
+  one stays behind the canvas's human Preview→Apply gate.
+- **Touching human-affirmed work.** `edit_shape` refuses a shape carrying
+  `origin.reviewed === true`.
+
+## 6. Staged tool exposure
+
+By default every client gets all 40 tool schemas on `tools/list` — the flat contract every
+published client already expects.
+
+Forty descriptions is real token weight for a session that may never touch half of them, so the
+server can stage the surface along the workflow it already teaches:
+
+```bash
+OPENTAKEOFF_MCP_STAGED_TOOLS=1 npx -y opentakeoff-mcp
+```
+
+Staged, only the **setup** stage starts enabled — 10 tools that orient you: `load_plan`,
+`sheet_info`, `set_scale`, `sheet_graph`, `resolve_tag`, `find_schedule`, `read_sheet_text`,
+`find_text`, `sheet_context`, `view_sheet` — plus one opener, `open_tool_stage`. Call it with
+`"measure"`, `"revise"`, or `"handoff"` and that group's tools enable and fire
+`tools/list_changed`. Opening is instant, idempotent, and never closes anything: the surface only
+grows, and the reply names exactly which tools just appeared.
+
+The stages are the same phase structure the instructions already describe in prose:
+
+| Stage | Tools | Opened when |
+|---|---|---|
+| `setup` (always on) | load, scale, read the set, look at it | — |
+| `measure` | `one_click`, `detect_rooms`, `measure_*`, `cut_out`, `place_count`, the sweeps, the derives | you're about to commit a shape |
+| `revise` | `list_shapes`, `edit_*`, `duplicate_condition`, `split_condition`, `delete_shape`, `undo_last`, the annotation and verdict family | you're auditing or correcting |
+| `handoff` | `takeoff_summary`, `export_*`, `import_takeoff`, `apply_rules` | you're finishing |
+
+**When to turn it on:** your client honors `tools/list_changed` (Claude Code, Claude Desktop,
+anything built against the current spec) *and* you care about the context cost of the tool list.
+**When to leave it off:** a client that reads the tool list once at startup — there, a staged
+server looks like a server with 11 tools that refuses everything else.
+
+Staging is context economy, not a permission boundary. Nothing is safer when a stage is closed;
+the safety lives in the refusals, the scale gate, and the pencil-vs-ink split, all of which hold
+identically in both modes.
+
+## 7. A worked session
+
+*"Take off the carpet on this floor plan"* — tool calls verbatim, replies abridged.
+
+```
+▸ load_plan  { "path": "/plans/sample-plan.pdf" }
+  { "sheets": [{ "sheet": "sample-plan.pdf", "width_px": 2448, "height_px": 1584,
+                 "sheet_number": "A-101", "detected_scale": "1/4\" = 1'-0\"" }] }
+
+▸ read_sheet_text  { "sheet": "sample-plan.pdf",
+                     "region": { "x0": 1468, "y0": 871, "x1": 2448, "y1": 1584 } }
+  { "text": "A-101 SCALE: 1/4\" = 1'-0\"" }
+
+    The title block confirms the detected note. Adopt it explicitly — never silently.
+
+▸ set_scale  { "sheet": "sample-plan.pdf", "use_detected": true }
+  { "upp": 0.02778, "label": "1/4\" = 1'-0\"", "source": "detected", "confirmed": false }
+
+▸ one_click  { "sheet": "sample-plan.pdf", "x": 600, "y": 1084, "condition": "CPT-1" }
+  { "status": "ok", "area_sf": 437.98, "perimeter_lf": 86.61, "confidence": 1, "shape_id": "shp-…" }
+  … three more rooms …
+
+    Two of those are actually tile. Reassign, then derive instead of re-measuring:
+
+▸ edit_shape  { "shape_id": "shp-…", "condition": "PT-1" }
+
+▸ derive_transitions  { "condition_a": "CPT-1", "condition_b": "PT-1", "condition": "T-1" }
+  { "committed": 2, "total_lf": 53.88, "withheld": [], "withheld_lf": 0 }
+
+    Both runs came back butt joints — gap under an inch, one open space. Across a
+    partition they would have landed in `withheld` instead, as questions.
+
+▸ view_sheet  { "sheet": "sample-plan.pdf", "overlay": true,
+                "region": { "x0": 500, "y0": 600, "x1": 1900, "y1": 1000 } }
+  … PNG: committed shapes burned in, unreviewed machine work dashed …
+
+▸ export_marked_pdf  {}
+  { "path": "/plans/sample-plan - marked set.pdf", "sheets": 1 }
+
+▸ export_report  { "path": "/plans/sample-report.json" }
+  { "schema": "opentakeoff.report.v1", … }
+```
+
+Hand back both paths, the totals, anything `withheld`, and the fact that the scale is
+agent-set and awaiting the estimator's confirmation.
+
+## 8. Refusals, and the move that answers each one
+
+Refusals are actionable strings by design — *"a silent zero doesn't tell a model what to do
+next."*
+
+| What you get | What it means | Next move |
+|---|---|---|
+| `Set the scale for <sheet> first — use set_scale (detected: 1/4" = 1'-0").` | the scale gate | adopt the detected note, or calibrate from a known dimension |
+| *That space isn't enclosed on the plan linework — the fill spilled.* | a real gap: an open doorway, a break in the wall | seed a more enclosed spot, or `measure_polygon` it |
+| *Landed in dense linework (hatching or text).* | the seed hit a text block or heavy hatch | `view_sheet` a crop, pick open floor, re-seed |
+| a ring not fully inside the parent (`cut_out`) | an edge-crossing cut is a boundary correction, not a hole | fix the parent with `edit_shape` instead |
+| `measure_surface` refuses with no height | wall SF = traced LF × the condition's height | `edit_condition { height_ft }`, then retrace |
+| an export refuses a path | that file wasn't written by us, and overwriting it would destroy someone's work | pass `overwrite: true`, or pick another path |
+| a `sweep_schedule_row` key that won't anchor | a fingerprint is never guessed from text alone | anchor it yourself: `find_text` the tag, `view_sheet` the marker, count by hand |
+
+## 9. Where to look next
+
+- [`mcp/README.md`](../mcp/README.md) — the tool-by-tool reference, the resource URIs, the
+  coordinate contract, the write-to-disk rules, and the v1 limits. This is the list to trust.
+- [`docs/MCP.md`](MCP.md) — the same surface in prose, ordered the way an agent reaches for it,
+  with the sheet-graph and sweep behavior in depth.
+- [`docs/USER_GUIDE.md`](USER_GUIDE.md) — the human half. Worth reading the parts you hand work
+  to: proposals, the Accept pill, and how an estimator confirms your scale.
+- [`docs/SHEET-GRAPH-EVAL.md`](SHEET-GRAPH-EVAL.md) — what the plan-set reader scores on real
+  bid sets, and what it still cannot read.
+- [**OpenTakeoff Academy**](https://aec.kentucky-ai.com) — an open benchmark for agents that do
+  takeoff. Bring any model and your own harness; you're scored on operating a real tool against
+  geometry you don't control.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -7,6 +7,11 @@ your MCP client. Not a wrapper around the UI: the server imports the same
 vertex snapping, and the totals math behave identically, and everything it
 commits round-trips into the app as a normal saved takeoff.
 
+This page walks the surface in depth, in the order an agent reaches for it. Two
+shorter reads sit either side of it: [`AGENT_GUIDE.md`](AGENT_GUIDE.md) is the
+operating manual — how a takeoff is run, what withholds, what refuses — and
+[`mcp/README.md`](../mcp/README.md) is the tool-by-tool reference.
+
 ## Setup
 
 ```bash

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -25,6 +25,7 @@ In a hurry, or already in the app? Press **`?`** (or the **?** button in the top
 15. [Keyboard reference](#15-keyboard-reference)
 16. [Troubleshooting](#16-troubleshooting)
 17. [Voice & the Command box](#17-voice--the-command-box)
+18. [Glossary — what the words mean here](#18-glossary--what-the-words-mean-here)
 
 ---
 
@@ -39,6 +40,42 @@ The fastest way to learn the canvas is to run one takeoff end to end on the bund
 5. **Read the report.** Open **Report** for the per-condition breakdown — SF, SY, waste-adjusted order quantities, and the materials buy list. Export **CSV**, **Excel**, or a **Marked set** PDF.
 
 That's the whole loop: open → scale → condition → measure → report. Everything autosaves to your browser as you go — reload the tab and your takeoff is still there.
+
+### The working order on a real bid
+
+The sample plan is one sheet. A bid set is forty, and the order you work it in is what keeps the
+number defensible. This is the sequence, with the section that covers each step:
+
+1. **Open the whole set at once** — drag the `.zip` straight off the bid platform. Plans, the
+   finish schedule, the addenda, all of it ([§2](#2-opening-plans--moving-around)).
+2. **Scale every sheet you'll measure, and check one dimension on each** (`K`). Ten seconds a
+   sheet. A plan set is never one uniform scale, and a wrong scale is every number wrong at once
+   ([§3](#3-scale--set-it-first)).
+3. **Build your conditions off the architect's schedule**, not off memory — **Schedule** in the
+   toolbar parses the finish table and you approve what becomes a condition. The product spec
+   rides along as report columns, so the submittal answers itself later
+   ([§4](#4-conditions--your-finishes)).
+4. **Set waste and materials before you trace**, not after. Waste is per condition and matched to
+   the install; the supporting-materials lines are what turn square feet into an order
+   ([§4](#4-conditions--your-finishes)).
+5. **Stitch anything split at a match line, and align it, before a single shape lands on it.**
+   Once takeoffs live on a stitch it won't re-align ([§2](#2-opening-plans--moving-around)).
+6. **Measure the floors first** — `O`, room by room, condition by condition. Floors are the bulk
+   of the number and everything else derives from them ([§6](#6-one-click-area)).
+7. **Derive what follows instead of measuring it twice**: base off the rooms you just traced,
+   **⟂ Transitions** for the line where two finishes meet — and read what it *reports and never
+   counts*, because those are doorway thresholds you still owe
+   ([§5](#5-the-measuring-tools)).
+8. **Walk the set and look at what landed.** Every sheet, at a zoom where you can see a ring
+   overshoot into a corridor. Fix with the grips ([§7](#7-selecting--editing-shapes)).
+9. **Save a revision** the moment the takeoff is whole. Do it again at every addendum — that's
+   what makes the next round a comparison instead of an archaeology dig
+   ([§11](#11-revisions)).
+10. **Export both**: the Report/Excel for pricing, and the **Marked set** PDF for anyone who has
+    to check you — the GC, the PM, your own reviewer ([§10](#10-the-report--exports)).
+
+Steps 8 through 10 are the ones under time pressure people skip, and they're the ones that decide
+whether a disputed quantity is a five-minute conversation or a re-takeoff.
 
 ---
 
@@ -737,19 +774,23 @@ What's sent, and only when you run an AI feature: the sheet region in question a
 
 The same engine speaks [MCP](https://modelcontextprotocol.io), one command away:
 `npx -y opentakeoff-mcp` (or the one-click `opentakeoff-mcp.mcpb` bundle for Claude Desktop). An
-MCP client gets **38 tools** plus browsable sheet resources, over the very same measuring engine,
+MCP client gets **40 tools** plus browsable sheet resources, over the very same measuring engine,
 with the same scale gate and the same provenance receipts:
 
 | Group | Tools |
 |---|---|
 | Open & orient | `load_plan` · `sheet_info` · `sheet_context` · `read_sheet_text` · `find_text` · `view_sheet` |
 | Scale | `set_scale` |
-| Measure | `one_click` · `detect_rooms` · `measure_polygon` · `measure_line` · `measure_surface` · `place_count` |
-| Repeat & derive | `symbol_sweep` · `sweep_schedule_row` · `derive_base` · `derive_transitions` |
+| Measure | `one_click` · `detect_rooms` · `measure_polygon` · `cut_out` · `measure_line` · `measure_surface` · `place_count` |
+| Repeat & derive | `symbol_sweep` · `sweep_schedule_row` · `derive_base` · `derive_transitions` · `apply_rules` |
 | Read the drawing set | `sheet_graph` · `resolve_tag` · `find_schedule` |
-| Edit & audit | `list_shapes` · `edit_shape` · `edit_condition` · `edit_materials` · `delete_shape` · `undo_last` |
+| Edit & audit | `list_shapes` · `edit_shape` · `edit_condition` · `edit_materials` · `duplicate_condition` · `split_condition` · `delete_shape` · `undo_last` |
 | Mark & sign | `annotate` · `list_annotations` · `link_annotation` · `mark_verdict` · `delete_verdict` |
 | Hand off | `takeoff_summary` · `export_takeoff` · `export_report` · `export_marked_pdf` · `import_takeoff` |
+
+If you're the one wiring an agent up rather than the one reading its output, the operating manual
+for that side is [`AGENT_GUIDE.md`](AGENT_GUIDE.md) — the same shape as this document, written for
+the agent.
 
 A few worth knowing about from the canvas side, because they're the same features you use:
 
@@ -932,4 +973,37 @@ the model, the feature says so plainly; details in
 
 ---
 
-*OpenTakeoff is Apache-2.0 and the codebase is deliberately readable — when you outgrow the manual, [`FEATURES.md`](../FEATURES.md) maps every capability to its code.*
+## 18. Glossary — what the words mean here
+
+Most of these are ordinary estimating words. A few are specific to how OpenTakeoff works, and
+those are the ones worth pinning down before you rely on a number.
+
+| Term | What it means here |
+|---|---|
+| **Condition** | One finish — `LVT-1`, `CPT-2`, `RB-1` — carrying its own color, hatch, waste %, multiplier, height, thickness, and materials. Everything you measure commits into one ([§4](#4-conditions--your-finishes)). |
+| **Twin** | The same finish measured in a second area that needs different preparation underneath. Gets its own tag (`SV-1 – Level 2`) and follows the original's materials until you edit a row ([§4](#4-conditions--your-finishes)). |
+| **Proposal** | A dashed, uncommitted shape — what One-Click traces and what an agent stages. Nothing is in your takeoff until you Create or Accept it ([§6](#6-one-click-area), [§13](#13-the-agent-panel)). |
+| **Pencil / ink** | Machine work is pencil (dashed proposals, the graphite `AGENT` diamond); your acceptance is ink (committed shapes, the green `APPROVED` seal). Only a human hand mints the seal ([§9](#9-markups-stamps--rfis)). |
+| **Provenance** | The record attached to every shape: the scale it was measured at, how it was made, whether a machine proposed it, and whether you corrected it — with the machine's original boundary frozen beside your fix ([§6](#6-one-click-area)). |
+| **Reported, never counted** | A quantity the engine found but refuses to commit, with the reason. Transitions across a wall are the common one: the real transition is a threshold in a doorway nothing can locate from a trace. Go measure it ([§5](#5-the-measuring-tools)). |
+| **Deduct / Cut Out** | A void subtracted from a condition's floor total — a column, a shaft, casework. Draws dashed red and carries its negative sign into the audit ([§5](#5-the-measuring-tools)). |
+| **Measured vs. w/Waste** | Measured is what's on the drawing. w/Waste is what you order. Waste lives only in the order column, never in the measured number ([§10](#10-the-report--exports)). |
+| **Basis** | What a supporting material is bought against: floor SF, linear LF, each, or figured seam LF. Order quantity = basis ÷ coverage rate, rounded up ([§4](#4-conditions--your-finishes)). |
+| **Figured seam LF** | Seam length read off the roll layout — where two cuts actually meet — not a percentage of perimeter. Needs a roll setup; without one it reads 0, meaning *needs a layout* ([§4](#4-conditions--your-finishes)). |
+| **Roll goods** | Broadloom, sheet vinyl, sheet rubber — material that comes off a roll, so the order depends on how the cuts nest, not just on area ([§4](#4-conditions--your-finishes)). |
+| **Stitch** | Two to four sheets split at a match line, joined into one working surface so a room crossing the seam traces as one shape. Align it before you trace on it ([§2](#2-opening-plans--moving-around)). |
+| **Level** | A label grouping sheets by floor — `L1`, `Level 2`, `Garage`. Drives gallery grouping and the Excel by-floor sheet ([§2](#2-opening-plans--moving-around)). |
+| **Label** | Which part of the job a shape belongs to — *Phase 1*, *East Wing*, *Alt-2*. Classification, not correction; drives report grouping ([§7](#7-selecting--editing-shapes)). |
+| **Scale gate** | Nothing prices without a scale on that sheet. Counts are the exception — EA doesn't depend on scale ([§3](#3-scale--set-it-first)). |
+| **Unconfirmed scale** | A scale an agent set, which no person has verified. Quantities compute, but the chip, the gallery badge, and the report all say so until you confirm it ([§3](#3-scale--set-it-first)). |
+| **Calibrate vs. Check** | Calibrate sets the scale from a dimension you type. Check (`K`) is its read-only twin — it grades the scale you already have ([§3](#3-scale--set-it-first)). |
+| **Hatch / poché** | The pattern fill inside a room or wall on the drawing. One-Click classifies it as pattern rather than boundary, so a hatched room still traces to the real walls ([§6](#6-one-click-area)). |
+| **Fill sensitivity** | How eagerly a fill escalates past ink the engine called hatch — Strict, Balanced, Aggressive. It cannot help when the boundary is all hard ink, and it says so ([§6](#6-one-click-area)). |
+| **Zone check** | A reading, not a takeoff: trace a wing and see what's inside it, with materials scaled to the zone. Nothing is saved ([§5](#5-the-measuring-tools)). |
+| **Marked set** | The distribution-ready PDF — your work burned into the drawings behind a legend cover, with a tally of how much of it a person has approved. The deliverable a GC can check ([§10](#10-the-report--exports)). |
+| **Revision** | A named snapshot of the whole takeoff. Compare two and you get quantity deltas per condition, per sheet, and on the buy list ([§11](#11-revisions)). |
+| **Contribute** | The opt-in button that donates a takeoff's labels and normalized shapes — never the plan, the names, or the coordinates — to a training corpus ([§12](#12-saving-your-data--contribute)). |
+
+---
+
+*OpenTakeoff is Apache-2.0 and the codebase is deliberately readable — when you outgrow the manual, [`FEATURES.md`](../FEATURES.md) maps every capability to its code. Driving it from an agent instead? [`AGENT_GUIDE.md`](AGENT_GUIDE.md) is this document's counterpart.*

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,6 +4,12 @@ Listed in the [official MCP registry](https://registry.modelcontextprotocol.io) 
 `io.github.Kentucky-ai/opentakeoff`, on [Glama](https://glama.ai/mcp/servers/Kentucky-ai/opentakeoff),
 and on [Smithery](https://smithery.ai/servers/Kentucky-ai/opentakeoff).
 
+**This page is the reference — every tool, every rule, every limit.** For *how to run a
+takeoff well* with it — the operating model, the standard finish, what the engine withholds
+and why, and the move that answers each refusal — read
+[`docs/AGENT_GUIDE.md`](../docs/AGENT_GUIDE.md) first. It's short, and it's the half that
+decides whether the numbers are any good.
+
 ## Run it in 60 seconds (npx)
 
 No clone, no build — point your MCP client at the published package:

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.49",
+  "version": "0.9.50",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.49",
+  "version": "0.9.50",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.49",
+      "version": "0.9.50",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.49",
+  "version": "0.9.50",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.49",
+      "version": "0.9.50",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
The MCP docs were a setup page plus a tool reference: they said what every verb
does and nothing about how a takeoff is run. That doctrine lived only in the
server's initialize instructions, where no human reads it.

- docs/AGENT_GUIDE.md (new): the counterpart to the user manual — the operating
  model in six facts, the five-step standard finish, the withheld-is-the-answer
  table, what has no agent verb and why, staged tool exposure and when it's the
  right call, a worked session, and a refusal → next-move table.
- docs/USER_GUIDE.md: "The working order on a real bid" (the sequence for a
  forty-sheet set, not the five-minute sample path) and §18, a glossary of the
  terms that mean something specific here. Tool count corrected 38 → 40, with
  cut_out / apply_rules / duplicate_condition / split_condition added.
- README.md: a three-row "Start here" router above the fold, and a plain-language
  account of what a real bid looks like on the canvas before the feature prose.
- AGENT_BRIEF.md: rewritten — it had drifted into an internal to-do list with
  "Visibility Goals" and success-metric checkboxes, on a public repo.
- AGENTS.md: the doc set and who each document is for; MCP sync list now names
  the staging table. Fixed a dangling docs/MCP_AND_API.md reference.

Docs only — no engine change. npm run check green, doc links green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
