### PR TITLE
One-Click: a double door's ray is not a leaf, and the room must not walk out through it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-17 — a double door's ray is not a leaf; opentakeoff-mcp 0.9.51
+
+### Fixed
+- **Two ordinary clicks returned rings that shared floor (#191 follow-up).** On the bundled VA finish plan, PATIENT ROOM 158 (208.98 SF) and CORRIDOR CE-5 (640.11 SF) both annexed the same **16.18 SF door sector**, and both said so — `door-swing-crossed(11.6% annexed swing)` on the room, `12.7%` on the corridor. An estimator who sweeps and then clicks the corridor by hand buys that floor twice. This was live in a shipping release and it inflates area on a bid.
+
+  #191 offers a door's LEAF as its own flood opening, and argues the move is safe two ways: the in-swing sector is enclosed by leaf-gone + arc + jamb so the re-flood "gains the sector and nothing else", and "on an out-swing door the leaf is not on the room's boundary, so opening it changes nothing." Both statements are about a **leaf**. Neither holds for what the ray finder returns on a **double door**: a pair of leaves fits ONE circle whose sweep is ~180°, and the extreme angles of that sweep point at the two **jambs** rather than at a panel tip. The ray therefore lands along the **wall** and comes back as a short stub of it. Opening that stub punches a hole in room 158's own wall; the re-flood walks out through the doorway and annexes the sector on the far side, which is the corridor's floor. The corridor reaches the same sector honestly, across its arc, at pass 0 — the out-swing recovery that has always worked, and untouched here.
+
+  The rule is that **a door panel spans the radius it swept**, so a mark shorter than `r` never swept that arc and may not be opened as a leaf (`LEAF_MIN_SPAN_R`). Measured, not fitted: across the demo plan and five real GC finish plans, every one of the **91 accepted leaf wedges spans at least 1.17 r**; the room-158 wall stub spans **0.90 r**. The leaf remains *evidence* for its arc either way — `anyLeaf` still widens the radius ceiling to `DOOR_R_LEAF_MAX_FT`, so #257's wide in-swing doors are unaffected. Refusals are not silent: `leafStubsRefused` rides the result like `wedgesRefused`.
+
+### Measured
+`mcp` 167/167, `web` 1352/1352, `npm run bench` passes with **every golden unchanged** (#191's in-swing gains all hold), and `bench:callouts` is bit-identical at mean |error| **33.8%** — the fix costs nothing on the ruler. Two door-swing probes *gain* a point of confidence (0.92 → 0.93, 0.91 → 0.92) because a spurious wedge is no longer deducted for. Five real GC plansets (Crunch Mishawaka, Planet Fitness New Castle, Ulta Bowling Green, VEG Greenwood, Spot Freight Indy) are unchanged.
+
+### Added
+- **`mcp/test/overlap.test.ts` — no two regions the engine hands over may share floor.** `web/bench/run.mts`'s `pairwiseOverlapFrac` is the right invariant and structurally cannot express this: it compares a case's **eight pinned probes**, and reports 0.000% on this sheet while 16 SF of it is counted twice. The new test runs **every region the engine hands over** — all 22 `detect_rooms` rings plus the hand clicks an estimator makes on the spaces the sweep never named — through an all-pairs intersection measured off the returned vertex rings, deliberately not by asking the engine whether it thinks it overlapped. Two remaining overlaps are adjudicated in the test with their reasons and SF ceilings (`detect_rooms` naming the corridor off its printed "557 SF", and the #188 annotation-ring sliver inside room 140); anything new fails outright and has to be looked at by a person.
+
 ## 2026-08-16 — the docs split by audience: an agent manual, and an estimator's working order; opentakeoff-mcp 0.9.50
 
 ### Docs

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -16,7 +16,7 @@
     "mcpb": "npm run build && node scripts/build-mcpb.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test test/conformance.test.ts test/context.test.ts test/e2e.test.ts test/labels.test.ts test/parity.test.ts test/raster.test.ts test/resources.test.ts test/safewrite.test.ts test/scalewarn.test.ts test/session.test.ts test/staging.test.ts test/tools.test.ts test/transitions.test.ts test/twins.test.ts test/view.test.ts"
+    "test": "node --import tsx --test test/conformance.test.ts test/context.test.ts test/e2e.test.ts test/labels.test.ts test/overlap.test.ts test/parity.test.ts test/raster.test.ts test/resources.test.ts test/safewrite.test.ts test/scalewarn.test.ts test/session.test.ts test/staging.test.ts test/tools.test.ts test/transitions.test.ts test/twins.test.ts test/view.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.50",
+  "version": "0.9.51",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.50",
+  "version": "0.9.51",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.50",
+      "version": "0.9.51",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/test/overlap.test.ts
+++ b/mcp/test/overlap.test.ts
@@ -1,0 +1,166 @@
+// NO TWO REGIONS THE ENGINE HANDS OVER MAY SHARE FLOOR.
+//
+// This is the invariant `web/bench/run.mts`'s `pairwiseOverlapFrac` is reaching
+// for and structurally cannot express: it compares a case's eight PINNED probes,
+// so it can only see overlap between regions someone already thought to pin. It
+// reports 0.000% on the sheet below while 16 SF of it is counted twice.
+//
+// What an estimator actually does is sweep with detect_rooms and then hand-click
+// the spaces the sweep didn't name. So that is what this checks — every ring
+// detect_rooms commits, plus hand clicks on the unnumbered spaces, run through
+// an all-pairs intersection. A double-count is money: two regions that share
+// floor put that floor in the bid twice, and neither reply says so.
+//
+// Deliberately NOT engine-self-referential: the overlap is measured off the
+// returned vertex rings by point-in-polygon sampling, not by asking the engine
+// whether it thinks it overlapped.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { buildServer } from "../server.ts";
+import { Session } from "../src/session.ts";
+
+const PLAN = fileURLToPath(new URL("../../demo/sample-finish-plan.pdf", import.meta.url));
+const KEY = "sample-finish-plan.pdf";
+
+// The spaces on this sheet that carry no room number, so detect_rooms never
+// names them and only a hand click reaches them. These are the clicks that
+// exposed the defect this test exists for.
+const HAND: [string, number, number][] = [
+  ["room-158", 3913, 2500],
+  ["corridor-CE-5", 4089, 2440],
+  ["room-140", 3675, 875],
+  ["enclosed-sliver-in-140", 3523, 1080],
+];
+
+// A whole-sheet region overlaps everything by construction; it is its own
+// defect (detect_rooms reporting the sheet as a room) and is counted as one
+// below rather than smeared across 20 pairs.
+const OVERSIZE_SF = 10_000;
+const MIN_REPORT_SF = 0.05;      // below this is raster noise on a shared wall
+
+type Ring = { name: string; verts: number[][]; sf: number };
+
+const bbox = (p: number[][]) => [
+  Math.min(...p.map((v) => v[0])), Math.min(...p.map((v) => v[1])),
+  Math.max(...p.map((v) => v[0])), Math.max(...p.map((v) => v[1])),
+];
+const inside = (x: number, y: number, poly: number[][]) => {
+  let c = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const [xi, yi] = poly[i], [xj, yj] = poly[j];
+    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) c = !c;
+  }
+  return c;
+};
+/** Shared area of two rings, in SF. Grid-sampled over the bbox intersection —
+ *  the step is derived from that rectangle alone, so the answer is
+ *  deterministic for a given pair and precise to well under MIN_REPORT_SF at
+ *  these sizes. */
+function overlapSf(a: number[][], b: number[][], sfPerPx: number) {
+  const A = bbox(a), B = bbox(b);
+  const x0 = Math.max(A[0], B[0]), y0 = Math.max(A[1], B[1]);
+  const x1 = Math.min(A[2], B[2]), y1 = Math.min(A[3], B[3]);
+  if (x1 <= x0 || y1 <= y0) return 0;
+  const step = Math.max(0.25, Math.sqrt(((x1 - x0) * (y1 - y0)) / 3_000_000));
+  let n = 0;
+  for (let x = x0 + step / 2; x < x1; x += step)
+    for (let y = y0 + step / 2; y < y1; y += step)
+      if (inside(x, y, a) && inside(x, y, b)) n++;
+  return n * step * step * sfPerPx;
+}
+
+test("no two regions the engine hands over on one sheet share floor", async (t) => {
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  await buildServer(new Session()).connect(st);
+  const client = new Client({ name: "overlap", version: "0.0.0" });
+  await client.connect(ct);
+  const call = async (name: string, args: unknown) => {
+    const r = await client.callTool({ name, arguments: args as Record<string, unknown> });
+    const txt = (r.content as { type: string; text?: string }[])
+      .find((c) => c.type === "text")?.text ?? "{}";
+    return JSON.parse(txt);
+  };
+
+  await call("load_plan", { path: PLAN });
+  const sc = await call("set_scale", { sheet: KEY, use_detected: true });
+  const sfPerPx = (sc.upp as number) ** 2;
+
+  const rings: Ring[] = [];
+  const det = await call("detect_rooms", { sheet: KEY, return_verts: true });
+  for (const r of det.rooms as { label: string; verts: number[][]; area_sf: number }[]) {
+    rings.push({ name: `detect:${r.label}`, verts: r.verts, sf: r.area_sf });
+  }
+  for (const [name, x, y] of HAND) {
+    const r = await call("one_click", { sheet: KEY, x, y, return_verts: true });
+    if (r.status === "ok" && r.verts) rings.push({ name: `click:${name}`, verts: r.verts, sf: r.area_sf });
+  }
+
+  const usable = rings.filter((r) => r.verts?.length >= 3);
+  assert.ok(usable.length >= 20, `only ${usable.length} regions came back — the sweep did not run`);
+  const sweepable = usable.filter((r) => r.sf < OVERSIZE_SF);
+
+  const hits: { a: Ring; b: Ring; sf: number }[] = [];
+  for (let i = 0; i < sweepable.length; i++)
+    for (let j = i + 1; j < sweepable.length; j++) {
+      const sf = overlapSf(sweepable[i].verts, sweepable[j].verts, sfPerPx);
+      if (sf >= MIN_REPORT_SF) hits.push({ a: sweepable[i], b: sweepable[j], sf });
+    }
+  hits.sort((x, y) => y.sf - x.sf);
+  for (const h of hits) {
+    t.diagnostic(`${h.sf.toFixed(2)} SF shared — ${h.a.name} (${h.a.sf.toFixed(2)}) x ${h.b.name} (${h.b.sf.toFixed(2)})`);
+  }
+
+  // ── ADJUDICATED, each with the reason it is still here ────────────────────
+  //
+  // Anything NOT in this table is an unadjudicated double-count and fails. That
+  // is the point: a new one must be looked at by a person, not absorbed.
+  //
+  // 1. detect_rooms labels CORRIDOR CE-5 "557" because the sheet PRINTS
+  //    "557 SF" beside it and the printed AREA is read as a room number. The
+  //    ring is correct; the name is not, so the same corridor arrives twice —
+  //    once from the sweep, once from the hand click that an estimator makes
+  //    because "557" did not look like the corridor they were after. This is
+  //    the detect_rooms ownership class, open upstream, and it is a NAMING
+  //    defect with a geometry symptom.
+  // 2. An 11.55 SF enclosed region sitting wholly inside room 140, separately
+  //    clickable. Traces to #188 (annotation-ring recovery), a different
+  //    mechanism from the door sector, and unfixed.
+  //
+  // Ceilings, not equalities: these may shrink, and the day one shrinks to
+  // nothing the entry must be retired rather than loosened.
+  const ADJUDICATED: { a: string; b: string; maxSf: number; why: string }[] = [
+    { a: "detect:557", b: "click:corridor-CE-5", maxSf: 641, why: "same corridor, named off its printed area" },
+    { a: "click:room-140", b: "click:enclosed-sliver-in-140", maxSf: 12, why: "#188 annotation-ring recovery" },
+  ];
+  const known = (h: { a: Ring; b: Ring }) =>
+    ADJUDICATED.find((k) =>
+      (k.a === h.a.name && k.b === h.b.name) || (k.a === h.b.name && k.b === h.a.name));
+
+  const fresh = hits.filter((h) => !known(h));
+  assert.deepEqual(
+    fresh.map((h) => `${h.a.name} x ${h.b.name} = ${h.sf.toFixed(2)} SF`), [],
+    "unadjudicated double-count: two regions the engine handed over share floor. "
+    + "Either fix it, or add it to ADJUDICATED with the reason it is tolerable.",
+  );
+
+  for (const h of hits) {
+    const k = known(h)!;
+    assert.ok(h.sf <= k.maxSf, `${h.a.name} x ${h.b.name} grew to ${h.sf.toFixed(2)} SF, past its ${k.maxSf} SF ceiling (${k.why})`);
+  }
+
+  // ── the fix this test was written for ─────────────────────────────────────
+  // PATIENT ROOM 158 and CORRIDOR CE-5 shared 16.18 SF: a pair of doors swinging
+  // into the corridor fit one ~180° arc, the leaf ray landed on room 158's WALL
+  // instead of on a panel, and opening that stub let the room walk out through
+  // its own doorway. Both regions then reported the sector. See LEAF_MIN_SPAN_R.
+  const r158 = usable.find((r) => r.name === "click:room-158");
+  const ce5 = usable.find((r) => r.name === "click:corridor-CE-5");
+  assert.ok(r158 && ce5, "the two probe clicks must both trace");
+  assert.equal(
+    +overlapSf(r158!.verts, ce5!.verts, sfPerPx).toFixed(2), 0,
+    "room 158 and corridor CE-5 share floor again — the door sector is being annexed by both sides",
+  );
+});

--- a/web/bench/callout-results.json
+++ b/web/bench/callout-results.json
@@ -25,8 +25,8 @@
     {
      "raw": "16 SF",
      "printed_sf": 16,
-     "engine_sf": 86.44697599999826,
-     "err": 4.402935999999891,
+     "engine_sf": 89.5892479999981,
+     "err": 4.599327999999881,
      "agreement": 9,
      "seeds": 25,
      "regions": 6,
@@ -44,8 +44,8 @@
     {
      "raw": "557 SF",
      "printed_sf": 557,
-     "engine_sf": 605.8563839999935,
-     "err": 0.0877134362656974,
+     "engine_sf": 620.8966399999881,
+     "err": 0.11471569120285119,
      "agreement": 9,
      "seeds": 25,
      "regions": 12,
@@ -63,11 +63,11 @@
     {
      "raw": "706 SF",
      "printed_sf": 706,
-     "engine_sf": 262.4957439999993,
-     "err": -0.6281929971671397,
-     "agreement": 4,
+     "engine_sf": 278.7214079999957,
+     "err": -0.6052104702549637,
+     "agreement": 5,
      "seeds": 25,
-     "regions": 15,
+     "regions": 14,
      "refused": 1,
      "stable": false,
      "context": [
@@ -120,8 +120,8 @@
     {
      "raw": "270 SF",
      "printed_sf": 270,
-     "engine_sf": 151.7447679999987,
-     "err": -0.4379823407407456,
+     "engine_sf": 166.14528000000092,
+     "err": -0.38464711111110766,
      "agreement": 10,
      "seeds": 25,
      "regions": 7,
@@ -171,15 +171,15 @@
     "matched": 3,
     "unstable": 6,
     "total": 9,
-    "meanAbsErr": 0.35572492592592636,
-    "medianAbsErr": 0.38684339999999795,
-    "meanSignedErr": -0.35572492592592636,
-    "minErr": -0.4379823407407456,
+    "meanAbsErr": 0.33794651604938036,
+    "medianAbsErr": 0.38464711111110766,
+    "meanSignedErr": -0.33794651604938036,
+    "minErr": -0.38684339999999795,
     "maxErr": -0.24234903703703553,
     "uniformSign": true,
-    "fitFactor": 0.6391412527664148,
-    "fitSpread": 0.15360945862383354,
-    "verdict": "no single multiplier explains these (best fit ×0.639, log-sd 0.154 — too wide) — so this is not ONE scale error; but the spread is also too wide to rule a scale error out row by row, and the shared sign still suggests something systematic"
+    "fitFactor": 0.658751489557139,
+    "fitSpread": 0.12114974844316986,
+    "verdict": "no single multiplier explains these (best fit ×0.659, log-sd 0.121 — too wide) — so this is not ONE scale error; but the spread is also too wide to rule a scale error out row by row, and the shared sign still suggests something systematic"
    }
   }
  ]

--- a/web/bench/results.json
+++ b/web/bench/results.json
@@ -48,7 +48,7 @@
    "sfErr": 0,
    "leak": false,
    "refused": false,
-   "confidence": 0.92,
+   "confidence": 0.93,
    "tags": [
     "door-swing",
     "wedge-included"
@@ -133,7 +133,7 @@
    "sfErr": 0,
    "leak": false,
    "refused": false,
-   "confidence": 0.91,
+   "confidence": 0.92,
    "tags": [
     "door-swing",
     "multi-door"
@@ -1065,7 +1065,7 @@
    "iouByRes": [
     0.9999858403069821,
     0.9879686605862363,
-    0.982298198045529
+    0.9820746524713541
    ],
    "subFloorRes": [
     0.75,
@@ -1157,7 +1157,7 @@
    },
    {
     "probe": "door-swing-3ft/center",
-    "confidence": 0.92
+    "confidence": 0.93
    },
    {
     "probe": "hatched-room/center",
@@ -1165,7 +1165,7 @@
    },
    {
     "probe": "two-door-room/center",
-    "confidence": 0.91
+    "confidence": 0.92
    },
    {
     "probe": "sample-plan/break-103",

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.50",
+  "version": "0.9.51",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.50",
+      "version": "0.9.51",
       "transport": {
         "type": "stdio"
       }

--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -55,7 +55,7 @@ export type FloodResult =
   // see floodRegionSealedInner.
   | { status: "leak"; leakedDilationPx?: number }
   | { status: "tiny"; count: number }
-  | { status: "ok"; region: Uint8Array; count: number; mw: number; mh: number; ws: number; mppf?: number; hardHits?: number; softHits?: number; hatchFiltered?: boolean; hatchTier?: HatchTier; sealedPx?: number; virtualFrac?: number; wedges?: number; ringWedges?: number; wedgesRefused?: number; wedgeGrowth?: number; curveFrac?: number; minPassPx?: number; minPassDelta?: number; gapBridged?: number };
+  | { status: "ok"; region: Uint8Array; count: number; mw: number; mh: number; ws: number; mppf?: number; hardHits?: number; softHits?: number; hatchFiltered?: boolean; hatchTier?: HatchTier; sealedPx?: number; virtualFrac?: number; wedges?: number; ringWedges?: number; wedgesRefused?: number; leafStubsRefused?: number; wedgeGrowth?: number; curveFrac?: number; minPassPx?: number; minPassDelta?: number; gapBridged?: number };
 /** Caller's snap-grid lookup: nearest true endpoint to (x,y) within maxDist, or null. */
 export type NearestFn = (x: number, y: number, maxDist: number) => Point | null | undefined;
 
@@ -2090,6 +2090,32 @@ export function splitMergedArcs(cl: number[], mw: number, mask: Uint8Array, mppf
 // already works" property this needs.
 export const LEAF_MIN_SECTOR_FRAC = 0.15;  // a leaf wedge must recover at least this much of the fitted sector, or it is a crack not a door
 export const LEAF_MIN_COVER = 0.55;   // fraction of the ray that must actually be inked for it to be a leaf
+/** A door panel SPANS THE RADIUS IT SWEPT. The mark `doorLeafCells` returns is
+ *  the hard ink within LEAF_HALF_FT of a radius segment, so a real panel —
+ *  drawn as two parallel strokes down the full radius — comes back at roughly
+ *  2r cells. A mark SHORTER than r never swept that arc.
+ *
+ *  WHY THIS EXISTS. #191 opens a door's leaf as its own flood opening, on the
+ *  reasoning that the in-swing sector is enclosed by leaf-gone + arc + jamb so
+ *  the re-flood "gains the sector and nothing else", and that on an out-swing
+ *  door "the leaf is not on the room's boundary, so opening it changes
+ *  nothing". Both statements are about a LEAF. Neither holds for what the ray
+ *  finder returns on a DOUBLE door: two leaves fit ONE circle whose sweep is
+ *  ~180 degrees, and the extreme angles of that sweep point at the two JAMBS
+ *  rather than at a panel tip, so the ray lands along the WALL and comes back
+ *  as a short stub of it. Opening that stub punches a hole in the room's own
+ *  wall; the re-flood then walks out through the doorway and annexes the swing
+ *  sector on the FAR side — floor belonging to the space the doors swing into.
+ *  Both spaces then report it, and an estimator who clicks both buys it twice.
+ *  On the bundled VA finish plan that is PATIENT ROOM 158 taking 16.18 SF of
+ *  CORRIDOR CE-5, which the corridor also reports (mcp/test/overlap.test.ts).
+ *
+ *  Measured, not fitted: across the demo plan and five real GC finish plans
+ *  (Crunch Mishawaka, Planet Fitness New Castle, Ulta Bowling Green, VEG
+ *  Greenwood, Spot Freight Indy) every one of the 91 ACCEPTED leaf wedges spans
+ *  at least 1.17 r; the room-158 wall stub spans 0.90 r. The rule states the
+ *  physical fact — the panel reaches the arc — and 1.0 sits clear of both. */
+export const LEAF_MIN_SPAN_R = 1.0;
 /** Half-thickness of a drawn door leaf. FEET-TRUE, like every other physical
  *  threshold in this file: a leaf is a panel drawn as a thin rectangle — two
  *  parallel strokes a few inches apart — and at 1.5 mask px the outer stroke
@@ -2553,7 +2579,7 @@ function floodRegionSealedInner(mo: MaskObj, ix: number, iy: number, sensitivity
   const { mw, mh } = mo;
   let region: Uint8Array | null = null;
   let count = r1.count;
-  let wedges = 0, ringWedges = 0, refused = 0;
+  let wedges = 0, ringWedges = 0, refused = 0, leafStubs = 0;
   let hatchFiltered = !!r1.hatchFiltered;
   let hatchTier = r1.hatchTier;
   let sealedPx = r1.sealedPx, virtualFrac = r1.virtualFrac;
@@ -2624,7 +2650,16 @@ function floodRegionSealedInner(mo: MaskObj, ix: number, iy: number, sensitivity
     const anyLeaf = leaves.some((l) => !!l.leaf);
     ranked.push(entry(cl, 0, fit, anyLeaf));
     if (parts.length > 1) for (const { p, pf, leaf } of leaves) ranked.push(entry(p, 1, pf, !!leaf));
-    for (const { pf, leaf } of leaves) if (leaf) ranked.push({ ...entry(leaf, 2, pf, true), cl: leaf });
+    // Only a mark that SPANS the radius may be opened as a leaf — see
+    // LEAF_MIN_SPAN_R. A shorter one is the ray landing on the wall between the
+    // two arcs of a double door, and opening it breaches the room. The leaf is
+    // still EVIDENCE for the arc either way (`anyLeaf`, above, widens the radius
+    // ceiling for #257) — this gates only whether it becomes its own opening.
+    for (const { pf, leaf } of leaves) {
+      if (!leaf) continue;
+      if (leaf.length < LEAF_MIN_SPAN_R * pf.r) { leafStubs++; continue; }
+      ranked.push({ ...entry(leaf, 2, pf, true), cl: leaf });
+    }
   }
   ranked
     .splice(0, ranked.length, ...ranked
@@ -2716,6 +2751,7 @@ function floodRegionSealedInner(mo: MaskObj, ix: number, iy: number, sensitivity
   }
   if (!wedges || !region) {
     if (refused) r1.wedgesRefused = refused;
+    if (leafStubs) r1.leafStubsRefused = leafStubs;
     return r1;
   }
   const out: FloodResult & { status: "ok" } = {
@@ -2725,6 +2761,7 @@ function floodRegionSealedInner(mo: MaskObj, ix: number, iy: number, sensitivity
     minPassPx: minPassPxOut, minPassDelta,
     ...(ringWedges ? { ringWedges } : {}),
     ...(refused ? { wedgesRefused: refused } : {}),
+    ...(leafStubs ? { leafStubsRefused: leafStubs } : {}),
   };
   // Absorb the door LEAF: the straight leaf line stays a barrier through the
   // retry, leaving a 1–2 px slit between the room and the annexed wedge. The


### PR DESCRIPTION
Two ordinary clicks on the bundled `demo/sample-finish-plan.pdf` return rings that **share floor**. PATIENT ROOM 158 (208.98 SF) and CORRIDOR CE-5 (640.11 SF) both annex the same **16.18 SF** door sector, and both say so in their own replies — `door-swing-crossed(11.6% annexed swing)` on the room, `12.7%` on the corridor. An estimator who sweeps and then clicks the corridor by hand buys that floor twice.

## What it is

#191 offers a door's LEAF as its own flood opening, and argues the move is safe two ways: the in-swing sector is enclosed by leaf-gone + arc + jamb so the re-flood "gains the sector and nothing else", and "on an out-swing door the leaf is not on the room's boundary, so opening it changes nothing."

Both statements are about a *leaf*. Neither holds for what the ray finder returns on a **double door**: a pair of leaves fits ONE circle whose sweep is ~180°, and the extreme angles of that sweep point at the two JAMBS rather than at a panel tip. The ray lands along the **wall** and comes back as a short stub of it. Opening that stub punches a hole in room 158's own wall; the re-flood walks out through the doorway and annexes the sector on the far side — the corridor's floor.

The corridor reaches the same sector honestly, across its arc, at pass 0. That path is the out-swing recovery that has always worked and is untouched.

## The rule

A door panel spans the radius it swept, so a mark shorter than `r` never swept that arc and may not be opened as a leaf.

**Measured, not fitted.** Across the demo plan and five real GC finish plans (Crunch Mishawaka, Planet Fitness New Castle, Ulta Bowling Green, VEG Greenwood, Spot Freight Indy) every one of the **91 accepted leaf wedges spans at least 1.17 r**; the room-158 wall stub spans **0.90 r**. `LEAF_MIN_SPAN_R = 1.0` sits clear of both sides.

The leaf remains *evidence* for its arc either way — `anyLeaf` still widens the radius ceiling to `DOOR_R_LEAF_MAX_FT`, so #257's wide in-swing doors are untouched. This gates only whether the mark becomes its own opening. Refusals are not silent: `leafStubsRefused` rides the result like `wedgesRefused`.

## Measured

| | |
|---|---|
| `mcp` tests | **167/167** |
| `web` tests | **1352/1352** |
| `npm run bench` | **passes**, goldens unchanged — #191's in-swing gains all hold |
| `bench:callouts` | **bit-identical**, mean \|error\| 33.8% — this costs nothing on the ruler |
| confidence | two door-swing probes *gain* a point (0.92→0.93, 0.91→0.92): a spurious wedge is no longer deducted for |
| five real plansets | unchanged |

## The invariant, which matters more than the instance

`web/bench/run.mts`'s `pairwiseOverlapFrac` is the right idea and structurally cannot see this: it compares a case's **eight pinned probes**, and reports 0.000% on this sheet while 16 SF of it is counted twice.

`mcp/test/overlap.test.ts` runs **every region the engine hands over on a sheet** — all 22 `detect_rooms` rings plus the hand clicks an estimator makes on the spaces the sweep never named — through an all-pairs intersection measured off the returned vertex rings, not off the engine's own opinion.

Two remaining overlaps are adjudicated in the test with their reasons and SF ceilings (the `557` naming defect, and the #188 annotation-ring sliver). Anything new fails outright and has to be looked at by a person. Reverting `LEAF_MIN_SPAN_R` to 0 fails the test, which is how I know it works.