### PR TITLE
Derive grout coverage on a linear (tile base) line, not just an area line

### DIFF
--- a/web/src/components/TakeoffsPanel.jsx
+++ b/web/src/components/TakeoffsPanel.jsx
@@ -33,7 +33,7 @@ import { areaVal, areaUnit, lenVal, lenUnit, heightUnit, heightInputToFeet, heig
 import { HATCHES, PALETTE, NO_FILL, HatchSwatch } from "./hatches.jsx";
 import { LINE_STYLES, LINE_STYLE_IDS } from "../lib/lineStyles.js";
 import { baseTagOf, localCount } from "../lib/variants.ts";
-import { materialKind, MATERIAL_PRESETS, GROUT_DEFAULTS, groutDerivedFields, showsGroutCalc, showsGroutDeriveAffordance } from "../lib/coverage.js";
+import { materialKind, MATERIAL_PRESETS, GROUT_DEFAULTS, groutDerivedFields, showsGroutCalc, showsGroutDeriveAffordance, isLinearGrout, baseGroutParams, baseCourses, groutRateStale, inFrac } from "../lib/coverage.js";
 import { draftCommitValue, blurCommitValue, blurCommitNonNegative } from "../lib/draftInput.js";
 import { ROLL_FLOORING_TYPES } from "../lib/rollgoods.js";
 import { hasRollSetup, mintRollSetup } from "../lib/rollTakeoff.js";
@@ -183,7 +183,8 @@ function CoveragePresetSelect({ material: m, onPick }) {
 
 // Editable supporting-materials rows for a condition (coverage-derived order qty).
 function MaterialsEditor({ materials, onAdd, onUpdate, onRemove, library, libById, overridden, onRevert, onAttach, onPromote,
-    twin = false, parentTag = "", dropped = [], parentRows = [], onFollowFamilyRow, onRestoreDroppedRow }) {
+    twin = false, parentTag = "", dropped = [], parentRows = [], onFollowFamilyRow, onRestoreDroppedRow,
+    heightFt = 0 }) {
   // library link affordances (#47, all optional so the editor works standalone):
   // linked lines show ⛓; a field differing from its library entry tints amber
   // and grows a per-field ↺ revert; unlinked lines can be promoted to the library
@@ -197,7 +198,11 @@ function MaterialsEditor({ materials, onAdd, onUpdate, onRemove, library, libByI
       {(materials || []).map((m) => {
         const lm = libById ? libById[m.lib_id] : null;
         const ov = (f) => (lm && overridden ? overridden(m, lm, f) : false);
-        const g = { ...GROUT_DEFAULTS, ...(m.grout || {}) };
+        // On a base (linear) line the piece's long dimension is the CONDITION's height,
+        // so it is derived in, not stored on the row — and the calculator below renders
+        // it read-only for the same reason.
+        const g = baseGroutParams({ ...GROUT_DEFAULTS, ...(m.grout || {}) },
+          isLinearGrout(m) ? heightFt : 0);
         // grout coverage derives from tile geometry — a param change re-derives
         // per + writes the derivation into the note so the Report shows its
         // work, but ONLY while the whole geometry is valid: an incomplete edit
@@ -205,7 +210,7 @@ function MaterialsEditor({ materials, onAdd, onUpdate, onRemove, library, libByI
         // silently committing a rate of 0 into the buy list and exports
         const setGrout = (patch) => {
           const grout = { ...g, ...patch };
-          onUpdate(m.id, { grout, ...(groutDerivedFields(grout) || {}) });
+          onUpdate(m.id, { grout, ...(groutDerivedFields(grout, m.basis, heightFt) || {}) });
         };
         const gi = (key, title, extra) => (
           <GroutParamInput name={`grout-${key}`} value={g[key]} title={title} override={ov("grout")}
@@ -260,10 +265,37 @@ function MaterialsEditor({ materials, onAdd, onUpdate, onRemove, library, libByI
                 opt-in below — never a calculator backfilled with defaults */}
             {showsGroutCalc(m) && (
               <div style={{ flexBasis: "100%", display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap", paddingLeft: 14, color: "var(--ink-muted)", fontSize: 12 }}>
-                <span>tile</span>
-                {gi("tileL", "Tile length (in)")}
-                <span>×</span>
-                {gi("tileW", "Tile width (in)")}
+                {isLinearGrout(m) ? (
+                  <>
+                    <span>base</span>
+                    {/* read-only: the height belongs to the CONDITION, and an editable copy
+                        here would be a second owner of one number. No height = not figurable,
+                        which says so rather than deriving off a default. */}
+                    <span title="Base height — set on the condition, not here"
+                      style={{ fontFamily: "var(--f-mono, monospace)", padding: "2px 5px", border: "1px dashed var(--ink-faint)",
+                        color: Number(heightFt) > 0 ? "var(--ink)" : "var(--c-warning)" }}>
+                      {Number(heightFt) > 0 ? `${inFrac(Number(heightFt) * 12)}″ H` : "set height on condition"}
+                    </span>
+                    {/* piece height defaults to the base height (one course); a SHORTER one
+                        is multi-course base, where the interior horizontal joints are real */}
+                    <span>· pc</span>
+                    {gi("tileL", "Piece height (in) — defaults to the base height (one course). Enter a SHORTER piece for multi-course base (a 6″ band of 2×2 mosaic is three courses)", { width: 52 })}
+                    <span>×</span>
+                    {gi("tileW", "Piece width (in) — for field-cut base, the parent tile dimension you did NOT rip")}
+                    {baseCourses(g, heightFt) > 1 && (
+                      <span title="Courses of base — a fractional last course is a CUT (waste), not more grout">
+                        ({Math.round(baseCourses(g, heightFt) * 100) / 100} crs)
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <span>tile</span>
+                    {gi("tileL", "Tile length (in)")}
+                    <span>×</span>
+                    {gi("tileW", "Tile width (in)")}
+                  </>
+                )}
                 <span>× thick</span>
                 {gi("tileT", "Tile thickness (in)")}
                 <span>″ · joint</span>
@@ -272,14 +304,23 @@ function MaterialsEditor({ materials, onAdd, onUpdate, onRemove, library, libByI
                 {gi("bagLbs", "Bag size (lbs)")}
                 <span>lb</span>
                 {ov("grout") && rv(m, "grout")}
+                {groutRateStale(m, heightFt) && (
+                  <button onClick={() => setGrout({})}
+                    title={`This line's rate (${m.per} per LF-basis unit) is not what its geometry and this condition's base height derive. A rate figured for a different base height — from a library entry or a hand edit — does not follow the height here. Click to re-derive.`}
+                    style={{ padding: "1px 6px", borderRadius: 0, border: "1px solid var(--c-warning)", background: "transparent", color: "var(--c-warning)", cursor: "pointer", fontSize: 11 }}>
+                    ⚠ rate ≠ geometry · re-derive
+                  </button>
+                )}
               </div>
             )}
             {showsGroutDeriveAffordance(m) && (
               <div style={{ flexBasis: "100%", display: "flex", alignItems: "center", gap: 6, paddingLeft: 14 }}>
                 <button onClick={() => setGrout({})}
-                  title="Start the grout calculator with standard tile geometry (12×24×3/8″ @ 1/8″, 25 lb bag) — REPLACES this line's coverage rate and note with the derived values"
+                  title={isLinearGrout(m)
+                    ? "Start the base-grout calculator with standard geometry (3/8″ thick @ 1/8″ joint, 25 lb bag) — the piece height comes from the condition. REPLACES this line's coverage rate and note"
+                    : "Start the grout calculator with standard tile geometry (12×24×3/8″ @ 1/8″, 25 lb bag) — REPLACES this line's coverage rate and note with the derived values"}
                   style={{ padding: "2px 7px", borderRadius: 0, border: "1px dashed var(--ink-faint)", background: "transparent", color: "var(--ink-muted)", cursor: "pointer", fontSize: 11 }}>
-                  derive from tile geometry…
+                  {isLinearGrout(m) ? "derive from base geometry…" : "derive from tile geometry…"}
                 </button>
                 {ov("grout") && rv(m, "grout")}
               </div>
@@ -942,7 +983,8 @@ function TakeoffsPanel({
               onAttach={onAttachLibMaterial} onPromote={onPromoteMaterial}
               twin={!!c.variant_of} parentTag={(conditions.find((x) => x.id === c.variant_of) || {}).finish_tag || ""}
               dropped={c.materials_dropped || []} parentRows={(conditions.find((x) => x.id === c.variant_of) || {}).materials || []}
-              onFollowFamilyRow={onFollowFamilyRow} onRestoreDroppedRow={onRestoreDroppedRow} />
+              onFollowFamilyRow={onFollowFamilyRow} onRestoreDroppedRow={onRestoreDroppedRow}
+              heightFt={c.height_ft} />
             {/* Duplicate, inline — deliberately NOT a window.prompt: those freeze a
                 CDP/automation-driven session dead, and this panel is scripted in demos. */}
             {onDuplicateCondition && (twinDraft.id === c.id ? (

--- a/web/src/lib/coverage.js
+++ b/web/src/lib/coverage.js
@@ -6,6 +6,10 @@ export function materialKind(m) {
   if (/mortar|thin-?set/i.test(n)) return "mortar";
   if (/grout/i.test(n)) return "grout";
   if (/adhes|glue|bond|mastic/i.test(n)) return "adhesive";
+  // Edge/cap profiles, LAST so it can't eat an adhesive whose name mentions a trim.
+  // These are stick goods: they are bought by the LENGTH OF STICK, not by a spread
+  // rate, which is why they get their own preset family below.
+  if (/\btrim\b|\bprofile\b|top cap|edge cap|nosing|\bschiene\b|reducer/i.test(n)) return "trim";
   return "";
 }
 export const MATERIAL_PRESETS = {
@@ -23,6 +27,19 @@ export const MATERIAL_PRESETS = {
     { label: '1/4″×3/8″×1/4″ sq', per: 65 },
     { label: '1/2″×1/2″×1/2″ sq', per: 42 },
     { label: '3/4″ U (large tile)', per: 30 },
+  ],
+  // LF per stick. Edge and cap profiles are stick goods, so the "coverage" that
+  // divides a linear measure is simply the stock length — an odd-looking rate to
+  // type from memory (8.2, not 8), and the reason tile base capped with an edge
+  // profile kept getting ordered a stick short. Metric stock lengths dominate:
+  // 2.5 m = 8.202 LF, 3 m = 9.843, 1.5 m = 4.921.
+  trim: [                                  // LF per stick
+    { label: "2.5 m stick (8′ 2-1/2″)", per: 8.202 },
+    { label: "3 m stick (9′ 10″)",      per: 9.843 },
+    { label: "1.5 m stick (4′ 11″)",    per: 4.921 },
+    { label: "8 ft stick",              per: 8 },
+    { label: "10 ft stick",             per: 10 },
+    { label: "12 ft stick",             per: 12 },
   ],
 };
 export const GROUT_DENSITY = 8.33;         // industry-standard grout density factor
@@ -52,6 +69,31 @@ export const groutParamsEqual = (a, b) => {
   return GROUT_PARAM_KEYS.every((k) => (Number(A[k]) || 0) === (Number(B[k]) || 0));
 };
 
+// ── tile base: the same formula on a line measured in LINEAR feet ────────────
+// Tile base (a cove or bullnose course, or field tile ripped to height and
+// capped with a trim profile) is measured in LF, but grout is consumed per SF
+// of the face being set. Two facts turn one into the other:
+//
+//  • A single course grouted at the floor line has joint density 1/W + 1/H per
+//    inch of face — which IS (H+W)/(H·W), the field-tile term for a tile of
+//    dimensions H × W. So the "tile" fed to the formula is the BASE PIECE: its
+//    long dimension is the piece height, its short one the piece width. No new
+//    formula, no joint-density parameter — the field one, fed the right piece.
+//  • Face SF per LF of run is the base height IN FEET (a 6″ base is 0.5 SF of
+//    face per LF). So sf/bag ÷ height_ft = lf/bag.
+//
+// The base HEIGHT belongs to the condition (height_ft) and is read-only in the
+// geometry block — two owners of one number drift, and a 6″ base whose block
+// still says 4″ prices a joint that isn't there. The piece height defaults to it
+// (see baseGroutParams) and is only worth typing for multi-course base.
+//
+// The WIDTH is always the estimator's, and it is the input that bites: for
+// field-cut base it is the parent tile dimension that was NOT ripped. A 6″ base
+// off a 12×24 is 6H × 24W (615 lf/bag); read as 6H × 12W it is 512, a 20%
+// over-order, and read as a 6×6 catalog piece it is 384 — 60% over.
+const GROUT_BASES = new Set(["area", "linear"]);
+export const isLinearGrout = (m) => (m?.basis || "area") === "linear";
+
 // The grout calculator's render gate: the tile-geometry row appears ONLY when
 // the line actually HAS geometry (m.grout truthy) — a kind:"grout" line
 // without it (e.g. a library entry whose geometry was detached by a hand
@@ -60,9 +102,9 @@ export const groutParamsEqual = (a, b) => {
 // silently backfilled with defaults, where one keystroke would commit the
 // whole default object over the pushed rate.
 export const showsGroutCalc = (m) =>
-  materialKind(m) === "grout" && (m.basis || "area") === "area" && !!m.grout;
+  materialKind(m) === "grout" && GROUT_BASES.has(m.basis || "area") && !!m.grout;
 export const showsGroutDeriveAffordance = (m) =>
-  materialKind(m) === "grout" && (m.basis || "area") === "area" && !m.grout;
+  materialKind(m) === "grout" && GROUT_BASES.has(m.basis || "area") && !m.grout;
 
 // Inches → drawing-style fraction (0.375 → "3/8", 1.25 → "1 1/4"); falls back
 // to the decimal when the value isn't on the 1/32″ grid.
@@ -76,6 +118,50 @@ export function inFrac(v) {
   return whole ? `${whole} ${rem}/${d}` : `${rem}/${d}`;
 }
 export const groutNote = (g) => `${g.tileL}×${g.tileW}×${inFrac(g.tileT)}″ @ ${inFrac(g.joint)}″ · ${g.bagLbs} lb`;
+// A base line's note names the two dimensions for what they ARE — height and piece
+// width — because "6×24" alone reads as a tile and hides the derivation the estimator
+// is being asked to confirm.
+export const baseGroutNote = (g) =>
+  `${inFrac(g.tileL)}″H × ${inFrac(g.tileW)}″W pc × ${inFrac(g.tileT)}″ @ ${inFrac(g.joint)}″ · ${g.bagLbs} lb`;
+
+// Height (ft) → the tile-geometry object the formula takes for a base line. tileL is the
+// PIECE height and defaults to the base height (one course spanning it — the catalog-cove
+// and field-cut case), deriving rather than storing so it can't drift from the condition.
+//
+// It stays honoured when the estimator states something SHORTER, because multi-course base
+// breaks the single-course identity: a 6″ band of 2×2 mosaic is three courses with two
+// interior horizontal joints, and read as one 6″×2″ piece it understates the grout by a
+// third. At or above the base height (or unset) the base height wins.
+export const baseGroutParams = (grout, heightFt) => {
+  const hIn = Number(heightFt) > 0 ? Number(heightFt) * 12 : 0;
+  if (!hIn) return grout;
+  const pieceH = Number(grout?.tileL);
+  return pieceH > 0 && pieceH < hIn ? grout : { ...grout, tileL: hIn };
+};
+// Courses in the base — 1 unless a shorter piece is stated. Display only: a fractional
+// last course is a CUT (waste), never more grout.
+export const baseCourses = (grout, heightFt) => {
+  const hIn = Number(heightFt) > 0 ? Number(heightFt) * 12 : 0;
+  const pieceH = Number(grout?.tileL);
+  return hIn && pieceH > 0 && pieceH < hIn ? hIn / pieceH : 1;
+};
+
+// A base grout line's rate depends on FOUR inputs, and only three of them live on the
+// row: the geometry (row), the bag (row), the joint (row) — and the base HEIGHT, which
+// lives on the condition. So unlike a field-tile line, this one can go stale without
+// anything on it changing. The case: a library entry derived at a 6″ base attached to a
+// 4″ base condition — per/note/grout all match the entry, nothing ambers, and a rate
+// figured for a taller base rides a shorter one. This is the same "a row must never
+// contradict its own calculator" invariant materials.js states for the per/note/grout
+// trio, extended to the input that isn't on the row. Area lines can't go stale this way
+// and always report false. `true` = show it and let the estimator re-derive; never
+// auto-correct, because silently rewriting a rate he typed is the other failure.
+export function groutRateStale(m, heightFt) {
+  if (!isLinearGrout(m) || materialKind(m) !== "grout" || !m?.grout) return false;
+  const d = groutDerivedFields(m.grout, "linear", heightFt);
+  if (!d) return Number(m.per) > 0;   // not figurable at all, yet the line carries a rate
+  return (Number(m.per) || 0) !== d.per;
+}
 
 // The { per, note } patch a grout-geometry edit derives, or null when the
 // geometry is incomplete/invalid (a cleared input mid-edit, a zero, NaN) —
@@ -83,10 +169,20 @@ export const groutNote = (g) => `${g.tileL}×${g.tileW}×${inFrac(g.tileT)}″ @
 // that silently zeroes the line's quantity in the buy list and every export.
 // Small rates keep two decimals so mosaic-scale coverages (e.g. 2.49 SF/bag)
 // don't round away up to ~20% of the order — and never floor to 0.
-export function groutDerivedFields(grout) {
-  const rate = groutCoverageSfPerBag(grout);
-  if (!Number.isFinite(rate) || rate <= 0) return null;
+// On a LINEAR (tile base) line the rate is lf/bag and needs the condition's height —
+// omit it, or pass 0, and this returns null, which is the same "keep the last good
+// per + note" contract as any other incomplete geometry. That is deliberate: a base
+// line whose condition has no height is NOT figurable, and writing the raw sf/bag onto
+// an LF-measured line is the exact bug this conversion exists to prevent.
+export function groutDerivedFields(grout, basis = "area", heightFt = 0) {
+  const linear = (basis || "area") === "linear";
+  const h = Number(heightFt) || 0;
+  if (linear && !(h > 0)) return null;
+  const g = linear ? baseGroutParams(grout, h) : grout;
+  const sf = groutCoverageSfPerBag(g);
+  if (!Number.isFinite(sf) || sf <= 0) return null;
+  const rate = linear ? sf / h : sf;
   const per = rate >= 10 ? Math.round(rate) : Math.round(rate * 100) / 100;
   if (!(per > 0)) return null;
-  return { per, note: groutNote(grout) };
+  return { per, note: linear ? baseGroutNote(g) : groutNote(g) };
 }

--- a/web/test/coverage.test.ts
+++ b/web/test/coverage.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 // coverage.js is plain JS (allowJs); the tsx loader resolves it from the .ts test.
-import { materialKind, MATERIAL_PRESETS, GROUT_DEFAULTS, GROUT_PARAM_KEYS, groutCoverageSfPerBag, groutDerivedFields, groutParamsEqual, groutNote, inFrac, showsGroutCalc, showsGroutDeriveAffordance } from "../src/lib/coverage.js";
+import { materialKind, MATERIAL_PRESETS, GROUT_DEFAULTS, GROUT_PARAM_KEYS, groutCoverageSfPerBag, groutDerivedFields, groutParamsEqual, groutNote, inFrac, showsGroutCalc, showsGroutDeriveAffordance, baseGroutParams, baseGroutNote, isLinearGrout, groutRateStale, baseCourses } from "../src/lib/coverage.js";
 
 const within = (actual: number, expected: number, tolPct: number) =>
   Math.abs(actual - expected) <= expected * (tolPct / 100);
@@ -137,13 +137,57 @@ test("groutParamsEqual: a present-but-junk param compares as the BLANK the edito
 
 // ── the calculator's render gate (round-2 Defect A) ─────────────────────────
 
-test("showsGroutCalc: only a grout-kind, area-basis line WITH geometry renders the calculator", () => {
+test("showsGroutCalc: a grout-kind area OR linear line WITH geometry renders the calculator", () => {
   const withG = { name: "Grout", kind: "grout", basis: "area", grout: { ...GROUT_DEFAULTS } };
   assert.equal(showsGroutCalc(withG), true);
   assert.equal(showsGroutCalc({ ...withG, grout: undefined }), false);       // geometry-less: never a defaults-backfilled calculator
-  assert.equal(showsGroutCalc({ ...withG, basis: "linear" }), false);
+  // linear = tile base. It used to be refused, which left base grout on a hand-typed
+  // rate with no way to derive it — the one line whose rate nobody can eyeball.
+  assert.equal(showsGroutCalc({ ...withG, basis: "linear" }), true);
+  assert.equal(showsGroutCalc({ ...withG, basis: "linear", grout: undefined }), false);
+  assert.equal(showsGroutCalc({ ...withG, basis: "count" }), false);         // an EA line has no face to grout
+  assert.equal(showsGroutCalc({ ...withG, basis: "seam_lf" }), false);
   assert.equal(showsGroutCalc({ name: "Adhesive", basis: "area", grout: { ...GROUT_DEFAULTS } }), false);   // not grout-kind
   assert.equal(showsGroutCalc({ name: "Grout", basis: "area", grout: { ...GROUT_DEFAULTS } }), true);       // name-classified counts too
+});
+
+// ── tile base: the field formula, fed the base piece, divided by face SF per LF ──
+
+test("groutDerivedFields: a linear line derives LF/bag from the CONDITION's height", () => {
+  // 6″ base, 6″-wide pieces, 3/8″ thick, 1/8″ joint, 25 lb. The piece IS the tile:
+  // 6×6 → 192 sf/bag, and a 6″ base is 0.5 SF of face per LF → 384 lf/bag.
+  const g = { ...GROUT_DEFAULTS, tileW: 6, tileT: 0.375, joint: 0.125, bagLbs: 25 };
+  const d = groutDerivedFields(g, "linear", 0.5);
+  assert.equal(d!.per, 384);
+  assert.equal(d!.note, '6″H × 6″W pc × 3/8″ @ 1/8″ · 25 lb');
+  // the same geometry read as FIELD tile is a different (and wrong-for-base) number
+  assert.notEqual(groutDerivedFields(g, "area", 0.5)!.per, d!.per);
+});
+
+test("groutDerivedFields: piece WIDTH is the parent dimension, and getting it wrong moves the buy", () => {
+  // 6″ base ripped from a 12×24: the piece is 6H × 24W. Read 12 there — the parent's
+  // OTHER dimension — and coverage falls 615 → 512, a 20% over-order. Against a 6×6
+  // catalog cove it is 60%. Width is not a detail on this line, it is the line.
+  const at = (w: number) => groutDerivedFields({ ...GROUT_DEFAULTS, tileW: w, tileT: 0.375, joint: 0.125, bagLbs: 25 }, "linear", 0.5)!.per;
+  assert.equal(at(24), 615);   // 6H × 24W — field-cut from a 12×24, ripped across the 12
+  assert.equal(at(12), 512);   // the same tile read the wrong way round
+  assert.equal(at(6), 384);    // a 6×6 catalog cove piece
+});
+
+test("groutDerivedFields: a linear line with no condition height is NOT figurable", () => {
+  const g = { ...GROUT_DEFAULTS, tileW: 6 };
+  assert.equal(groutDerivedFields(g, "linear", 0), null);
+  assert.equal(groutDerivedFields(g, "linear"), null);
+  assert.equal(groutDerivedFields(g, "linear", -1), null);
+  // ...and null is the "keep the last good per + note" contract — never a rate of 0
+  assert.notEqual(groutDerivedFields(g, "area"), null);
+});
+
+test("baseGroutParams: the piece's long dimension is derived from height, never stored", () => {
+  const g = { ...GROUT_DEFAULTS, tileL: 99, tileW: 6 };
+  assert.equal(baseGroutParams(g, 0.5).tileL, 6);      // 0.5 ft → 6″, overriding whatever tileL held
+  assert.equal(baseGroutParams(g, 0).tileL, 99);       // no height → untouched (and derive returns null)
+  assert.equal(baseGroutParams(g, 0.5).tileW, 6);      // width is the estimator's, never derived
 });
 
 test("showsGroutDeriveAffordance: the explicit opt-in appears exactly when the calculator is withheld for missing geometry", () => {
@@ -164,4 +208,76 @@ test("inFrac/groutNote: drawing-style fractions, decimal fallback off the 1/32�
   assert.equal(inFrac(0.03125), "1/32");
   assert.equal(inFrac(0.33), "0.33");
   assert.equal(groutNote({ tileL: 2, tileW: 2, tileT: 0.25, joint: 0.0625, bagLbs: 25 }), "2×2×1/4″ @ 1/16″ · 25 lb");
+});
+
+// ── the stale-rate guard: a base line's fourth input lives off the row ────────
+
+test("groutRateStale: a rate derived at one base height is flagged on another", () => {
+  const g = { ...GROUT_DEFAULTS, tileW: 6, tileT: 0.375, joint: 0.125, bagLbs: 25 };
+  const at6 = groutDerivedFields(g, "linear", 0.5)!;          // 6" base → 384 lf/bag
+  const line = { name: "Grout", kind: "grout", basis: "linear", grout: g, per: at6.per };
+  assert.equal(groutRateStale(line, 0.5), false, "derived for this height — clean");
+  assert.equal(groutRateStale(line, 0.3333), true, "a 4\" base does not get a 6\"-base rate");
+  // no height at all: not figurable, yet the line carries a rate → flag it
+  assert.equal(groutRateStale(line, 0), true);
+  assert.equal(groutRateStale({ ...line, per: 0 }, 0), false, "no rate to contradict");
+});
+
+test("groutRateStale: area lines and non-grout lines can never go stale this way", () => {
+  const g = { ...GROUT_DEFAULTS };
+  assert.equal(groutRateStale({ name: "Grout", kind: "grout", basis: "area", grout: g, per: 512 }, 0), false);
+  assert.equal(groutRateStale({ name: "Mortar", kind: "mortar", basis: "linear", grout: g, per: 99 }, 0.5), false);
+  assert.equal(groutRateStale({ name: "Grout", kind: "grout", basis: "linear", per: 99 }, 0.5), false, "no geometry, nothing to contradict");
+});
+
+// ── multi-course base: where the single-course identity stops holding ─────────
+
+test("baseGroutParams: a SHORTER stated piece is honoured; at-or-above the base height derives", () => {
+  const g = (tileL?: number) => ({ ...GROUT_DEFAULTS, tileW: 2, ...(tileL != null ? { tileL } : {}) });
+  assert.equal(baseGroutParams(g(2), 0.5).tileL, 2);      // 2" chip in a 6" band → multi-course
+  assert.equal(baseGroutParams(g(6), 0.5).tileL, 6);      // exactly the base height → one course
+  assert.equal(baseGroutParams(g(99), 0.5).tileL, 6);     // taller than the base → one course
+  assert.equal(baseGroutParams(g(), 0.5).tileL, 6);       // unset → derived
+});
+
+test("groutDerivedFields: a 6\" band of 2×2 mosaic is three courses, not one 6×2 piece", () => {
+  const chip = { ...GROUT_DEFAULTS, tileW: 2, tileT: 0.25, joint: 0.25, bagLbs: 25 };
+  const asCourses = groutDerivedFields({ ...chip, tileL: 2 }, "linear", 0.5)!.per;
+  const asOnePiece = groutDerivedFields({ ...chip, tileL: 6 }, "linear", 0.5)!.per;
+  assert.ok(Math.abs(asCourses - 96) < 2, `three courses → ${asCourses}, expected ≈96`);
+  assert.ok(Math.abs(asOnePiece - 144) < 3, `one piece → ${asOnePiece}, expected ≈144`);
+  assert.ok(asCourses < asOnePiece, "missing the interior horizontal joints under-buys");
+});
+
+test("baseCourses: 1 unless a shorter piece is stated", () => {
+  assert.equal(baseCourses({ ...GROUT_DEFAULTS, tileL: 2 }, 0.5), 3);
+  assert.equal(baseCourses({ ...GROUT_DEFAULTS, tileL: 6 }, 0.5), 1);
+  assert.equal(baseCourses({ ...GROUT_DEFAULTS, tileL: 99 }, 0.5), 1);
+  assert.equal(baseCourses({ ...GROUT_DEFAULTS }, 0), 1, "no height → no course claim");
+});
+
+// ── stick goods: an edge/cap profile is bought by the stock LENGTH ────────────
+
+test("materialKind: edge/cap profiles classify as trim, and never eat an adhesive", () => {
+  assert.equal(materialKind({ name: "Top cap profile" }), "trim");
+  assert.equal(materialKind({ name: "Tile edge trim" }), "trim");
+  assert.equal(materialKind({ name: "Stair nosing" }), "trim");
+  assert.equal(materialKind({ name: "SCHIENE edge" }), "trim");
+  // adhesive is matched FIRST, so a trim-adhesive stays an adhesive
+  assert.equal(materialKind({ name: "Trim adhesive" }), "adhesive");
+  assert.equal(materialKind({ name: "Cove base adhesive" }), "adhesive");
+  // an explicit kind still wins
+  assert.equal(materialKind({ name: "Top cap profile", kind: "transition" }), "transition");
+});
+
+test("trim presets are LF-per-stick, with the metric stock lengths exact", () => {
+  const by = Object.fromEntries((MATERIAL_PRESETS as any).trim.map((p: any) => [p.label, p.per]));
+  // 2.5 m = 8.202 ft, not 8 — a stick short on every order is the failure this prevents
+  assert.ok(Math.abs(by["2.5 m stick (8′ 2-1/2″)"] - 2.5 / 0.3048) < 0.001);
+  assert.ok(Math.abs(by["3 m stick (9′ 10″)"] - 3 / 0.3048) < 0.001);
+  assert.ok(Math.abs(by["1.5 m stick (4′ 11″)"] - 1.5 / 0.3048) < 0.001);
+  // 500 LF of cap off 2.5 m sticks
+  assert.equal(Math.ceil(500 / by["2.5 m stick (8′ 2-1/2″)"]), 61);
+  // a grout line must NOT pick up the trim calculator
+  assert.equal(showsGroutCalc({ name: "Top cap profile", basis: "linear", grout: { ...GROUT_DEFAULTS } }), false);
 });


### PR DESCRIPTION
Tile base is measured in **LF** but grout is consumed per **SF** of the face being set, so `showsGroutCalc` required `basis === "area"` — withholding the calculator from exactly the line whose rate nobody can eyeball. A base grout line was stuck on a hand-typed number with no way to derive it.

### It needs no new formula
A single course grouted at the floor line has joint density `1/W + 1/H` per inch of face, which **is** `(H+W)/(H·W)` — the field-tile term for a tile of `H × W`. So the "tile" fed to the existing formula is the **base piece**, and face SF per LF is the base height in feet, so `sf/bag ÷ height_ft` gives `lf/bag`.

- **Piece height is read-only, from the condition** (`height_ft`). Two owners of one number drift, and a 6″ base whose block still says 4″ prices a joint that isn't there. It defaults the piece height and stays honoured when a *shorter* one is stated — multi-course base breaks the single-course identity (a 6″ band of 2×2 mosaic is three courses with two interior horizontal joints, understated by a third if read as one 6″×2″ piece).
- **Piece width is the input that bites.** For base cut from field tile it's the parent dimension *not* ripped: a 6″ base off a 12×24 is 6H × 24W → **615 lf/bag**; read as 6H × 12W it's 512, a 20% over-order.
- A linear line with **no condition height is not figurable** and returns `null` — the same "keep the last good `per` + `note`" contract as any other incomplete geometry. Never an SF rate written onto an LF-measured line.
- **New `groutRateStale`.** This line's rate depends on four inputs and only three live on the row, so it can go stale with nothing on it changing — a library entry derived at a 6″ base, attached to a 4″ one, matched on every field and ambered nowhere. It flags and offers a re-derive; it never auto-corrects.

### Also: `trim` is stick goods
New `trim` material kind (matched *after* adhesive so a "trim adhesive" stays an adhesive) and an LF-per-stick preset family. The coverage that divides a linear measure is the stock length, and the metric lengths are the ones you can't type from memory: **2.5 m is 8.202 LF, not 8** — a stick short on every order.

### Gates
`npm run check` exits 0 — typecheck, lint, **1363** tests, bench, build. Node v24.

Verified in the running app, not just in tests: a linear-basis grout line now shows `derive from base geometry…`, and deriving it reads `6″H × 24″W pc × 3/8″ @ 1/8″ · 25 lb → 615`.