### PR TITLE
chore: vendor-neutral language throughout the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,4 +13,4 @@ What you're estimating and where the current tools fall short. Real workflow bea
 What it should do, ideally down to the click-by-click.
 
 **What you use today**
-If another tool does this (STACK, PlanSwift, Bluebeam, …), say which and what you'd keep or change — we build our own take, not copies.
+If another tool does this, describe the behavior and what you'd keep or change — describe what it does, not the brand; we build our own take, not copies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -708,7 +708,7 @@ The engine work RFC #60 asked for, built and staged for upstream by **Kevin Murp
 - User guide: new "Angle lock (45°/90°)" section + ⇧ shortcut row.
 
 ## 2026-06-28
-- **Crisp detail-view canvas** — past ~1.15× zoom the visible region re-renders straight from the PDF vectors at the current zoom (Bluebeam/AutoCAD-style), so deep zoom never pixelates.
+- **Crisp detail-view canvas** — past ~1.15× zoom the visible region re-renders straight from the PDF vectors at the current zoom (the way desktop CAD viewers do), so deep zoom never pixelates.
 
 ## 2026-06-23
 - **Bundled sample plan** — a real (public, architect-sealed) medical-center floor finish plan with one-click **Load sample plan**; social card + README hero.

--- a/docs/ESTIMATING_ROADMAP.md
+++ b/docs/ESTIMATING_ROADMAP.md
@@ -67,7 +67,7 @@ A new browser-global asset mirroring templates/materials/stamps:
 
 ## Phase 4 — estimate worksheet plus proposal PDF
 
-**Worksheet (StackCT-style, editable).** Extend `ReportPanel.jsx` (or a new
+**Worksheet (spreadsheet-style, editable).** Extend `ReportPanel.jsx` (or a new
 `EstimatePanel.jsx`) into a worksheet: each condition row expands to its item
 lines with **Qty | Unit | Material Unit $ | Material Ext $ | Labor Unit $ | Labor
 Ext $ | Line Total**, editable qty/unit-cost/waste/markup, live condition

--- a/web/bench/corpus.ts
+++ b/web/bench/corpus.ts
@@ -329,7 +329,7 @@ export function syntheticCorpus(): SyntheticCase[] {
 
   {
     // Same-pen demising wall on a SHARED tile module (flattened exports draw
-    // everything hairline; AutoCAD's global hatch origin makes adjacent
+    // everything hairline; the CAD tool's global hatch origin makes adjacent
     // same-pattern fills share the lattice). The wall sits in a perfect
     // lattice of its own pen → soft → rooms merge. Pre-existing exposure
     // (the old classifier's protects were width-based too); KNOWN-FAIL

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Free, open-source (Apache-2.0) construction takeoff engine that a person and an AI agent drive the same way. Open a plan (PDF, image, or .zip plan set), set the scale, trace areas — with one-click room detection and a 45°/90° angle lock — then apply waste % and per-condition supporting materials, and export quantities (SF/SY/LF/EA) as CSV/JSON. A person clicks the canvas; an agent calls the identical engine over MCP (`npx opentakeoff-mcp`) and gets the identical number, with the scale and origin of every measurement recorded. Built for flooring; the measuring engine works for any trade (drywall, paint, concrete, sitework). No account, no upload — plans never leave the machine.
 
-OpenTakeoff is the open-source alternative to subscription takeoff tools (STACK, PlanSwift, Kreo, Togal, Bluebeam quantity takeoff) — and the first of them an AI agent can drive natively, not through screen scraping or a bolted-on chat layer. It is a static web app: self-hosting is one `npm run build` and any static file host.
+OpenTakeoff is an open-source alternative to subscription takeoff software — and the first takeoff engine an AI agent can drive natively, not through screen scraping or a bolted-on chat layer. It is a static web app: self-hosting is one `npm run build` and any static file host.
 
 ## Docs
 

--- a/web/src/lib/canvasConstants.js
+++ b/web/src/lib/canvasConstants.js
@@ -24,7 +24,7 @@ export const MAX_CANVAS_AREA = 16384 * 16384 * 0.9;  // per-canvas pixel cap —
 export const MAX_PANEL_AREA  = 28e6;                 // base-raster pixel budget per panel (~112MB RGBA; 4-up ≈ 450MB)
 // Detail view: once zoomed past the base raster's 1:1 IN DEVICE PIXELS, we overlay a
 // crop of JUST the visible region, re-rendered from the PDF vectors at the current zoom —
-// Bluebeam/AutoCAD-style. Crispness becomes unbounded (up to the per-region canvas cap)
+// the way desktop CAD viewers do. Crispness becomes unbounded (up to the per-region canvas cap)
 // without ever holding a giant full-sheet bitmap; the region is ~viewport-sized so the cap
 // effectively never binds. Engage compares t.scale × devicePixelRatio (softness starts
 // when the raster is upscaled in device px — on a 2× display that's t.scale 0.5, not 1).

--- a/web/src/lib/layers.ts
+++ b/web/src/lib/layers.ts
@@ -60,7 +60,7 @@ const BOUNDARY = new Set([
 const DISCIPLINES = new Set(["A", "S", "M", "E", "P", "F", "C", "L", "T", "I", "Q", "G", "H", "V", "W", "X", "Z"]);
 
 /** Normalize a raw layer name to comparable tokens: strip the xref path
- * (everything before the LAST `|`), fold AutoCAD bind separators (`$n$`),
+ * (everything before the LAST `|`), fold CAD xref bind separators (`$n$`),
  * uppercase, split on every non-alphanumeric run. */
 export function layerNameTokens(raw: string): string[] {
   const base = String(raw || "").split("|").pop() || "";

--- a/web/src/lib/stamps.js
+++ b/web/src/lib/stamps.js
@@ -2,7 +2,7 @@
 //
 // A stamp is a reusable annotation — a named group of markup-like primitives
 // with local coordinates — that drops onto any sheet with a click (the
-// tool-chest pattern estimators know from Bluebeam). Unlike conditions and
+// tool-chest pattern estimators know from desktop markup tools). Unlike conditions and
 // markups (per-project), the stamp library is the app's FIRST cross-project
 // asset: it lives under its own key in the keyPath-less meta store, shared
 // across every project in the browser (the condition-template / material-

--- a/web/src/lib/totals.js
+++ b/web/src/lib/totals.js
@@ -297,7 +297,7 @@ export function roundSheetRow(r) {
   };
 }
 
-// Kreo-style derived metric: vertical wall SF = floor-area perimeters × the
+// Derived metric: vertical wall SF = floor-area perimeters × the
 // condition's height. Display-only (never in condition rows or the CSV): a
 // floor perimeter includes door openings and shared walls, so this is a
 // read-it-yourself ceiling estimate, not an order quantity.

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -5647,7 +5647,7 @@ export default function TakeoffCanvas() {
     setConditions((cs) => splitFromFamily(cs, id));
     setCommitMsg(`${c.finish_tag} no longer follows ${par?.finish_tag || "its family"}.`);
   };
-  // Height/Thickness are LIVE parameters (Kreo-style): changing them re-flows
+  // Height/Thickness are LIVE parameters: changing them re-flows
   // every dependent shape on this condition — wall SF tracks the tile height.
   const setCondParam = (field, raw) => {
     const v = raw === "" ? null : Math.max(0, parseFloat(raw) || 0);
@@ -5782,7 +5782,7 @@ export default function TakeoffCanvas() {
   const countTotal = condRow?.ea || 0;
   const wallTotal = condRow?.wall_sf || 0;
   const borderTotal = condRow?.border_sf || 0;
-  // display-only Kreo-style derived metric: floor-area perimeters × the condition height
+  // display-only derived metric: floor-area perimeters × the condition height
   const condH = Number(aCond?.height_ft) || 0; // the live-readout JSX below still reads this
   const vertTotal = verticalWallSf(visibleShapes, activeCond, aCond?.height_ft, condMult);
   const num = (v, d = 1) => v.toLocaleString(undefined, { maximumFractionDigits: d });

--- a/web/test/layerIoU.test.ts
+++ b/web/test/layerIoU.test.ts
@@ -8,7 +8,7 @@
 //
 // Fixtures are synthetic op-list scenes (the layerExtract fake-OPS idiom;
 // mcp/scripts/make-layered-fixture.mjs is the on-disk precedent): each states
-// its layers the way a Revit/AutoCAD export does and carries the truth
+// its layers the way a CAD/BIM export does and carries the truth
 // rectangle for every labeled room. The eval loop is the REAL room-detection
 // path — roomLabelSeeds → detectRegions over the built mask — so a lift here
 // is a lift in detect_rooms, not in a bespoke harness. A room the detector

--- a/web/test/layers.test.ts
+++ b/web/test/layers.test.ts
@@ -36,7 +36,7 @@ test("the precedence that prevents confident wrong numbers: DEMO and PATT beat W
 
 test("field variants: xref prefixes, bind separators, spaces, truncation, bare words", () => {
   assert.equal(role("ARCH-FLOOR|A-WALL-FULL"), "boundary", "xref path strips to the last pipe");
-  assert.equal(role("XREF$0$A-WALL-FULL"), "boundary", "AutoCAD bind separator folds");
+  assert.equal(role("XREF$0$A-WALL-FULL"), "boundary", "CAD xref bind separator folds");
   assert.equal(role("A-WALL FULL HT"), "boundary", "spaces tokenize like dashes");
   assert.equal(role("A-WALL-1"), "boundary", "renumbered variant");
   assert.equal(role("WALL"), "boundary", "bare word still identifies…");


### PR DESCRIPTION
Named competitors and CAD vendors were doing work in this repo that plain language does better — positioning (*"the open-source alternative to X, Y, Z"*), describing our own features (*"Kreo-style derived metric"*, *"StackCT-style worksheet"*), and stating file-format facts (*"AutoCAD bind separators"*). This replaces every one of them with a description of the thing itself.

**Positioning and contributor-facing**
- `web/public/llms.txt` — drops the competitor list. The claim that carries the file (first takeoff engine an AI agent drives natively, not through screen scraping) stands without it.
- `.github/ISSUE_TEMPLATE/feature_request.md` — asks contributors to describe the behavior they want rather than name the tool they saw it in.

**Our own features, described as themselves**
- `docs/ESTIMATING_ROADMAP.md` — worksheet is "spreadsheet-style".
- `web/src/lib/totals.js`, `web/src/pages/TakeoffCanvas.jsx` — vertical wall SF is a derived metric, full stop.
- `web/src/lib/stamps.js` — the tool-chest pattern estimators know from desktop markup tools.
- `web/src/lib/canvasConstants.js`, `CHANGELOG.md` — detail-view re-render is "the way desktop CAD viewers do".

**Format facts, still accurate without the vendor**
- `web/src/lib/layers.ts`, `web/test/layers.test.ts` — "CAD xref bind separators (`$n$`)". The `XREF$0$` convention is what the regex folds; naming the convention is the useful half.
- `web/bench/corpus.ts` — "the CAD tool's global hatch origin".
- `web/test/layerIoU.test.ts` — "the way a CAD/BIM export does".

Comments, docs, and one test-assertion string. No behavior change; `npm run check` green end to end (typecheck, lint, tests, bench, build).

A `git grep` for the full vendor list across the tree now returns nothing.