### PR TITLE
A curve is a circle through three clicks, not a spline through a dozen

### DIFF
--- a/docs/CONTRIBUTION_SPEC.md
+++ b/docs/CONTRIBUTION_SPEC.md
@@ -88,7 +88,7 @@ No scale *value* ever appears—a sheet's `units_per_px` stays local.
 | `sheet` | string | required | positional sheet token |
 | `verts_norm` | number[][] | required | final geometry, normalized 0..1 |
 | `computed` | object | required | the quantities the expert accepted (SF / LF / EA) |
-| `curved` | boolean | when true | curved linear run: `verts_norm` are spline control points (centripetal Catmull-Rom), not a polyline—consumers must flatten before treating them as drawn geometry |
+| `curved` | boolean | when true | the run was traced with curves. LEGACY form (pre-arc): `verts_norm` are spline control points (centripetal Catmull-Rom), not a polyline—consumers must flatten before treating them as drawn geometry. Anything traced with the ⌒ Curve switch since the 3-point arc landed is already flattened, and `verts_norm` is a plain polyline |
 | `height_ft` | number | when set | wall height override |
 | `id` | string | when present | opaque durable UUID (see §2) |
 | `created_at` | string | when present | ISO-8601 UTC creation stamp; legacy shapes predate stamping and omit it |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -373,13 +373,15 @@ Click vertex by vertex around the space; `⏎`, double-click, or the **Finish** 
 
 **Curved boundaries.** Buildings are not all right angles: a bowed wall, a radius corner, a curved curb or pool edge. You don't leave the tool for them—the readout carries a **╱ Straight / ⌒ Curve** switch, and you flip it *mid measurement*, as often as you like inside one shape.
 
-- **Curve** mode: every click you place is a point the boundary **bends smoothly through** instead of turning a corner at. Curve points draw as round handles instead of stars, and the readout says how many are in play.
-- **`Q`** flips the switch once a trace is going. (With nothing traced yet, `Q` is still the Curved Line tool.)
-- **`⌥`-click** always places the *other* kind for exactly one point—one curve point without leaving Straight, or one hard corner without leaving Curve.
+- **Curve** mode: **an arc is three clicks, and it is a real circle.** The clicks alternate—the first lands anywhere **on the bow**, the second on its **far end**—and together with the vertex you were already on, those three points define exactly one circle. That is the whole difference: a radius wall *is* a circle, so the arc **sits on it** instead of near it. The bow point draws as a round handle, and the arc redraws live as you aim the far end.
+- **`Q`** flips the switch once a trace is going.
+- **`⌥`-click** always places the *other* kind for exactly one point—one bow point without leaving Straight, or one hard corner without leaving Curve.
 
-So a bowed room is: click the straight walls, flip to Curve, click along the bow, flip back, close it. Click a few points along the curve rather than one—the boundary passes through exactly the points you gave it, so more points on a tight arc is a truer arc.
+The live chip reads the length **along the arc**, not across it, and sweeps past half a circle are fine: put the bow where the wall actually goes and the arc follows it round. `⏎` waits until the far end is placed—a bow on its own is half a gesture.
 
-The same switch works on **Line**, **Cut Out**, and **Surface Area**: a curved feature strip, a bowed deduct, a radius wall. On `⏎` the shape commits as **one ordinary geometry**—the curve is flattened into the ring or the run, so SF, LF, Cut Out, the marked set, and every export treat it as the polygon or polyline it now is, and its `origin` records that it was traced with curves. (The dedicated **Curved Line** (`Q`) tool is the other case: an all-curve line whose control points stay draggable afterward.)
+So a bowed room is: click the straight walls, flip to Curve, click the bow and the far end, flip back, close it.
+
+The same switch works on **Line**, **Cut Out**, and **Surface Area**: a curved feature strip, a bowed deduct, a radius wall. On `⏎` the shape commits as **one ordinary geometry**—the arc is flattened into the ring or the run, passing exactly through the point you clicked, so SF, LF, Cut Out, the marked set, and every export treat it as the polygon or polyline it now is, and its `origin` records that it was traced with curves.
 
 ### Rectangle (`R`)
 
@@ -388,10 +390,6 @@ Two clicks: one corner, then the opposite corner. Between them the cursor chip r
 ### Linear (`L`)
 
 An open run, two or more points → LF. The **╱ Straight / ⌒ Curve** switch works here too (see Area, above)—a run that bends partway along commits as one line. If the condition carries a **thickness**, the run also yields border SF (LF × thickness ÷ 12)—feature strips, borders, transitions. The live chip reads the running segment length, amber at 12′.
-
-### Curved Line (`Q`)
-
-Like Linear, but the line bends smoothly through your clicks—radius walls, curved transitions, winding corridors. Click a few points along the curve, **⏎** or double-click finishes; drag any point later and the curve re-smooths through it. LF comes from the true curved length (a spline through your points, not the chords between them), and a condition **thickness** yields border SF the same way Linear's does.
 
 ### Surface Area (`S`)
 
@@ -853,7 +851,6 @@ Every shortcut in the app, verified against the code. Letter keys are suppressed
 | `A` | Area |
 | `R` | Rectangle |
 | `L` | Linear |
-| `Q` | Curved Line |
 | `S` | Surface Area (walls) |
 | `C` | Count |
 | `D` | Deduct shape (Cut Out) |
@@ -884,8 +881,8 @@ Every shortcut in the app, verified against the code. Letter keys are suppressed
 | `⇧⌘Z` | Redo |
 | `Esc` | Back out one level: clear the vertex pick first, then everything in progress (trace, proposal, calibration, check, selection, markup draft, armed stamp, zone) |
 | Hold `⇧` | Force the 45° angle lock at any cursor angle |
-| `Q` mid-trace | Flip the ╱ Straight / ⌒ Curve switch (Area, Cut Out, Line, Surface) |
-| `⌥`-click (Area / Cut Out / Line / Surface) | Place the *other* kind of point for one click—a curve point in Straight mode, a corner in Curve mode |
+| `Q` | Flip the ╱ Straight / ⌒ Curve switch mid-trace (Area, Cut Out, Line, Surface) |
+| `⌥`-click (Area / Cut Out / Line / Surface) | Place the *other* kind of point for one click—a bow point in Straight mode, a corner in Curve mode |
 | `⌥`-click (One-Click) | Carve a cutout inside a selected space |
 | `⇧`-click an edge | Insert a vertex at the edge midpoint (selected shape or One-Click proposal) and drag it |
 

--- a/web/src/components/UserGuide.jsx
+++ b/web/src/components/UserGuide.jsx
@@ -67,7 +67,7 @@ const START = [
 
 export const TOOLS = [
   [["O"], "One-Click Area — click inside a room, it selects itself"],
-  [["A"], "Area"], [["R"], "Rectangle"], [["L"], "Linear"], [["Q"], "Curved Line"],
+  [["A"], "Area"], [["R"], "Rectangle"], [["L"], "Linear"], [["Q"], "Straight ⇄ Curve (mid-trace)"],
   [["S"], "Surface Area (walls)"], [["C"], "Count"],
   [["D"], "Deduct shape (Cut Out)"], [["⇧", "D"], "Deduct rectangle"],
   [["H"], "Highlighter"], [["K"], "Check a dimension against what the drawing says"],

--- a/web/src/lib/arc.js
+++ b/web/src/lib/arc.js
@@ -1,0 +1,158 @@
+// Three-point circular arc — the curve an estimator actually needs.
+//
+// A radius wall on a plan IS a circle: the architect drew it with a center and
+// a radius, so the only curve that can sit ON it is a circular arc. Two clicks
+// fix nothing (infinitely many circles pass through two points) and four or
+// more over-determine it, so the gesture is exactly three: the arc's START is
+// the vertex you already placed, then you click a point ON the bow, then the
+// END — and the arc through those three is unique. Move the third and the arc
+// re-solves live, which is what makes it a TRACE instead of a guess: put the
+// middle click anywhere on the wall and the arc lands on the wall.
+//
+// This replaces splining a run of clicked points (Catmull-Rom, #284). A spline
+// interpolates its points and wanders between them — it is right AT the clicks
+// and wrong everywhere else, so tracing a bow meant chasing it with a dozen
+// knots and still missing. Three clicks, exact everywhere.
+//
+// Sheet px in = sheet px out, and the arc is a DRAWING gesture, not a new
+// geometry type: everything flattens at commit, so SF/LF, the eraser,
+// hit-testing, the report and every export keep seeing plain polygons.
+
+const TAU = Math.PI * 2;
+const norm = (a) => ((a % TAU) + TAU) % TAU;
+
+/**
+ * The circle through three points, or null when there isn't one — collinear,
+ * coincident, or so nearly straight that the center runs off to infinity and
+ * the "arc" is a chord with rounding noise on it. Every caller falls back to
+ * the straight segment on null, which is the right answer for a flat bow.
+ *
+ * @returns {{cx:number, cy:number, r:number, a0:number, a1:number, am:number, sweep:number}|null}
+ *   sweep is SIGNED and carries the direction that passes through `m`:
+ *   positive = increasing angle (clockwise on screen, y-down), |sweep| < 2π.
+ */
+export function circleThrough(a, m, b) {
+  const [ax, ay] = a, [mx, my] = m, [bx, by] = b;
+  // 2× the signed area of the triangle — zero when the three are collinear
+  const d = 2 * (ax * (my - by) + mx * (by - ay) + bx * (ay - my));
+  if (!Number.isFinite(d) || Math.abs(d) < 1e-9) return null;
+  const a2 = ax * ax + ay * ay, m2 = mx * mx + my * my, b2 = bx * bx + by * by;
+  const cx = (a2 * (my - by) + m2 * (by - ay) + b2 * (ay - my)) / d;
+  const cy = (a2 * (bx - mx) + m2 * (ax - bx) + b2 * (mx - ax)) / d;
+  const r = Math.hypot(ax - cx, ay - cy);
+  // A center this far out is a straight line wearing a circle's clothes; the
+  // flattened arc would be indistinguishable from the chord anyway.
+  if (!Number.isFinite(r) || r > 1e7) return null;
+  const a0 = Math.atan2(ay - cy, ax - cx);
+  const a1 = Math.atan2(by - cy, bx - cx);
+  const am = Math.atan2(my - cy, mx - cx);
+  // Which way round: take the direction whose path from a to b crosses m.
+  const fwd = norm(a1 - a0);            // increasing-angle sweep a → b
+  const fwdM = norm(am - a0);           // …and where m falls along it
+  const sweep = fwdM <= fwd ? fwd : fwd - TAU;
+  return { cx, cy, r, a0, a1, am, sweep };
+}
+
+// How many straight pieces the arc is worth. Scales with drawn length so a
+// tight fillet and a 40 ft radius wall both read smooth, under a hard cap so a
+// sweeping corridor can't mint a thousand-vertex shape (render-invariance
+// budget), and with a floor so a small arc never goes faceted.
+function stepsFor(r, sweep) {
+  const len = Math.abs(sweep) * r;
+  const bySpan = Math.abs(sweep) / (4 * Math.PI / 180);   // ≥ one piece per 4°
+  return Math.max(8, Math.min(96, Math.ceil(Math.max(len / 4, bySpan))));
+}
+
+/**
+ * a → (through m) → b, flattened to a polyline. Returns the INTERIOR points
+ * only — neither `a` nor `b` — so a boundary walk can push its own corners and
+ * never double one. Collinear input returns [] (the caller's straight segment
+ * from a to b is already the right geometry).
+ *
+ * `m` is emitted EXACTLY, and the budget is split either side of it. The bow
+ * point is a click, often a snapped one: it is a place on the wall the
+ * estimator chose, so the drawn boundary has to actually go through it rather
+ * than past it by half a step.
+ */
+export function flattenArc(a, m, b) {
+  const c = circleThrough(a, m, b);
+  if (!c) return [];
+  const total = stepsFor(c.r, c.sweep);
+  // where m falls along the sweep, in the sweep's own direction
+  const toM = c.sweep >= 0 ? norm(c.am - c.a0) : -norm(c.a0 - c.am);
+  const f = Math.abs(c.sweep) > 1e-12 ? Math.min(1, Math.abs(toM) / Math.abs(c.sweep)) : 0;
+  const n1 = Math.max(1, Math.min(total - 1, Math.round(total * f)));
+  const n2 = Math.max(1, total - n1);
+  const at = (t) => [c.cx + c.r * Math.cos(t), c.cy + c.r * Math.sin(t)];
+  const out = [];
+  for (let i = 1; i < n1; i++) out.push(at(c.a0 + toM * (i / n1)));
+  out.push([m[0], m[1]]);
+  for (let i = 1; i < n2; i++) out.push(at(c.am + (c.sweep - toM) * (i / n2)));
+  return out;
+}
+
+/** Drawn length of the arc a → m → b, in the units the points came in. */
+export function arcLength(a, m, b) {
+  const c = circleThrough(a, m, b);
+  return c ? Math.abs(c.sweep) * c.r : Math.hypot(b[0] - a[0], b[1] - a[1]);
+}
+
+/**
+ * SVG path data for the LIVE preview — one `A` command, so the bow you are
+ * dragging is a true conic at any zoom instead of the flattened stand-in the
+ * commit will store. Falls back to a straight `L` when there's no circle.
+ */
+export function arcPathD(a, m, b) {
+  const c = circleThrough(a, m, b);
+  if (!c) return `M ${a[0]} ${a[1]} L ${b[0]} ${b[1]}`;
+  const large = Math.abs(c.sweep) > Math.PI ? 1 : 0;
+  // angles come from atan2 in a y-down frame, so increasing angle IS SVG's
+  // positive sweep direction — no flip needed
+  const dir = c.sweep > 0 ? 1 : 0;
+  return `M ${a[0]} ${a[1]} A ${c.r} ${c.r} 0 ${large} ${dir} ${b[0]} ${b[1]}`;
+}
+
+/**
+ * Boundary points → the drawn polyline (sheet px in = sheet px out).
+ *
+ * `throughAt` marks the points that are the MIDDLE of an arc: index i marked
+ * means the boundary runs pts[i-1] → pts[i] → pts[i+1] as one circular arc
+ * instead of two straight segments. A marked point with no neighbour to lean
+ * on — first or last of an open trace, or sitting next to another mark — is
+ * demoted to a plain corner, so a half-placed arc still draws as something
+ * honest while the estimator is mid-gesture.
+ *
+ * @param {number[][]} pts        traced vertices
+ * @param {number[]|Set<number>} [throughAt] indices of arc MIDDLE points
+ * @param {boolean} [closed]      true for a committed ring (the last point
+ *                                wraps to the first), false for the
+ *                                in-progress trace
+ */
+export function flattenArcRing(pts, throughAt, closed = true) {
+  const src = pts || [];
+  const n = src.length;
+  const copy = () => src.map((p) => [p[0], p[1]]);
+  const marks = throughAt instanceof Set ? throughAt : new Set(throughAt || []);
+  if (n < 3 || !marks.size) return copy();
+
+  // A mark only counts where both neighbours exist and neither is itself a
+  // mark — resolved up front so the walk below never has to look two ways.
+  const live = new Array(n).fill(false);
+  for (let i = 0; i < n; i++) {
+    if (!marks.has(i)) continue;
+    const hasPrev = closed || i > 0;
+    const hasNext = closed || i < n - 1;
+    if (!hasPrev || !hasNext) continue;
+    const pi = (i - 1 + n) % n, ni = (i + 1) % n;
+    if (marks.has(pi) || marks.has(ni)) continue;   // adjacent marks: no clean triple
+    live[i] = true;
+  }
+
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    if (!live[i]) { out.push([src[i][0], src[i][1]]); continue; }
+    // the corner before was pushed on its own turn; the corner after will be
+    for (const p of flattenArc(src[(i - 1 + n) % n], src[i], src[(i + 1) % n])) out.push(p);
+  }
+  return out;
+}

--- a/web/src/lib/canvasConstants.js
+++ b/web/src/lib/canvasConstants.js
@@ -55,7 +55,6 @@ export const MEASURE_TOOLS = [
   { id: "area", icon: "area", label: "Area", shortcut: "A" },
   { id: "rect", icon: "rectTool", label: "Rectangle", shortcut: "R" },
   { id: "linear", icon: "linear", label: "Linear", shortcut: "L" },
-  { id: "curve", icon: "curve", label: "Curved Line", shortcut: "Q" },
   { id: "surface", icon: "surface", label: "Surface Area", shortcut: "S" },
   { id: "count", icon: "count", label: "Count", shortcut: "C" },
 ];

--- a/web/src/lib/curve.js
+++ b/web/src/lib/curve.js
@@ -1,10 +1,13 @@
-// Curved-line geometry — a centripetal Catmull-Rom spline through the estimator's
-// clicked control points, flattened to a dense polyline for length math, rendering,
-// and hit-testing. The SHAPE stores only the control points (few, draggable — drag
-// one and the curve re-smooths), while every consumer (totals, reflow, export)
-// sees the flattened polyline, so downstream math is exactly the linear
-// tool's. Centripetal parameterization (alpha 0.5) is the standard fix for the
-// cusps/loops uniform Catmull-Rom produces on unevenly spaced clicks.
+// Centripetal Catmull-Rom spline through clicked control points, flattened to a
+// dense polyline for length math, rendering and hit-testing. Centripetal
+// parameterization (alpha 0.5) is the standard fix for the cusps/loops uniform
+// Catmull-Rom produces on unevenly spaced clicks.
+//
+// LEGACY, and read-only: this is how `curved: true` shapes traced before the
+// 3-point arc landed are still drawn and measured, so their LF never moves
+// under them. Nothing new is traced as a spline — a curve an estimator draws
+// today is a circular arc through three clicks (`lib/arc.js`), because a spline
+// is exact only AT its clicks and a radius wall needs exact everywhere.
 
 function crPoint(p0, p1, p2, p3, t) {
   // Barry–Goldman pyramidal evaluation with centripetal knots.
@@ -41,95 +44,6 @@ export function flattenCurve(pts, opts = {}) {
   for (let i = 1; i < P.length - 2; i++) {
     const steps = Math.max(2, Math.round(want[i - 1] * scale));
     for (let j = 1; j <= steps; j++) out.push(crPoint(P[i - 1], P[i], P[i + 1], P[i + 2], j / steps));
-  }
-  return out;
-}
-
-// ── curved AREA boundaries (#284) ────────────────────────────────────────────
-// A footprint is rarely all-straight or all-curved: it is straight walls with
-// an arc in them. So a ring carries a set of CURVE vertices (shape.curve_at)
-// alongside its points, and a maximal run of them — together with the plain
-// anchor on each side — flattens through the same centripetal spline the
-// curved line tool uses. Everything outside a run stays a straight segment,
-// exactly as traced.
-//
-// The result is one closed polyline, which is the whole point: area,
-// perimeter, cutouts, hit-testing, the marked PDF and every export keep
-// treating it as a normal polygon. Nothing downstream learns a new geometry.
-
-/** Every vertex curved, ring closed: one periodic spline, no seam. Same
- * chord-proportional step budget as flattenCurve (smooth at any zoom, hard
- * total cap so a big ring can't mint a thousand-vertex shape). */
-export function flattenClosedCurve(pts, opts = {}) {
-  const n = (pts || []).length;
-  if (n < 3) return (pts || []).map((p) => [p[0], p[1]]);
-  const maxPts = opts.maxPts || 220;
-  const at = (i) => pts[((i % n) + n) % n];
-  const want = [];
-  let total = 0;
-  for (let i = 0; i < n; i++) {
-    const a = at(i), b = at(i + 1);
-    const steps = Math.max(6, Math.min(24, Math.round(Math.hypot(b[0] - a[0], b[1] - a[1]) / 6)));
-    want.push(steps); total += steps;
-  }
-  const scale = total > maxPts ? maxPts / total : 1;
-  const out = [];
-  for (let i = 0; i < n; i++) {
-    const steps = Math.max(2, Math.round(want[i] * scale));
-    out.push([at(i)[0], at(i)[1]]);
-    for (let j = 1; j < steps; j++) out.push(crPoint(at(i - 1), at(i), at(i + 1), at(i + 2), j / steps));
-  }
-  return out;
-}
-
-/**
- * Boundary points → the drawn polyline (sheet px in = sheet px out).
- *
- * @param {number[][]} pts        traced vertices
- * @param {number[]|Set<number>} [curveAt] indices of CURVE vertices
- * @param {boolean} [closed]      true for a committed ring, false for the
- *                                in-progress trace (no wrap: a run at either
- *                                end anchors on itself)
- */
-export function flattenRing(pts, curveAt, closed = true, opts = {}) {
-  const src = pts || [];
-  const n = src.length;
-  const marks = curveAt instanceof Set ? curveAt : new Set(curveAt || []);
-  const copy = () => src.map((p) => [p[0], p[1]]);
-  if (n < 3 || !marks.size) return copy();
-  const mark = new Array(n);
-  let curved = 0;
-  for (let i = 0; i < n; i++) { mark[i] = marks.has(i); if (mark[i]) curved++; }
-  if (!curved) return copy();
-  if (curved === n) return closed ? flattenClosedCurve(src, opts) : flattenCurve(src, opts);
-
-  // Rotate a closed ring so it starts on a plain anchor — then a run can never
-  // wrap past the end, and the walk below is the same for both modes. A ring's
-  // start vertex is arbitrary (area, perimeter and the drawn path are all
-  // invariant to it), so this costs nothing.
-  let P = src, M = mark;
-  if (closed) {
-    const s = mark.indexOf(false);
-    if (s > 0) { P = [...src.slice(s), ...src.slice(0, s)]; M = [...mark.slice(s), ...mark.slice(0, s)]; }
-  }
-  const out = [];
-  let i = 0;
-  while (i < n) {
-    if (!M[i]) { out.push([P[i][0], P[i][1]]); i++; continue; }
-    let j = i;
-    while (j < n && M[j]) j++;
-    // The span an anchor hands the curve is part of the curve: control points
-    // are anchor → run → anchor, so the boundary leaves and rejoins the
-    // straight work smoothly instead of kinking at the handover.
-    const havePrev = closed || i > 0;
-    const haveNext = closed || j < n;
-    const prev = havePrev ? P[(i - 1 + n) % n] : P[i];
-    const next = haveNext ? P[j % n] : P[j - 1];
-    const flat = flattenCurve([prev, ...P.slice(i, j), next], opts);
-    // drop an endpoint only when a real anchor owns it: prev was pushed on its
-    // own turn, next will be
-    for (let k = havePrev ? 1 : 0; k < (haveNext ? flat.length - 1 : flat.length); k++) out.push(flat[k]);
-    i = j;
   }
   return out;
 }

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -65,7 +65,8 @@ import { buildMarkedSetPdf, downloadBytes } from "../lib/markedset.js";
 import { loadProfiles } from "../lib/identity.js";
 import { resolveBranding, loadBrandingSelection } from "../lib/branding.js";
 import { starPath, cloudPath, thinStroke, strokePathD, chiselRibbon, buildSnapGrid, nearestSnap, ANGLE_TOL, angleSnap, closedMetrics, openLen, pointInPoly, hitShape, arrowheadPath, distToSeg, reflectVertsNorm } from "../lib/geometry.js";
-import { flattenCurve, flattenRing } from "../lib/curve.js";
+import { flattenCurve } from "../lib/curve.js";
+import { flattenArcRing, arcPathD, arcLength } from "../lib/arc.js";
 import { dashArrayFor, boostForDark, clampWeight, snapWeight, LINE_STYLES, LINE_STYLE_IDS, WEIGHT_STEPS } from "../lib/lineStyles.js";
 import { nextRfiNumber } from "../lib/rfi.js";
 import { libFields, matFieldOverridden, libPushPatch, libRevertPatch, libEntryPatch, matEditPatch } from "../lib/materials.js";
@@ -211,7 +212,7 @@ const PALETTE_MAX = 9;
 const TOOL_VERB = {
   select: "select", area: "measure_polygon", rect: "measure_polygon",
   deduct: "cut_out", "deduct-rect": "cut_out",
-  linear: "measure_line", curve: "measure_line", surface: "measure_surface",
+  linear: "measure_line", surface: "measure_surface",
   count: "place_count", oneclick: "one_click", calibrate: "set_scale",
   check: "check_dimension", zone: "zone_check", "stitch-align": "stitch_align",
   schedule: "find_schedule", highlighter: "annotate", cloud: "annotate",
@@ -385,15 +386,16 @@ export default function TakeoffCanvas() {
   const [palette, setPalette] = useState([]);   // ordered condition ids pinned to the top-bar quick-access palette (≤ PALETTE_MAX)
   const [shapes, setShapes] = useState([]);
   const [poly, setPoly] = useState([]);
-  // #284 — which of the in-progress trace's points are CURVE points (⌥-click).
-  // Parallel to poly and written ONLY through the three helpers below, so it
-  // can never drift out of step with the points it describes.
+  // #284 — which of the in-progress trace's points are arc BOW points. Parallel
+  // to poly and written ONLY through the three helpers below, so it can never
+  // drift out of step with the points it describes.
   const [polyCurve, setPolyCurve] = useState([]);
   // Sticky curve mode — the STACK-style straight/curve switch you flip mid
-  // measurement, so a long arc is a run of ordinary clicks instead of a held
-  // modifier. ⌥ still works, and it INVERTS whatever the mode is: ⌥-click in
-  // straight mode drops one curve point, ⌥-click in curve mode drops one
-  // corner. The mode is trace-local; it clears with the trace.
+  // measurement rather than a modifier you hold. In Curve the clicks ALTERNATE:
+  // one lands on the bow, the next on the far end, and the circular arc through
+  // the vertex you were already on, the bow and the end is unique — so it sits
+  // ON a radius wall instead of near it. ⌥ still works, and it INVERTS whatever
+  // the mode is. The mode is trace-local; it clears with the trace.
   const [curveMode, setCurveMode] = useState(false);
   const clearPoly = () => { setPoly([]); setPolyCurve([]); setCurveMode(false); };
   const dropLastPoint = () => { setPoly((q) => q.slice(0, -1)); setPolyCurve((q) => q.slice(0, -1)); };
@@ -401,6 +403,9 @@ export default function TakeoffCanvas() {
   // the drawn boundary of the in-progress trace: straight where it was clicked
   // straight, splined through every run of curve points
   const curveIdx = useMemo(() => polyCurve.reduce((a, c, i) => (c ? (a.push(i), a) : a), []), [polyCurve]);
+  // Mid-gesture: the last click was a bow point, so the NEXT click closes that
+  // arc rather than opening another. The live preview reads the same flag.
+  const bowOpen = polyCurve.length > 0 && polyCurve[polyCurve.length - 1] && poly.length >= 2;
   const [guideOpen, setGuideOpen] = useState(false);   // the in-app manual overlay (? / the toolbar button)
   const [proposal, setProposal] = useState(null);  // One-Click selection under review: { key, regions: [{kind:'pos'|'neg', seed, poly, area_sf, perim_lf}] } — panel-LOCAL px
   // ── in-canvas takeoff agent state ──────────────────────────────────────────
@@ -627,6 +632,7 @@ export default function TakeoffCanvas() {
   const crossVRef = useRef(null);
   const crossHRef = useRef(null);
   const rubberRef = useRef(null);
+  const arcRef = useRef(null);      // live 3-point arc preview (bow placed → cursor); the rubber band becomes its chord
   const rectRef = useRef(null);
   const cloudRef = useRef(null);       // live cloud preview (first corner → cursor)
   const highlightRef = useRef(null);   // live highlight-box preview (first corner → cursor; own translucent fill, NOT rectRef's condition fill)
@@ -2275,7 +2281,7 @@ export default function TakeoffCanvas() {
         // agent-proposal accept resumes the key the moment the offer clears
         if (agentOfferFnsRef.current?.pending()) { e.preventDefault(); agentOfferFnsRef.current.confirm(); return; }
         if (tool === "oneclick" && proposal?.regions.length) { e.preventDefault(); createProposal(); return; }
-        const ok = ((tool === "area" || tool === "deduct") && poly.length >= 3) || (tool === "zone" && poly.length >= 3 && !zoneTraceCross) || ((tool === "linear" || tool === "surface" || tool === "curve") && poly.length >= 2);
+        const ok = !bowOpen && (((tool === "area" || tool === "deduct") && poly.length >= 3) || (tool === "zone" && poly.length >= 3 && !zoneTraceCross) || ((tool === "linear" || tool === "surface") && poly.length >= 2));
         if (ok) { e.preventDefault(); finishShape(); return; }
         // ⏎ with agent proposals pending on a visible sheet = accept them all —
         // the agent's analogue of one-click's Create gate. Only fires when no
@@ -2294,7 +2300,7 @@ export default function TakeoffCanvas() {
       // would abandon the points already placed, so this binding can only be
       // an improvement on the one it shadows.
       if (lower === "q" && CURVABLE.has(tool) && poly.length) { setCurveMode((c) => !c); return; }
-      const map = { v: "select", a: "area", r: "rect", l: "linear", q: "curve", s: "surface", c: "count", d: "deduct", o: "oneclick", k: "check", h: "highlighter", n: "dimension" };
+      const map = { v: "select", a: "area", r: "rect", l: "linear", s: "surface", c: "count", d: "deduct", o: "oneclick", k: "check", h: "highlighter", n: "dimension" };
       const t = map[lower];
       if (t) setTool(t);
     };
@@ -2465,7 +2471,12 @@ export default function TakeoffCanvas() {
     // ⌥-click on an area/deduct trace drops a CURVE point (#284): the boundary
     // bends through it instead of turning a corner at it. Every other
     // point-placing tool takes the click as it always has.
-    else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "curve" || tool === "surface" || tool === "zone") addPoint(p, CURVABLE.has(tool) && (curveMode !== !!(ev && ev.altKey)));
+    else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "surface" || tool === "zone") {
+      // Curve alternates bow → end → bow → end. A bow needs a vertex behind it
+      // to arc away from, so the first point of a trace is always a corner.
+      const wantCurve = CURVABLE.has(tool) && (curveMode !== !!(ev && ev.altKey));
+      addPoint(p, wantCurve && poly.length > 0 && !bowOpen);
+    }
     else if (tool === "count") commitCount(p);
     else if (tool === "rect" || tool === "deduct-rect") {
       if (poly.length === 0) addPoint(p, false);
@@ -2757,7 +2768,7 @@ export default function TakeoffCanvas() {
     }
 
     // rubber-band preview: last point → cur (area/deduct/zone); rect preview: corner → cur
-    const drawing = (tool === "area" || tool === "deduct" || tool === "linear" || tool === "curve" || tool === "surface" || tool === "zone");
+    const drawing = (tool === "area" || tool === "deduct" || tool === "linear" || tool === "surface" || tool === "zone");
 
     // polar tracking: endpoint snap wins (osnap beats polar); otherwise pull the
     // rubber band onto the 45° family. ⇧ forces the lock at any angle. The click
@@ -2769,7 +2780,7 @@ export default function TakeoffCanvas() {
       : (tool === "check" && check.length === 1 ? check[0] : null));
     angleRef.current = null;
     let lock = null;
-    if (angleOn && anchor && !snapRef.current && !panRef.current) {
+    if (angleOn && anchor && !bowOpen && !snapRef.current && !panRef.current) {
       const sc = tfRef.current.scale;
       if (Math.hypot(cur[0] - anchor[0], cur[1] - anchor[1]) >= 12 / sc)
         lock = angleSnap(anchor, cur, e.shiftKey);
@@ -2831,8 +2842,12 @@ export default function TakeoffCanvas() {
         txt = `${fmtCheckLen(w, units)} × ${fmtCheckLen(h, units)} · ${num(areaVal(sf, units))} ${areaUnit(units)}${units === "metric" ? "" : ` · ${num(sf / 9)} SY`}`;
         over = w >= CARPET_ROLL_FT - 0.02 || h >= CARPET_ROLL_FT - 0.02;
       } else if (drawing && anchor && liveUpp) {
-        // line/polyline: live segment length, ALWAYS (not just under the 45° lock)
-        const len = Math.hypot(cur[0] - anchor[0], cur[1] - anchor[1]) * liveUpp;
+        // line/polyline: live segment length, ALWAYS (not just under the 45° lock).
+        // With a bow open the segment IS the arc, so measure along it — reading
+        // the chord here would price a curved wall short the whole time you aim.
+        const len = bowOpen
+          ? arcLength(poly[poly.length - 2], anchor, cur) * liveUpp
+          : Math.hypot(cur[0] - anchor[0], cur[1] - anchor[1]) * liveUpp;
         txt = lock ? `${lock.deg}° · ${fmtCheckLen(len, units)}` : fmtCheckLen(len, units);
         over = len >= CARPET_ROLL_FT - 0.02;
       } else if (lock) {
@@ -2854,12 +2869,25 @@ export default function TakeoffCanvas() {
     }
     if (rubberRef.current) {
       if (!panRef.current && drawing && poly.length > 0) {
-        const last = poly[poly.length - 1];
+        // With a bow open the band runs from the arc's START and goes dashed —
+        // it is the chord under the bow, a reference line, not the boundary.
+        const last = poly[bowOpen ? poly.length - 2 : poly.length - 1];
         rubberRef.current.setAttribute("x1", last[0]); rubberRef.current.setAttribute("y1", last[1]);
         rubberRef.current.setAttribute("x2", cur[0]); rubberRef.current.setAttribute("y2", cur[1]);
         rubberRef.current.setAttribute("stroke-width", lock ? 3 : 1.5);  // the lock reads in the band itself
+        const dash = bowOpen ? `${5 / tfRef.current.scale} ${4 / tfRef.current.scale}` : "";
+        if (rubberRef.current.__dash !== dash) { rubberRef.current.setAttribute("stroke-dasharray", dash); rubberRef.current.__dash = dash; }
         rubberRef.current.style.display = "block";
       } else rubberRef.current.style.display = "none";
+    }
+    // The arc itself — a real SVG conic through (start, bow, cursor), so what
+    // you aim with is what commits rather than a preview that flattens later.
+    if (arcRef.current) {
+      if (!panRef.current && drawing && bowOpen) {
+        arcRef.current.setAttribute("d", arcPathD(poly[poly.length - 2], poly[poly.length - 1], cur));
+        arcRef.current.setAttribute("stroke-width", 2.5 / tfRef.current.scale);
+        arcRef.current.style.display = "block";
+      } else arcRef.current.style.display = "none";
     }
     if (rectRef.current) {
       const schedDraw = tool === "schedule" && scheduleAnchor;
@@ -2898,7 +2926,7 @@ export default function TakeoffCanvas() {
     }
   }
   function hideCrosshair() {
-    for (const ref of [crossVRef, crossHRef, rubberRef, rectRef, cloudRef, highlightRef, dimRef, snapMarkRef, aimMarkRef, aimChipRef]) if (ref.current) ref.current.style.display = "none";
+    for (const ref of [crossVRef, crossHRef, rubberRef, arcRef, rectRef, cloudRef, highlightRef, dimRef, snapMarkRef, aimMarkRef, aimChipRef]) if (ref.current) ref.current.style.display = "none";
     if (hlRef.current == null && hlPathRef.current) hlPathRef.current.style.display = "none";
     if (hoverRef.current) hoverRef.current.style.display = "none";
     hoverIdRef.current = "";
@@ -4577,12 +4605,11 @@ export default function TakeoffCanvas() {
     // A curved area commits as ONE closed polygon (#284) — the spline is
     // flattened here, at the boundary, so nothing downstream (area, perimeter,
     // Cut Out, hit-testing, the marked PDF, every export) has to learn a second
-    // kind of geometry. flattenRing is the identity on an all-straight trace.
-    const drawn = curveIdx.length ? flattenRing(poly, curveIdx, false) : poly;
+    // kind of geometry. flattenArcRing is the identity on an all-straight trace.
+    const drawn = curveIdx.length ? flattenArcRing(poly, curveIdx, false) : poly;
     if (tool === "surface") commitSurface(drawn, curveIdx.length > 0);
     else if (tool === "linear") commitLinear(drawn, false, curveIdx.length > 0);
-    else if (tool === "curve") commitLinear(poly, true);
-    else commitPoly(curveIdx.length ? flattenRing(poly, curveIdx, true) : poly, tool === "deduct", { curved: curveIdx.length > 0 });
+    else commitPoly(curveIdx.length ? flattenArcRing(poly, curveIdx, true) : poly, tool === "deduct", { curved: curveIdx.length > 0 });
     clearPoly();
   }
   // #137 — the parent state deleting a reconciled deduct should restore. The
@@ -5759,8 +5786,8 @@ export default function TakeoffCanvas() {
     if (cond.hatch && cond.hatch !== "solid") return `url(#${patId(cond)})`;
     return solid ? solid + (darkMode ? "4d" : "33") : "none";
   };
-  // the drawn boundary — flattenRing is the identity on an all-straight trace
-  const mm = closedMetrics(curveIdx.length ? flattenRing(poly, curveIdx, true) : poly);
+  // the drawn boundary — flattenArcRing is the identity on an all-straight trace
+  const mm = closedMetrics(curveIdx.length ? flattenArcRing(poly, curveIdx, !bowOpen) : poly);
   // the live readout prices the IN-PROGRESS poly with its own panel's scale
   const liveUpp = poly.length ? uppFor(panelAt(poly[0][0]).key) : uppFor(focusPanel.key);
   const liveArea = liveUpp ? mm.area * liveUpp * liveUpp : null;
@@ -5880,7 +5907,7 @@ export default function TakeoffCanvas() {
       return { ...next, computed: recomputeShape(next) };
     }));
   };
-  const finishOk = ((tool === "area" || tool === "deduct") && poly.length >= 3) || (tool === "zone" && poly.length >= 3 && !zoneTraceCross) || ((tool === "linear" || tool === "surface" || tool === "curve") && poly.length >= 2);
+  const finishOk = !bowOpen && (((tool === "area" || tool === "deduct") && poly.length >= 3) || (tool === "zone" && poly.length >= 3 && !zoneTraceCross) || ((tool === "linear" || tool === "surface") && poly.length >= 2));
 
   // ── Layers panel (#85 phase 2) wiring ──────────────────────────────────────
   // Open sheets that actually carry a PDF layer table. Empty for the common
@@ -6980,7 +7007,7 @@ export default function TakeoffCanvas() {
        <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
         <div ref={containerRef} onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp}
           onPointerCancel={onPointerUp} onPointerLeave={leaveCanvas} onContextMenu={(e) => e.preventDefault()}
-          onDoubleClick={(e) => { if (tool === "oneclick") { if (proposal?.regions.length) createProposal(); } else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "curve" || tool === "surface" || tool === "zone") finishShape(); else if (tool === "select") editMarkupAt(e); }}
+          onDoubleClick={(e) => { if (tool === "oneclick") { if (proposal?.regions.length) createProposal(); } else if (tool === "area" || tool === "deduct" || tool === "linear" || tool === "surface" || tool === "zone") finishShape(); else if (tool === "select") editMarkupAt(e); }}
           style={{ position: "absolute", inset: 0, background: darkMode ? "#0b0e14" : "var(--paper-cream)", cursor: tool === "select" ? "default" : "none", touchAction: "none" }}>
           {/* aim crosshair (draw modes): the OS cursor is hidden on the canvas — the
               crosshair IS the cursor. Two crisp full-page hairlines riding the
@@ -7542,18 +7569,26 @@ export default function TakeoffCanvas() {
                   (deduct keeps its danger red). Committed shapes wear the condition's own
                   color; the draft never mimics anyone's takeoff look. Solid, no dashes. */}
               <line ref={rubberRef} stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={1.5 / tf.scale} strokeOpacity={0.85} strokeLinecap="round" style={{ display: "none" }} />
+              <path ref={arcRef} fill="none" stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={2.5 / tf.scale} strokeLinecap="round" style={{ display: "none" }} />
               <rect ref={rectRef} fill={tool === "deduct" ? "rgba(176,58,38,.22)" : shapeFill(aCond)} stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={2 / tf.scale} style={{ display: "none" }} />
               <path ref={cloudRef} fill="rgba(37,99,235,.06)" stroke="#1f3fc7" strokeWidth={2 / tf.scale} strokeDasharray={`${5 / tf.scale} ${4 / tf.scale}`} style={{ display: "none" }} />
               <rect ref={highlightRef} fill="rgba(196,122,16,.18)" stroke="#c47a10" strokeWidth={2 / tf.scale} style={{ display: "none" }} />
               <line ref={dimRef} stroke="#1f3fc7" strokeWidth={2 / tf.scale} strokeDasharray={`${5 / tf.scale} ${4 / tf.scale}`} style={{ display: "none" }} />
               <path ref={hlPathRef} style={{ display: "none" }} />
-              {poly.length >= 2 && (tool === "linear" || tool === "curve" || tool === "surface"
-                ? <polyline points={(tool === "curve" ? flattenCurve(poly) : curveIdx.length ? flattenRing(poly, curveIdx, false) : poly).map((p) => p.join(",")).join(" ")} fill="none" stroke={tool === "surface" ? activeColor : "#1f3fc7"} strokeWidth={(tool === "surface" ? 3.5 : 2.5) / tf.scale} strokeDasharray={tool === "surface" ? `${10 / tf.scale} ${3 / tf.scale} ${2 / tf.scale} ${3 / tf.scale}` : undefined} strokeLinecap="round" strokeLinejoin="round" />
-                : <polygon points={(curveIdx.length ? flattenRing(poly, curveIdx, tool !== "zone") : poly).map((p) => p.join(",")).join(" ")} fill={poly.length >= 3 ? (tool === "deduct" ? "rgba(176,58,38,.22)" : tool === "zone" ? "rgba(31,63,199,.06)" : shapeFill(aCond)) : "none"} stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={2 / tf.scale} strokeDasharray={tool === "zone" ? `${7 / tf.scale} ${5 / tf.scale}` : undefined} />)}
-              {/* bold the most recent segment so you see where you just clicked */}
-              {poly.length >= 2 && (
-                <line x1={poly[poly.length - 2][0]} y1={poly[poly.length - 2][1]} x2={poly[poly.length - 1][0]} y2={poly[poly.length - 1][1]}
-                  stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={3.5 / tf.scale} strokeLinecap="round" />
+              {poly.length >= 2 && (tool === "linear" || tool === "surface"
+                ? <polyline points={(curveIdx.length ? flattenArcRing(poly, curveIdx, false) : poly).map((p) => p.join(",")).join(" ")} fill="none" stroke={tool === "surface" ? activeColor : "#1f3fc7"} strokeWidth={(tool === "surface" ? 3.5 : 2.5) / tf.scale} strokeDasharray={tool === "surface" ? `${10 / tf.scale} ${3 / tf.scale} ${2 / tf.scale} ${3 / tf.scale}` : undefined} strokeLinecap="round" strokeLinejoin="round" />
+                : <polygon points={(curveIdx.length ? flattenArcRing(poly, curveIdx, tool !== "zone" && !bowOpen) : poly).map((p) => p.join(",")).join(" ")} fill={poly.length >= 3 ? (tool === "deduct" ? "rgba(176,58,38,.22)" : tool === "zone" ? "rgba(31,63,199,.06)" : shapeFill(aCond)) : "none"} stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={2 / tf.scale} strokeDasharray={tool === "zone" ? `${7 / tf.scale} ${5 / tf.scale}` : undefined} />)}
+              {/* Bold the most recent segment so you see where you just clicked.
+                  A closed arc bolds AS the arc — a straight chord drawn across
+                  the bow would read as the boundary and it isn't one. Nothing
+                  bolds while a bow is still open; the live preview is the
+                  segment then. */}
+              {poly.length >= 2 && !bowOpen && (
+                polyCurve[poly.length - 2] && poly.length >= 3
+                  ? <path d={arcPathD(poly[poly.length - 3], poly[poly.length - 2], poly[poly.length - 1])} fill="none"
+                      stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={3.5 / tf.scale} strokeLinecap="round" />
+                  : <line x1={poly[poly.length - 2][0]} y1={poly[poly.length - 2][1]} x2={poly[poly.length - 1][0]} y2={poly[poly.length - 1][1]}
+                      stroke={tool === "deduct" ? "#b03a26" : "#1f3fc7"} strokeWidth={3.5 / tf.scale} strokeLinecap="round" />
               )}
               {poly.map((p, i) => {
                 const isLast = i === poly.length - 1;
@@ -7716,7 +7751,7 @@ export default function TakeoffCanvas() {
               eye already is while tracing; the canvas stays chrome-free. */}
           {CURVABLE.has(tool) && (
             <div style={{ display: "flex", gap: 0, marginBottom: 8, border: "1px solid var(--ink-faint)" }}
-              title="Straight places corners; Curve bends the boundary through the points you place. Switch as often as you like inside one measurement — Q flips it once a trace is going, and ⌥-click always places the OTHER kind for one point.">
+              title="Straight places corners. Curve takes two clicks — one anywhere ON the bow, then its far end — and lays the unique circle through those and the vertex you were on, so it sits on a radius wall instead of near it. Switch as often as you like inside one measurement: Q flips it once a trace is going, and ⌥-click always places the OTHER kind for one point.">
               {[["straight", "Straight", "╱"], ["curve", "Curve", "⌒"]].map(([k, label, glyph]) => {
                 const on = (k === "curve") === curveMode;
                 return (
@@ -7746,7 +7781,7 @@ export default function TakeoffCanvas() {
             );
           })() : tool === "surface" && poly.length >= 2 && liveUpp ? (
             (() => {
-              const liveLF = openLen(curveIdx.length ? flattenRing(poly, curveIdx, false) : poly) * liveUpp;
+              const liveLF = openLen(curveIdx.length ? flattenArcRing(poly, curveIdx, false) : poly) * liveUpp;
               return condH > 0 ? (
                 <>
                   <div style={{ fontSize: 22, fontWeight: 700, color: "var(--ink)" }}>{num(areaVal(liveLF * condH, units))} <span style={{ fontSize: 13, fontWeight: 600 }}>{areaUnit(units)} wall</span></div>
@@ -7768,7 +7803,7 @@ export default function TakeoffCanvas() {
               <div style={{ fontSize: 22, fontWeight: 700, color: tool === "deduct" ? "var(--c-danger)" : "var(--ink)" }}>{tool === "deduct" ? "−" : ""}{num(areaVal(liveArea, units))} <span style={{ fontSize: 13, fontWeight: 600 }}>{areaUnit(units)}</span></div>
               <div style={{ fontSize: 12.5, color: "var(--ink-secondary)", marginTop: 2 }}>{units === "metric" ? `${fl(livePerim)} perim` : `${num(liveArea / 9)} SY  ·  ${num(livePerim)} LF perim`}</div>
               {condH > 0 && <div style={{ fontSize: 11.5, color: "var(--ink-muted)", marginTop: 2 }}>@H {num(heightVal(condH, units), 2)}{units === "metric" ? " m" : "′"}: {fa(livePerim * condH)} vert{units === "metric" ? "" : ` · ${num((liveArea * condH) / 27)} CY`}</div>}
-              {CURVABLE.has(tool) && <div style={{ fontSize: 11.5, color: "var(--ink-muted)", marginTop: 4 }}>{curveIdx.length ? `${curveIdx.length} curve point${curveIdx.length === 1 ? "" : "s"} — the boundary bends through them` : "Q or the switch above bends the boundary · ⌥-click bends one point"}</div>}
+              {CURVABLE.has(tool) && <div style={{ fontSize: 11.5, color: "var(--ink-muted)", marginTop: 4 }}>{bowOpen ? "Bow set — click the far END of the arc" : curveMode && poly.length ? "Click a point ON the bow, then its far end" : curveIdx.length ? `${curveIdx.length} arc${curveIdx.length === 1 ? "" : "s"} — each one a true circle through 3 points` : "Q or the switch above draws an arc · ⌥-click flips one point"}</div>}
             </>
           ) : selShape ? (
             // #283 — a FINISHED takeoff reads the same as it did mid-trace.

--- a/web/test/arc.test.ts
+++ b/web/test/arc.test.ts
@@ -1,0 +1,112 @@
+// Three-point arc geometry — pins the contract the estimator leans on: the arc
+// passes through the point clicked ON the bow, it goes the way that point says
+// (including the long way round, past 180°), a flat bow degrades to a straight
+// segment instead of a giant circle, and a ring that mixes straight walls with
+// an arc closes with the right AREA — the number that reaches the takeoff.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { circleThrough, flattenArc, arcLength, arcPathD, flattenArcRing } from "../src/lib/arc.js";
+
+type Pt = [number, number];
+
+const ringArea = (pts: Pt[]) => {
+  let a = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const q = pts[(i + 1) % pts.length];
+    a += pts[i][0] * q[1] - q[0] * pts[i][1];
+  }
+  return Math.abs(a) / 2;
+};
+const near = (got: number, want: number, tol: number, what: string) =>
+  assert.ok(Math.abs(got - want) <= tol, `${what}: got ${got}, want ${want} ±${tol}`);
+
+const QA: Pt = [100, 0], QM: Pt = [70.7106781, 70.7106781], QB: Pt = [0, 100];
+
+test("the circle is the circumcircle, and every flattened point lands on it", () => {
+  const c = circleThrough(QA, QM, QB)!;
+  near(c.cx, 0, 1e-6, "center x");
+  near(c.cy, 0, 1e-6, "center y");
+  near(c.r, 100, 1e-6, "radius");
+  const pts = flattenArc(QA, QM, QB);
+  assert.ok(pts.length >= 8, "a quarter circle is worth more than a couple of chords");
+  for (const p of pts) near(Math.hypot(p[0], p[1]), 100, 1e-6, "point on circle");
+  near(arcLength(QA, QM, QB), Math.PI * 50, 1e-4, "quarter-arc length");
+});
+
+test("flattenArc returns the interior only — the caller owns its corners", () => {
+  const pts = flattenArc(QA, QM, QB);
+  const same = (p: Pt, q: Pt) => Math.hypot(p[0] - q[0], p[1] - q[1]) < 1e-9;
+  assert.ok(!pts.some((p) => same(p as Pt, QA)), "start is not re-emitted");
+  assert.ok(!pts.some((p) => same(p as Pt, QB)), "end is not re-emitted");
+});
+
+test("the bow point picks the direction, including the long way round", () => {
+  near(arcLength([100, 0], [-100, 0], [0, -100]), Math.PI * 150, 1e-4, "reflex arc, one way");
+  near(arcLength([100, 0], [-100, 0], [0, 100]), Math.PI * 150, 1e-4, "reflex arc, other way");
+  assert.match(arcPathD([100, 0], [-100, 0], [0, -100]), /A 100 100 0 1 1 /, "large-arc, positive sweep");
+  assert.match(arcPathD([100, 0], [-100, 0], [0, 100]), /A 100 100 0 1 0 /, "large-arc, negative sweep");
+  assert.ok(flattenArc([100, 0], [-100, 0], [0, -100]).some((p) => p[1] > 90), "passes the bow point's side");
+});
+
+test("a flat bow is a straight line, not a circle the size of the county", () => {
+  assert.equal(circleThrough([0, 0], [50, 0], [100, 0]), null, "collinear has no circle");
+  assert.deepEqual(flattenArc([0, 0], [50, 0], [100, 0]), [], "…so it contributes no interior points");
+  near(arcLength([0, 0], [50, 0], [100, 0]), 100, 1e-9, "length falls back to the chord");
+  assert.equal(arcPathD([0, 0], [50, 0], [100, 0]), "M 0 0 L 100 0", "…and the path to a line");
+  const c = circleThrough([0, 0], [50, 0.5], [100, 0]);
+  assert.ok(c && Number.isFinite(c.r), "a near-flat bow still solves");
+  near(arcLength([0, 0], [50, 0.5], [100, 0]), 100, 0.05, "…and measures barely over the chord");
+});
+
+test("a square with one semicircular bay closes with the right area", () => {
+  // 100×100 room, top wall bowed out through (50,150): the bow's circle is
+  // centred (50,100) r=50, so the ring is 10,000 + a half disc of 3,926.99.
+  const ring: Pt[] = [[0, 0], [100, 0], [100, 100], [50, 150], [0, 100]];
+  const flat = flattenArcRing(ring, [3], true) as Pt[];
+  const want = 10000 + (Math.PI * 50 * 50) / 2;
+  const got = ringArea(flat);
+  assert.ok(got < want, "a chorded arc is inscribed — it can only under-measure");
+  near(got, want, want * 0.005, "bowed-bay area");
+  for (const corner of [[0, 0], [100, 0], [100, 100], [0, 100]])
+    assert.ok(flat.some((p) => Math.hypot(p[0] - corner[0], p[1] - corner[1]) < 1e-9), `corner ${corner} survives`);
+  assert.ok(flat.some((p) => Math.hypot(p[0] - 50, p[1] - 150) < 1e-6), "the clicked bow point is ON the drawn boundary");
+});
+
+test("an arc closing the ring wraps the same as any other", () => {
+  const ring: Pt[] = [[0, 100], [0, 0], [100, 0], [100, 100], [50, 150]];   // the marked point is LAST
+  near(ringArea(flattenArcRing(ring, [4], true) as Pt[]), 10000 + (Math.PI * 50 * 50) / 2, 70, "wrapping arc area");
+});
+
+test("half-placed and ambiguous marks degrade to corners rather than guessing", () => {
+  const open: Pt[] = [[0, 0], [100, 0], [150, 50]];
+  assert.deepEqual(flattenArcRing(open, [2], false), open, "a trailing bow is still just a point");
+  assert.deepEqual(flattenArcRing(open, [0], false), open, "…so is a leading one");
+  const two: Pt[] = [[0, 0], [50, 30], [60, 40], [100, 0]];
+  assert.deepEqual(flattenArcRing(two, [1, 2], false), two, "adjacent bows both demote");
+  assert.ok(flattenArcRing(open, [0], true).length > open.length, "closing the ring makes a leading bow real");
+});
+
+test("no marks is the identity, and the input is never mutated", () => {
+  const sq: Pt[] = [[0, 0], [100, 0], [100, 100], [0, 100]];
+  const snapshot = JSON.stringify(sq);
+  assert.deepEqual(flattenArcRing(sq, []), sq);
+  assert.deepEqual(flattenArcRing(sq, undefined), sq);
+  assert.ok(flattenArcRing(sq, new Set([2])).length > 4, "a Set works the same as an array");
+  flattenArcRing(sq, [2], true);
+  flattenArc(sq[0], sq[1], sq[2]);
+  assert.equal(JSON.stringify(sq), snapshot, "input untouched");
+});
+
+test("the vertex budget holds — a sweeping arc can't mint a thousand-point shape", () => {
+  assert.ok(flattenArc([0, 0], [5000, 3000], [10000, 0]).length <= 96, "big arc capped");
+  assert.ok(flattenArc([0, 0], [2, 1], [4, 0]).length >= 8, "small arc still smooth");
+  const ring: Pt[] = [[0, 0], [400, 0], [400, 400], [200, 900], [0, 400]];
+  assert.ok(flattenArcRing(ring, [3], true).length <= 100, "a ring with an arc stays lean");
+});
+
+test("degenerate input doesn't throw", () => {
+  assert.deepEqual(flattenArcRing([], [0]), []);
+  assert.deepEqual(flattenArcRing([[1, 2]], [0]), [[1, 2]]);
+  assert.equal(circleThrough([5, 5], [5, 5], [5, 5]), null, "coincident points have no circle");
+  assert.deepEqual(flattenArc([5, 5], [5, 5], [9, 9]), [], "a bow on the start point is flat");
+});

--- a/web/test/curve.test.ts
+++ b/web/test/curve.test.ts
@@ -1,9 +1,10 @@
-// Curved-line geometry — pins flattenCurve's contract: interpolation through
+// Legacy spline geometry — pins flattenCurve's contract for the `curved: true`
+// shapes traced before the 3-point arc (see arc.test.ts): interpolation through
 // every control point, straight-line passthrough under 3 points, near-collinear
 // stability, the vertex cap, and input immutability.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { flattenCurve, flattenRing } from "../src/lib/curve.js";
+import { flattenCurve } from "../src/lib/curve.js";
 
 type Pt = [number, number];
 const len = (pts: Pt[]) => pts.slice(1).reduce((L, p, i) => L + Math.hypot(p[0] - pts[i][0], p[1] - pts[i][1]), 0);
@@ -49,67 +50,4 @@ test("input never mutated", () => {
   const snapshot = JSON.stringify(ctrl);
   flattenCurve(ctrl);
   assert.equal(JSON.stringify(ctrl), snapshot);
-});
-
-// ── flattenRing: a boundary that is straight in places and curved in others ──
-// (#284). The contract that matters downstream: ONE closed polyline out, the
-// straight work untouched, every clicked point still on the boundary.
-const ringArea = (pts: Pt[]) => {
-  let a = 0;
-  for (let i = 0; i < pts.length; i++) {
-    const q = pts[(i + 1) % pts.length];
-    a += pts[i][0] * q[1] - q[0] * pts[i][1];
-  }
-  return Math.abs(a) / 2;
-};
-
-test("flattenRing with no curve points is the identity (a straight trace is untouched)", () => {
-  const sq: Pt[] = [[0, 0], [100, 0], [100, 100], [0, 100]];
-  const out = flattenRing(sq, []);
-  assert.deepEqual(out, sq);
-  assert.notEqual(out, sq, "must be a copy, not the same array");
-  assert.deepEqual(flattenRing(sq, undefined), sq);
-});
-
-test("a bowed wall: the straight corners survive, the marked points shape the arc", () => {
-  // a room with three straight walls and a bowed one — the estimator clicks
-  // three points along the bow and ⌥s them
-  const room: Pt[] = [[0, 0], [100, 0], [100, 100], [70, 120], [30, 120], [0, 100]];
-  const out = flattenRing(room, [3, 4]);
-  for (const c of [[0, 0], [100, 0], [100, 100], [0, 100]] as Pt[]) assert.ok(hasPt(out, c), `straight corner ${c} kept verbatim`);
-  for (const c of [[70, 120], [30, 120]] as Pt[]) assert.ok(hasPt(out, c), `the curve passes through clicked point ${c}`);
-  assert.ok(out.length > room.length, "the bow is sampled, the straight walls are not");
-  // the boundary bends through the clicked points instead of turning corners
-  // at them, so the bowed end holds a little MORE than the chord polygon
-  assert.ok(ringArea(out) > ringArea(room), "a bow adds area over the straight-chord reading");
-  assert.ok(ringArea(out) < ringArea(room) * 1.1, "and it is a bend, not an excursion");
-});
-
-test("every vertex curved closes as a periodic spline — no seam, no lost area", () => {
-  const oct: Pt[] = Array.from({ length: 8 }, (_, i) => [50 + 50 * Math.cos((i * Math.PI) / 4), 50 + 50 * Math.sin((i * Math.PI) / 4)] as Pt);
-  const out = flattenRing(oct, [0, 1, 2, 3, 4, 5, 6, 7]);
-  const circle = Math.PI * 2500;
-  assert.ok(ringArea(oct) < ringArea(out), "the spline holds more area than the straight octagon");
-  assert.ok(ringArea(out) < circle * 1.02, "and does not overshoot the circle it was clicked on");
-  // a periodic spline has no privileged start: the seam is as smooth as the
-  // rest, so no two consecutive samples are wildly longer than their neighbors
-  const steps: number[] = out.map((p: Pt, i: number) => Math.hypot(p[0] - out[(i + 1) % out.length][0], p[1] - out[(i + 1) % out.length][1]));
-  assert.ok(Math.max(...steps) < 4 * (steps.reduce((n: number, v: number) => n + v, 0) / steps.length), "no seam kink");
-});
-
-test("open mode (the in-progress trace) anchors a run on itself at either end", () => {
-  const pts: Pt[] = [[0, 0], [50, 30], [100, 0]];
-  const out = flattenRing(pts, [1], false);
-  assert.deepEqual(out[0], [0, 0]);
-  assert.deepEqual(out[out.length - 1], [100, 0]);
-  assert.ok(out.length > 3, "the middle point curves");
-  // a run touching the END of the trace still terminates on the clicked point
-  const tail = flattenRing([[0, 0], [50, 30], [100, 0]] as Pt[], [2], false);
-  assert.deepEqual(tail[tail.length - 1], [100, 0]);
-});
-
-test("the vertex budget holds on a ring curved end to end (render-invariance)", () => {
-  const many: Pt[] = Array.from({ length: 40 }, (_, i) => [200 + 200 * Math.cos((i * Math.PI) / 20), 200 + 200 * Math.sin((i * Math.PI) / 20)] as Pt);
-  assert.ok(flattenRing(many, many.map((_, i) => i)).length <= 260, "closed spline stays inside the cap");
-  assert.ok(flattenRing(many, [5, 6, 7, 20, 21]).length <= 260, "so does a ring with several runs");
 });


### PR DESCRIPTION
The **⌒ Curve** switch (#284) had the right *shape* — you never leave the measurement — but the wrong *gesture*. It splined a run of clicked points, and a Catmull-Rom is exact only AT its knots and wanders between them, so tracing a radius wall meant chasing it with click after click and still landing beside it.

The guide's own advice gave it away: *"more points on a tight arc is a truer arc."* That is a tool asking you to compensate for it.

## Three clicks, one circle

A radius wall **is** a circle — the architect drew it with a center and a radius — and three points define exactly one circle. So in Curve the clicks now **alternate**: one lands anywhere **on the bow**, the next on the **far end**, and the arc through those and the vertex you were already on lands *on* the wall. Two clicks per arc, wherever you like along it.

## What changed

- **`lib/arc.js`** — `circleThrough` / `flattenArc` / `arcLength` / `arcPathD` / `flattenArcRing`, with `test/arc.test.ts` (10 cases).
- The bow keeps the round handle #284 already had; the rubber band becomes the dashed chord under it; the arc previews as a real SVG conic — what you aim with is what commits. `⏎` waits for the far end; a bow alone is half a gesture.
- **The flattened arc passes through the bow point exactly.** It is a click, often a snapped one — a place on the wall the estimator chose — so the step budget splits either side of it rather than sampling past it. The test caught this before it ever ran in the app.
- Sweeps past 180° work (the bow picks the direction). A flat bow degrades to the straight chord instead of solving a circle the size of the county.
- The live chip reads length **along the arc**, never the chord — the chord would price a curved wall short the whole time you aim. The 45° lock stays out of it.
- Still flattens **at commit**, so SF/LF, Cut Out, hit-testing, the marked set and every export keep seeing plain geometry.

The standalone **Curved Line** tool is retired — `Q` is the switch now. `flattenCurve` stays as the read path so `curved: true` runs traced before today keep their LF; `flattenRing`/`flattenClosedCurve` go with the gesture they served.

## Verified

In the running app on the sample plan: a straight–straight–arc ring commits as one smooth shape, and the Report round-trips it — 3 shapes, **11,503.2 SF** → 12,078.4 w/waste, 1,342 SY, 47 gal adhesive. `npm run check` green on Node 24.