### PR TITLE
symbol_sweep: one drain, one row — the walkers coalesce (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-21 — one drain, one row; opentakeoff-mcp 0.9.60
+
+### Fixed
+- **`symbol_sweep` could commit one symbol twice (#293).** Found the day 0.9.56 shipped, validating against a real plumbing sheet: one floor drain came back as two matches **0.2 px apart** (0.921 and 0.925), both above the commit bar, both committed — `ea_total` said 5 where 4 symbols are drawn, and the overlay stacked the two markers into what renders as a single ×. A drain counted twice with a machine's confidence behind it. The mechanism is in the dedupe: a kept entry *migrates* (`twin.at = s.at`) toward better-scoring proposals, so two cluster seeds that started farther apart than the merge radius can both walk onto the same peak — and nothing re-checked the invariant after a move. The bundled fixtures never tripped it because their 6-segment drain is too clean; the trigger is a **dense** symbol (a circle flattened to dozens of short segments) proposing the same instance from many anchor pairs. `mergeProposals` (extracted from the inline loop, exported for the mechanism test — the failure is a property of proposal ORDER, which drawn ink cannot pin deterministically) keeps the walking cluster semantics and then restores the invariant with a final greedy-by-score pass **at the merge radius**: greedy never moves a position, so it cannot re-break what it enforces. The radius is `mergeR` deliberately, not the shadow radius — the first attempt coalesced at `suppressR` and the ceiling-grid test caught it immediately, swallowing **adjacent real instances**: abutting 2×4 tiles sit closer than half a symbol diagonal, and an estimator counting a tiled symbol must get every tile. That wrong turn is pinned as its own regression test. Re-run against the sheet that found it: found 4, one row per drain, the survivor the better reading.
+
 ## 2026-08-21 — the workspace becomes portable; opentakeoff-mcp 0.9.59
 
 Four requests from @Seekr42 (#299–#302), filed overnight as one coherent architecture — the project, the profile, and the workspace as first-class objects instead of "whatever this browser profile has accumulated." Shipped as #303, #305, #306.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.59",
+      "version": "0.9.60",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.59",
+  "version": "0.9.60",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.59",
+  "version": "0.9.60",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.59",
+      "version": "0.9.60",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.59",
+  "version": "0.9.60",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.59",
+      "version": "0.9.60",
       "transport": {
         "type": "stdio"
       }

--- a/web/src/lib/symbolsweep.ts
+++ b/web/src/lib/symbolsweep.ts
@@ -660,6 +660,37 @@ export function buildNegative(fp: SymbolFingerprint, segs: number[], rect: [Poin
   };
 }
 
+/** One physical placement, one entry (#293). A dense symbol proposes the same
+ * instance from many anchor pairs at centers spread wider than the merge
+ * radius, so clustering keeps the old walking semantics — an entry follows
+ * the best-scoring proposal of its neighborhood — but that walk could END
+ * with two entries on the same peak: each walker absorbed its own chain, and
+ * nothing re-checked the pairwise invariant after a move. Measured on a real
+ * plumbing sheet as one floor drain committed twice, 0.2 px apart (0.921 and
+ * 0.925), the two markers stacked into what renders as a single ×. The final
+ * pass restores the invariant greedily by score — greedy never moves a
+ * position, so it cannot re-break what it enforces. Exported for the tests:
+ * the failure is a property of proposal ORDER, which drawn-ink fixtures
+ * cannot pin down deterministically. */
+export function mergeProposals<T extends { at: Point; score: number; xf: number; rotation: number; mirrored: boolean }>(scored: T[], mergeR: number): T[] {
+  const kept: T[] = [];
+  for (const s of scored) {
+    const twin = kept.find((k) => Math.hypot(k.at[0] - s.at[0], k.at[1] - s.at[1]) <= mergeR);
+    if (!twin) { kept.push({ ...s }); continue; }
+    if (s.score > twin.score || (s.score === twin.score && s.xf < twin.xf)) {
+      twin.at = s.at; twin.score = s.score; twin.rotation = s.rotation; twin.mirrored = s.mirrored; twin.xf = s.xf;
+    }
+  }
+  const byBest = [...kept].sort((a, b) =>
+    b.score - a.score || a.xf - b.xf || a.at[1] - b.at[1] || a.at[0] - b.at[0]);
+  const out: T[] = [];
+  for (const s of byBest) {
+    if (out.some((k) => Math.hypot(k.at[0] - s.at[0], k.at[1] - s.at[1]) <= mergeR)) continue;
+    out.push(s);
+  }
+  return out;
+}
+
 /** Steps 2–4 against ANY sheet's segments: constellation candidates, scoring,
  * classification. Anchor rarity is judged per TARGET sheet — the same seed
  * prunes differently on sheets with different length histograms, which is the
@@ -818,14 +849,7 @@ export function matchSymbol(fp: SymbolFingerprint, segs: number[], opts: MatchOp
     scored.push({ at: [c.tx, c.ty], score, rotation: xforms[c.xf].rotation, mirrored: xforms[c.xf].mirrored, xf: c.xf });
   }
   const mergeR = Math.max(2 * tol, 4);
-  const kept: Scored[] = [];
-  for (const s of scored) {
-    const twin = kept.find((k) => Math.hypot(k.at[0] - s.at[0], k.at[1] - s.at[1]) <= mergeR);
-    if (!twin) { kept.push(s); continue; }
-    if (s.score > twin.score || (s.score === twin.score && s.xf < twin.xf)) {
-      twin.at = s.at; twin.score = s.score; twin.rotation = s.rotation; twin.mirrored = s.mirrored; twin.xf = s.xf;
-    }
-  }
+  const kept = mergeProposals(scored, mergeR);
 
   // Shadow suppression. A partially-symmetric symbol reads ALMOST as itself
   // under the wrong transform — square + diagonal without the stub — at a

--- a/web/test/sweepCoalesce.test.ts
+++ b/web/test/sweepCoalesce.test.ts
@@ -1,0 +1,125 @@
+// #293 — one instance, one row. The proposal dedupe keeps walking semantics
+// (an entry follows the best-scoring proposal of its neighborhood), and the
+// walk could end with two entries on the same peak: each walker absorbed its
+// own chain, and nothing re-checked the pairwise invariant after a move.
+// Measured on a real plumbing sheet as one floor drain committed twice —
+// matches 0.2 px apart at 0.921 and 0.925, stacked into what renders as a
+// single ×, ea_total one high with a machine's confidence behind it.
+//
+// The failure is a property of proposal ORDER, not of any particular ink —
+// which is why the drawn-ink fixtures never tripped it and why the mechanism
+// test drives `mergeProposals` directly with the choreographed chain. The
+// sweep-level tests then lock the invariant on geometry, including the case
+// the first fix attempt got wrong: ADJACENT real instances (a ceiling grid's
+// abutting tiles) sit closer than half a symbol diagonal and must all count.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sweepSymbols, mergeProposals } from "../src/lib/symbolsweep.ts";
+
+const P = (x: number, y: number, score: number, xf = 0) =>
+  ({ at: [x, y] as [number, number], score, xf, rotation: 0, mirrored: false });
+
+test("mergeProposals: a migration chain cannot leave two entries on one peak (#293)", () => {
+  // The choreography that reproduces the measured pair. mergeR = 4:
+  //   A (0,0)   0.930  → seeds walker K1
+  //   D (7.6,0) 0.926  → 7.6 px from K1: seeds walker K2
+  //   B (3.8,0) 0.940  → within 4 of K1: K1 walks to 3.8
+  //   C (7.4,0) 0.950  → within 4 of K1 (3.6 away): K1 walks to 7.4
+  // Old behavior: K1 ends at (7.4, 0.950) and K2 at (7.6, 0.926) — 0.2 px
+  // apart, both above the commit bar, one drain counted twice.
+  const out = mergeProposals([P(0, 0, 0.93), P(7.6, 0, 0.926), P(3.8, 0, 0.94), P(7.4, 0, 0.95)], 4);
+  assert.equal(out.length, 1, `one physical peak, one entry — got ${out.length}`);
+  assert.equal(out[0].score, 0.95, "and the entry is the peak's best reading");
+
+  // Distinct placements beyond the radius are never collapsed.
+  const two = mergeProposals([P(0, 0, 0.95), P(30, 0, 0.93)], 4);
+  assert.equal(two.length, 2);
+
+  // Determinism: score tie breaks to the earliest transform, then position.
+  const tie = mergeProposals([P(0, 0, 0.95, 3), P(1, 0, 0.95, 1)], 4);
+  assert.equal(tie[0].xf, 1);
+});
+
+test("mergeProposals invariant: every output pair is separated by more than mergeR (#293)", () => {
+  // A plateau chain along a line — the worst case for walkers.
+  const chain = Array.from({ length: 20 }, (_, i) => P(i * 3, 0, 0.9 + i * 0.001));
+  for (const mergeR of [4, 6, 8]) {
+    const out = mergeProposals(chain, mergeR);
+    for (let i = 0; i < out.length; i++) {
+      for (let j = i + 1; j < out.length; j++) {
+        const d = Math.hypot(out[i].at[0] - out[j].at[0], out[i].at[1] - out[j].at[1]);
+        assert.ok(d > mergeR, `entries ${i},${j} are ${d.toFixed(1)} px apart at mergeR ${mergeR}`);
+      }
+    }
+  }
+});
+
+// ── sweep-level: the invariant holds on ink, and adjacency survives ─────────
+function lcg(seed: number) {
+  let s = seed >>> 0;
+  return () => ((s = (s * 1664525 + 1013904223) >>> 0) / 2 ** 32);
+}
+// A drain the way real plumbing sheets draw one: a 24-gon "circle" (radius
+// 12) plus a cross — 26 short segments, dozens of usable anchor pairs.
+const DRAIN: [number, number, number, number][] = [];
+for (let i = 0; i < 24; i++) {
+  const a = (i / 24) * 2 * Math.PI, b = ((i + 1) / 24) * 2 * Math.PI;
+  DRAIN.push([12 * Math.cos(a), 12 * Math.sin(a), 12 * Math.cos(b), 12 * Math.sin(b)]);
+}
+DRAIN.push([-8, 0, 8, 0], [0, -8, 0, 8]);
+
+test("dense jittered instances each count exactly once, matches pairwise separated by more than mergeR (#293)", () => {
+  const rnd = lcg(293);
+  const segs: number[] = [];
+  const place = (ox: number, oy: number, jitter = 0) => {
+    for (const [ax, ay, bx, by] of DRAIN) {
+      const j = () => (rnd() - 0.5) * 2 * jitter;
+      segs.push(ax + ox + j(), ay + oy + j(), bx + ox + j(), by + oy + j());
+    }
+  };
+  place(100, 100);                          // the seed — clean
+  const instances: [number, number][] = [[300, 100], [500, 100], [100, 300], [300, 300], [500, 300]];
+  for (const [x, y] of instances) place(x, y, 0.8);   // drafting jitter inside tol 2
+
+  const res = sweepSymbols(segs, [[86, 86], [114, 114]]);
+  for (const [x, y] of instances) {
+    assert.ok(res.matches.some((m) => Math.hypot(m.at[0] - x, m.at[1] - y) < 8), `the instance at ${x},${y} is counted`);
+  }
+  assert.equal(res.matches.length, instances.length, "one row per drawn instance");
+  for (let i = 0; i < res.matches.length; i++) {
+    for (let j = i + 1; j < res.matches.length; j++) {
+      const d = Math.hypot(res.matches[i].at[0] - res.matches[j].at[0], res.matches[i].at[1] - res.matches[j].at[1]);
+      assert.ok(d > 4, `rows ${i} and ${j} are ${d.toFixed(1)} px apart — one instance, two rows`);
+    }
+  }
+});
+
+test("adjacent REAL instances are not swallowed: abutting tiles all count (#293 first-attempt regression)", () => {
+  // A 2×4 tile lattice: neighbors sit exactly one tile-height apart — CLOSER
+  // than half the symbol diagonal, which is why the coalesce radius must be
+  // mergeR and never suppressR. An estimator counting a tiled symbol must get
+  // every tile.
+  const TW = 50, TH = 25;
+  const segs: number[] = [];
+  for (let r = 0; r < 3; r++) for (let c = 0; c < 3; c++) {
+    const x = c * TW, y = r * TH;
+    segs.push(x, y, x + TW, y, x + TW, y, x + TW, y + TH, x + TW, y + TH, x, y + TH, x, y + TH, x, y);
+    segs.push(x, y, x + TW, y + TH);        // a diagonal so the tile isn't a bare rect
+  }
+  // Orientation pinned: on a lattice, rotation/mirror freedom mints extra
+  // legitimate readings off the shared edges (the phantom phenomenon the
+  // crossing-mode counter-example exists for) — this test is about adjacency
+  // spacing, not about those. The seed's own orthogonal neighbors sit inside
+  // the seed-shadow radius and may be suppressed — that is the pre-existing
+  // excludeCenter behavior, not this fix — so the assertion is on the SIX
+  // far tiles, which include vertical pairs 25 px apart: closer than half
+  // the symbol diagonal (~28), exactly the spacing a suppressR-radius
+  // coalesce (the first fix attempt) wrongly halved.
+  const res = sweepSymbols(segs, [[-2, -2], [TW + 2, TH + 2]], { rotations: false, mirror: false });
+  const far: [number, number][] = [[2, 0], [1, 1], [2, 1], [0, 2], [1, 2], [2, 2]];
+  for (const [c, r] of far) {
+    const cx = c * TW + TW / 2, cy = r * TH + TH / 2;
+    assert.ok(res.matches.some((m) => Math.hypot(m.at[0] - cx, m.at[1] - cy) < 8),
+      `the tile at column ${c}, row ${r} is counted — adjacency must survive the coalesce`);
+  }
+});


### PR DESCRIPTION
Closes #293. Found the same day 0.9.56 shipped, validating against a real plumbing sheet: one floor drain came back as **two committed matches 0.2 px apart** (0.921 and 0.925) — `ea_total` 5 where 4 symbols are drawn, the two markers stacked into what renders as a single ×. A drain counted twice with a machine's confidence behind it.

## Mechanism

The dedupe keeps walking semantics — a kept entry follows the best-scoring proposal of its neighborhood (`twin.at = s.at`). Two cluster seeds that start farther apart than `mergeR` can both walk onto the same peak, and nothing re-checked the pairwise invariant after a move. The trigger is a **dense** symbol: a circle flattened to dozens of short segments proposes one instance from many anchor pairs at centers spread wider than the radius — which is why the bundled 6-segment fixture drain never tripped it across 1400 tests.

## Fix

`mergeProposals` (extracted from the inline loop, exported) keeps the walk and then restores the invariant with a **final greedy-by-score pass at `mergeR`** — greedy never moves a position, so it cannot re-break what it enforces. Deterministic tie-break unchanged (earliest transform, then reading order).

**The radius is `mergeR` deliberately, not `suppressR`.** The first attempt coalesced at the shadow radius and the ceiling-grid test caught it immediately: **adjacent real instances** — abutting 2×4 tiles, whose centers sit one tile-height apart — are legitimately closer than half a symbol diagonal, and an estimator counting a tiled symbol must get every tile. That wrong turn and its catch are pinned as a regression test.

## Verified

- Mechanism test drives `mergeProposals` with the choreographed proposal chain that reproduces the measured pair (walker migrates 0 → 3.8 → 7.4 while a second seed at 7.6 survives — two entries 0.2 px apart, mirroring the shipped failure); fails on the old algorithm, passes now.
- Invariant test: pairwise separation > `mergeR` on plateau chains at several radii.
- Sweep-level: dense jittered instances each count exactly once; the abutting-tile lattice keeps every far tile (orientation pinned — lattice rotation phantoms are the crossing-negative's department, not this test's).
- **Re-run against the sheet that found it** (unreleased engine over stdio): `found: 4`, one row per drain, the survivor the 0.925 reading; withheld unchanged.

`npm run check` green (1397 pass, Node 24) · mcp 173/173 · 0.9.57 guard-complete bump.

Staged for merge after the current validation pass — merging deploys, and the pass is running against published 0.9.56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)