### PR TITLE
Read the sheet the way it is drawn: fragmented sheet numbers, discipline plans, compound row keys

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.56",
+  "version": "0.9.57",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.56",
+  "version": "0.9.57",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.56",
+      "version": "0.9.57",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { openPdf, positionedText, textSpans, textItemsInRegion, OPS, type DocHandle, type PageHandle, type TextSpan, type OcgEntry } from "./pdf.ts";
 import { expandForScaleNotes, mixedScaleWarning } from "./scalewarn.ts";
 import { classifyLayerName, layerRoleCodes, segRoles, type LayerInfo } from "../../web/src/lib/layers.ts";
-import { buildSheetGraph, resolveTag, classifySheetRole, type SheetGraph, type SheetSpans } from "../../web/src/lib/sheetgraph.ts";
+import { buildSheetGraph, resolveTag, classifySheetRole, rowKeyAnswersFor, type SheetGraph, type SheetSpans } from "../../web/src/lib/sheetgraph.ts";
 import { UserError, round1, round2 } from "./format.ts";
 // Condition twins — the inheritance rule, shared with the canvas so a headless session and
 // the app can never disagree about what a twin holds (web/test/variants.test.ts).
@@ -2313,10 +2313,17 @@ export class Session {
     const graph = await this.ensureGraph();
     if (!graph.available) throw new UserError("This set has no text layer (a scan) — the sheet graph is unavailable, so schedule rows cannot be read.");
 
-    // 1. the row — the same tables resolve_tag / find_schedule read
-    const rowHits = graph.tables.flatMap((tb) => tb.rows.filter((r) => r.key === t).map((r) => ({ tb, r })));
+    // 1. the row — the same tables resolve_tag / find_schedule read. A
+    // schedule often keys one row for several marks ("R1 / E1" — same device,
+    // return vs exhaust service): that row ANSWERS for each mark, and the
+    // sweep runs on the mark as drawn on the plans, not the compound key.
+    const canonKey = (k: string) => (k || "").trim().toUpperCase().replace(/\s+/g, "");
+    const rowHits = graph.tables.flatMap((tb) => tb.rows.filter((r) => rowKeyAnswersFor(r.key, t)).map((r) => ({ tb, r })));
     if (!rowHits.length) {
-      const found = graph.tables.map((x) => `${x.kind} on ${x.sheet} (${x.rows.length} rows)`).join(" | ");
+      const found = graph.tables.map((x) => {
+        const keys = x.rows.map((row) => row.key).slice(0, 12).join(", ");
+        return `${x.kind} on ${x.sheet} (${x.rows.length} rows: ${keys}${x.rows.length > 12 ? ", …" : ""})`;
+      }).join(" | ");
       throw new UserError(`No schedule row "${t}" in the set — tables found: ${found || "none"}. Check the tag as drawn (find_schedule shows each table's region), or merge the schedule sheet in with load_plan.`);
     }
     if (rowHits.length > 1) {
@@ -2326,7 +2333,7 @@ export class Session {
     // sibling keys span EVERY table in the set, not just the row's own: a
     // marker labeled with any other schedule key is that mark's instance, and
     // disclosing it as "excluded, labeled 135" beats calling it unlabeled
-    const siblings = [...new Set(graph.tables.flatMap((x) => x.rows.map((row) => row.key)))].filter((k) => k !== t).sort();
+    const siblings = [...new Set(graph.tables.flatMap((x) => x.rows.flatMap((row) => canonKey(row.key).split("/").filter(Boolean))))].filter((k) => k !== t).sort();
     const table = tb.title?.text || `${tb.kind} schedule`;
 
     // 2. plan-role sheets, and every drawn occurrence of the tag on them
@@ -2406,6 +2413,12 @@ export class Session {
         if (e instanceof Error && /region, not one symbol/.test(e.message)) break;
         continue;
       }
+      // a degenerate grab is not a marker: one or two short strokes at the tag
+      // are its own underline/leader, which recur at EVERY tagged mark and
+      // "corroborate" trivially — matching on them counts tags' furniture, not
+      // devices. Widen instead; if no pad ever captures real marker geometry,
+      // the refusal below states it.
+      if (cand.segments < 3) continue;
       if (!corro) { fp = cand; anchorRect = rect; break; }
       const cr = this.sweepRatio(anchorSheet, corro.sh);
       let probe: SymbolMatchResult;

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -2169,7 +2169,7 @@ test("sweep_schedule_row refusals: unanchorable row, unknown row, ambiguous key 
   // an unknown key names what WAS found
   const zz = await call(client, "sweep_schedule_row", { tag: "ZZ" });
   assert.equal(zz.isError, true);
-  assert.match(zz.data.error, /No schedule row "ZZ" .* finish on symbol-set\.pdf#4 \(3 rows\)/);
+  assert.match(zz.data.error, /No schedule row "ZZ" .* finish on symbol-set\.pdf#4 \(3 rows: T1, T2, T9\)/);
 
   // the same key defined in two tables (the fixture merged in twice under a
   // second name) is ambiguous — refused, never a coin flip

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.56",
+  "version": "0.9.57",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.56",
+      "version": "0.9.57",
       "transport": {
         "type": "stdio"
       }

--- a/web/src/lib/sheetgraph.ts
+++ b/web/src/lib/sheetgraph.ts
@@ -58,7 +58,9 @@ const isVertical = (s: GraphSpan): boolean =>
 const SCHEDULE_TITLE_RE = /^[A-Z][A-Z ()/&.'’-]* SCHEDULE( *[-–] *[A-Z0-9 ()/&.'’-]+)?( *\(?(?:CONTINUATION|CONTINUED|CONT['’]?D?)\.?\)?)?$/;
 const ROLE_SIGNALS: Array<{ re: RegExp; role: SheetRole; conf: number }> = [
   { re: /DEMOLITION\s+PLAN|DEMO\s+PLAN/, role: "demolition", conf: 0.9 },
-  { re: /FINISH\s+PLAN|FLOOR\s+PLAN|FURNITURE\s+PLAN|CEILING\s+PLAN/, role: "plan", conf: 0.85 },
+  // every discipline draws plans, not just finishes — an M-sheet's "SECOND
+  // FLOOR DUCTWORK PLAN" is as much a plan title as an A-sheet's finish plan
+  { re: /(?:FINISH|FLOOR|FURNITURE|CEILING|DUCTWORK|PIPING|MECHANICAL|ELECTRICAL|LIGHTING|POWER|PLUMBING|SPRINKLER|HVAC|FRAMING|FOUNDATION|ROOF|SITE|EQUIPMENT)\s+PLAN\b/, role: "plan", conf: 0.85 },
   { re: SCHEDULE_TITLE_RE, role: "schedule", conf: 0.85 },
   { re: /SCHEDULE/, role: "schedule", conf: 0.5 },
   { re: /LEGEND/, role: "legend", conf: 0.5 },
@@ -77,9 +79,9 @@ export function classifySheetRole(sheet: SheetSpans): { role: SheetRole; confide
     for (const sig of ROLE_SIGNALS) if (sig.re.test(u)) { hits.push({ role: sig.role, conf: sig.conf, span: sp }); break; }
   }
   if (!hits.length) {
-    // sheet-number fallback: A-1xx is conventionally a plan — weak, stated as weak
+    // sheet-number fallback: <discipline>-1xx is conventionally a plan — weak, stated as weak
     const n = norm(sheet.sheet_number || "");
-    if (/^A-?1\d\d/.test(n)) return { role: "plan", confidence: 0.4, evidence: null };
+    if (/^(A|M|E|P|S|FP)-?1\d\d/.test(n)) return { role: "plan", confidence: 0.4, evidence: null };
     return { role: "unknown", confidence: 0, evidence: null };
   }
   // strongest signal wins; disagreement between DISTINCT roles halves confidence
@@ -590,13 +592,30 @@ export const isNonFinishSchedule = (title: string): boolean => {
 };
 
 function rowKeyOf(raw: string, kind: "room-finish" | "finish", buildings?: Set<string>): { key: string; building?: string } | null {
-  const key = norm(raw).replace(/[^A-Z0-9-]/g, "");
-  if (kind === "finish") return CODE_RE.test(key) ? { key } : null;
+  const kept = norm(raw).replace(/[^A-Z0-9/-]/g, "");
+  const key = kept.replace(/\//g, "");
+  if (kind === "finish") {
+    // a compound cell keys one row for several marks — "R1 / E1" is the same
+    // device scheduled for two services; keep the slash so the row can answer
+    // for each mark on its own (checked first: slash-stripped "R1E1" would
+    // otherwise pass CODE_RE and bury the compound)
+    const parts = kept.split("/").filter(Boolean);
+    if (parts.length > 1 && parts.every((p) => CODE_RE.test(p))) return { key: parts.join("/") };
+    return CODE_RE.test(key) ? { key } : null;
+  }
   if (ROW_KEY_RE.test(key)) return { key };
   const q = key.match(QUALIFIED_KEY_RE);
   if (q && buildings?.has(q[1])) return { key, building: q[1] };
   return null;
 }
+
+/** Does a schedule-row key answer for a mark? Exact, or one of a compound
+ * key's slash-separated parts ("R1/E1" answers for "R1" and for "E1"). */
+export const rowKeyAnswersFor = (key: string, want: string): boolean => {
+  const c = norm(key).replace(/\s+/g, "");
+  const w = norm(want).replace(/\s+/g, "");
+  return c === w || c.split("/").filter(Boolean).includes(w);
+};
 
 /** The number part of a row key — "A-134" and "134" both answer for 134. */
 const numOf = (key: string): string => key.match(QUALIFIED_KEY_RE)?.[2] ?? key;
@@ -1370,7 +1389,7 @@ export function resolveTag(graph: SheetGraph, tag: string): ResolveResult {
     const code = norm(cell.text).replace(/[^A-Z0-9-]/g, "");
     const fin: ResolvedFinish = { surface, code: cell.text.trim(), source: { sheet: r.sheet, text: cell.text.trim(), bbox: cell.bbox } };
     for (const ft of finTables) {
-      const def = ft.rows.find((fr) => norm(fr.key) === code);
+      const def = ft.rows.find((fr) => rowKeyAnswersFor(fr.key, code));
       if (def) {
         const cells: Record<string, string> = {};
         for (const [k, v] of Object.entries(def.cells)) cells[k] = v.text;

--- a/web/src/lib/sheets.ts
+++ b/web/src/lib/sheets.ts
@@ -29,6 +29,7 @@ interface TextItemLike {
   str?: string;
   transform: number[];
   height?: number;
+  width?: number;
 }
 interface TextContentLike {
   items: TextItemLike[];
@@ -86,16 +87,61 @@ export const STANDARD_SCALES: Scale[] = [
 const SHEET_NO_RE = /^[A-Z]{1,3}[-. ]?\d{1,3}(\.\d{1,2})?[A-Z]?$/;
 export function extractSheetNumber(textContent: TextContentLike, viewport: Viewport): string | null {
   const W = viewport.width, H = viewport.height;
-  let best: string | null = null, bestH = 0;
+
+  // CAD exports often split one drawn string into several glyph runs — "M-121A"
+  // arrives as "M" + "-" + "121A", and no single item matches the sheet-number
+  // shape while some other lone token (a sheet-issue row's "GMP-3") does. So
+  // collect the title-block region's items positioned, then test BOTH the
+  // singles and the baseline-joined runs; a join that isn't a sheet number
+  // simply fails the regex, so joining can only add candidates, never hide one.
+  type Placed = { raw: string; x: number; y: number; h: number; w: number };
+  const placed: Placed[] = [];
+  // pdf.js item.width is font-scaled user units — device width scales by the
+  // viewport scale alone, not the glyph transform
+  const vscale = Math.hypot(viewport.transform?.[0] ?? 1, viewport.transform?.[1] ?? 0) || 1;
   for (const it of textContent.items || []) {
     const raw = (it.str || "").trim().toUpperCase().replace(/\s+/g, "");
-    if (raw.length < 2 || raw.length > 8 || !SHEET_NO_RE.test(raw)) continue;
+    if (!raw) continue;
     const t = pdfjsLib.Util.transform(viewport.transform, it.transform);
     const x = t[4], y = t[5], h = Math.hypot(t[2], t[3]) || it.height || 0;
-    // title block lives lower-right; require it there and prefer the biggest text
+    // title block lives lower-right; require it there
     if (x < W * 0.60 || y < H * 0.55) continue;
+    const w = it.width != null ? it.width * vscale : raw.length * 0.62 * h; // gap math only
+    placed.push({ raw, x, y, h, w });
+  }
+
+  let best: string | null = null, bestScore = 0;
+  const consider = (raw: string, x: number, y: number, h: number) => {
+    if (raw.length < 2 || raw.length > 8 || !SHEET_NO_RE.test(raw)) return;
     const score = h + (x / W) * 4 + (y / H) * 4; // bigger + further to lower-right wins
-    if (score > bestH) { bestH = score; best = raw; }
+    if (score > bestScore) { bestScore = score; best = raw; }
+  };
+
+  for (const p of placed) consider(p.raw, p.x, p.y, p.h);
+
+  // group into baseline rows, join adjacent fragments, test the joined runs
+  const rows: Placed[][] = [];
+  for (const p of [...placed].sort((a, b) => a.y - b.y || a.x - b.x)) {
+    const row = rows[rows.length - 1];
+    if (row && Math.abs(p.y - row[0].y) <= Math.max(2, row[0].h * 0.35)) row.push(p);
+    else rows.push([p]);
+  }
+  for (const row of rows) {
+    row.sort((a, b) => a.x - b.x);
+    let run: Placed[] = [];
+    const flush = () => {
+      if (run.length > 1) {
+        const h = Math.max(...run.map((r) => r.h));
+        consider(run.map((r) => r.raw).join(""), run[0].x, run[0].y, h);
+      }
+      run = [];
+    };
+    for (const p of row) {
+      const prev = run[run.length - 1];
+      if (prev && p.x - (prev.x + prev.w) > Math.max(...run.map((r) => r.h)) * 1.2) flush();
+      run.push(p);
+    }
+    flush();
   }
   return best;
 }

--- a/web/test/sheetNumber.test.ts
+++ b/web/test/sheetNumber.test.ts
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractSheetNumber } from "../src/lib/sheets.ts";
+
+// Identity viewport: item transform [fs,0,0,fs,x,y] lands at (x,y) with glyph
+// height fs. Page is 1000×800; the title-block gate is x ≥ 600, y ≥ 440.
+const VP = { width: 1000, height: 800, transform: [1, 0, 0, 1, 0, 0] };
+const item = (str: string, x: number, y: number, fs: number, width?: number) => ({
+  str,
+  transform: [fs, 0, 0, fs, x, y],
+  ...(width != null ? { width } : {}),
+});
+
+test("an intact title-block number still wins", () => {
+  const tc = {
+    items: [
+      item("A-101", 920, 760, 30),
+      item("GMP-3", 880, 500, 8), // sheet-issue row: smaller, higher up
+      item("SCALE: 1/8\" = 1'-0\"", 700, 700, 10),
+    ],
+  };
+  assert.equal(extractSheetNumber(tc, VP), "A-101");
+});
+
+test("a sheet number split into glyph runs is joined and beats a lone lookalike", () => {
+  // the DocuSign-flattened Johnston County set: "M-121A" arrives as three runs
+  // while the sheet-issue table's "GMP-3" is one item — the bug read GMP-3
+  const tc = {
+    items: [
+      item("M", 920, 780, 28, 18),
+      item("-", 940, 780, 28, 8),
+      item("121A", 950, 780, 28, 70),
+      item("GMP-3", 880, 500, 8, 30),
+    ],
+  };
+  assert.equal(extractSheetNumber(tc, VP), "M-121A");
+});
+
+test("fragments far apart on a baseline do not join", () => {
+  // two tokens on one row separated by a column gap — the join must not
+  // manufacture a candidate from them (and neither matches alone)
+  const tc = {
+    items: [
+      item("121A", 700, 780, 10, 30),
+      item("M", 900, 780, 10, 8), // 170px gap ≫ 1.2 × glyph height
+    ],
+  };
+  assert.equal(extractSheetNumber(tc, VP), null);
+});
+
+test("no sheet-number-shaped text → null", () => {
+  const tc = { items: [item("SECOND FLOOR", 900, 760, 20)] };
+  assert.equal(extractSheetNumber(tc, VP), null);
+});

--- a/web/test/sheetgraph.test.ts
+++ b/web/test/sheetgraph.test.ts
@@ -9,7 +9,7 @@
 //   - schedule sheets never mint phantom room tags.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildSheetGraph, resolveTag, classifySheetRole, extractTable, roomTags, detailCallouts, revisionOf, type GraphSpan, type SheetSpans, type SheetGraph } from "../src/lib/sheetgraph.ts";
+import { buildSheetGraph, resolveTag, classifySheetRole, rowKeyAnswersFor, extractTable, roomTags, detailCallouts, revisionOf, type GraphSpan, type SheetSpans, type SheetGraph } from "../src/lib/sheetgraph.ts";
 
 // span builder: 8pt-tall text, width ~5px/char — the shape the MCP server serves
 const sp = (str: string, x: number, y: number): GraphSpan => ({ str, x, y, w: str.length * 5, h: 8 });
@@ -61,6 +61,27 @@ test("sheet roles classify from what the sheet SAYS, with evidence", () => {
   // titleless sheet falls back to the number convention — stated as weak
   const bare = classifySheetRole({ key: "x", sheet_number: "A-101", spans: [sp("nothing here", 0, 0)] });
   assert.deepEqual({ r: bare.role, weak: bare.confidence < 0.5 }, { r: "plan", weak: true });
+  // every discipline draws plans — a mechanical sheet's ductwork plan title
+  // must classify plan, not lose to an incidental LEGEND note
+  const mech = classifySheetRole({
+    key: "m", sheet_number: "M-121A",
+    spans: [sp("SECOND FLOOR DUCTWORK PLAN AREA A", 100, 700), sp("WALL RATING LEGEND:", 620, 640)],
+  });
+  assert.equal(mech.role, "plan");
+  assert.ok(mech.confidence >= 0.8);
+  // and the number-convention fallback knows discipline prefixes
+  const mBare = classifySheetRole({ key: "y", sheet_number: "M-101", spans: [sp("nothing here", 0, 0)] });
+  assert.deepEqual({ r: mBare.role, weak: mBare.confidence < 0.5 }, { r: "plan", weak: true });
+});
+
+test("a compound schedule-row key answers for each of its marks", () => {
+  assert.equal(rowKeyAnswersFor("R1/E1", "R1"), true);
+  assert.equal(rowKeyAnswersFor("R1/E1", "E1"), true);
+  assert.equal(rowKeyAnswersFor("R1/E1", "R1/E1"), true);
+  assert.equal(rowKeyAnswersFor("R1 / E1", "E1"), true);
+  assert.equal(rowKeyAnswersFor("R1/E1", "E2"), false);
+  assert.equal(rowKeyAnswersFor("S1", "S1"), true);
+  assert.equal(rowKeyAnswersFor("S1", "S"), false);
 });
 
 test("table extraction: header anchors, evidence per cell, titles found above", () => {


### PR DESCRIPTION
Three real-planset failures traced on one mechanical set (a flattened DocuSign export of a school's M-sheets), each fixed at its root, plus one honesty floor. Together they broke the entire one-gesture `sweep_schedule_row` path and misfiled the plan sheet.

**1. `extractSheetNumber` — glyph-run fragmentation.** CAD exports split one drawn string into runs: "M-121A" arrives as `M` + `-` + `121A`, no single item matches the sheet-number shape, and a lone lookalike ("GMP-3" in the sheet-issue table) won on *both* pages. Title-block items are now baseline-joined and the joined runs tested too — a join that isn't a sheet number fails the regex, so joining only ever adds candidates.

**2. `classifySheetRole` — plans beyond finishes.** The plan lane knew FINISH/FLOOR/FURNITURE/CEILING PLAN only; "SECOND FLOOR DUCTWORK PLAN AREA A" lost to an incidental "WALL RATING LEGEND:" note (legend @ 0.25) and the sheet was excluded from every set-wide sweep. The title signal now knows the discipline plans (ductwork, piping, electrical, lighting, plumbing, roof, site, framing, …) and the weak number-convention fallback accepts M/E/P/S/FP-1xx alongside A-1xx.

**3. Compound schedule-row keys.** "R1 / E1" (one device scheduled for two services) was slash-stripped to `R1E1` and answered for neither mark. The slash is kept, `rowKeyAnswersFor` lets a compound row answer for each part, sweep siblings expand to part keys, and the no-such-row refusal now discloses the keys the tables actually hold.

**4. Degenerate-fingerprint floor.** With roles fixed, the same set exposed a counting hazard: the pad ladder around a tag can grab exactly one short stroke — the tag's own underline — which recurs at every tagged mark, corroborates trivially, and swept 27 "R1" where the truth is 13. A fingerprint under 3 segments is now no fingerprint: widen the pad or refuse with the existing message. On tag-adjacent drawings the tool now refuses honestly instead of committing a confident wrong number.

Verified against the real set: sheet numbers M-121A/M-602 read correctly, M-121A classifies plan @ 0.85, R1/E1 rows resolve, and all four marks refuse with the symbol_sweep pointer rather than miscounting. Bundled demo plan unchanged (AF101/AF600, plan/schedule). `npm run check` green (1401 tests), mcp suite 173/173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)