### PR TITLE
Manage the plan set: bulk close, Clear workspace, and a page-count cache that opens a known set without reading it (#301, #302)

### DIFF
--- a/web/src/components/PlanNavigator.jsx
+++ b/web/src/components/PlanNavigator.jsx
@@ -53,6 +53,9 @@ export default function PlanNavigator({
   sheets, getDoc, scales, detectedScales, scaleUnconfirmed = {}, shapes, labels, onLabel, onDetect,
   thumbCacheRef, busyRef, openTabs, onOpen,
   onAddFiles, onClosePdf, onRemoveFromProject,
+  // manage mode (#301/#302): bulk close + workspace reset, and the persisted
+  // page-count cache that lets a known set open without reading its bytes
+  onCloseMany, onClearWorkspace, knownPages = {}, onPages,
   onCloseProject, onBrowseProjects,
   levels = {}, onAssignLevel,
   // stitches (#161): persisted match-line composites — created from a 2..MAX_GROUP
@@ -146,6 +149,11 @@ export default function PlanNavigator({
   const [driveErr, setDriveErr] = useState("");
   const [addMenu, setAddMenu] = useState(false);
   const [confirmClose, setConfirmClose] = useState(null);   // { file, shapeCount } | null
+  // ══ MANAGE state (#301) ═══════════════════════════════════════════════════
+  const [mSel, setMSel] = useState([]);            // file names checked in manage mode
+  const [confirmBulk, setConfirmBulk] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [working, setWorking] = useState(false);   // a bulk remove / clear in flight
   const [, bump] = useState(0);
   const seqRef = useRef(0);
   const queueRef = useRef([]);
@@ -176,24 +184,38 @@ export default function PlanNavigator({
       .finally(() => setDriveBusy(false));
   };
 
-  // enumerate: learn every file's page count through the shared doc cache
+  // enumerate page counts. The persisted cache answers a known file instantly —
+  // no byte read, no pdf.js doc — which is what lets a large plan set's gallery
+  // open without loading the set (#302). Only files the cache can't answer for
+  // load a doc here, and what they learn is reported up (onPages) so the NEXT
+  // open is instant too. Thumbnails stay scroll-lazy either way (the observer/
+  // pump below loads a doc only when a card actually becomes visible).
+  const pageOf = (name) => pages[name] !== undefined ? pages[name] : knownPages[name];
   useEffect(() => {
     const seq = ++seqRef.current;
     (async () => {
       for (const s of sheets) {
+        // truthy counts are settled; a 0 (unreadable last try) retries on the
+        // next sheets change, matching the old enumerate's healing behavior —
+        // a removed-and-re-added file must not stay hidden behind a stale 0
+        if (pageOf(s.name)) continue;
         try {
           const pdf = await getDoc(s.name);
           if (seq !== seqRef.current) return;
-          setPages((m) => (m[s.name] ? m : { ...m, [s.name]: pdf.numPages || 1 }));
+          const n = pdf.numPages || 1;
+          setPages((m) => (m[s.name] ? m : { ...m, [s.name]: n }));
+          onPages?.(s.name, n);
         } catch { if (seq === seqRef.current) setPages((m) => (m[s.name] !== undefined ? m : { ...m, [s.name]: 0 })); }
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return () => { seqRef.current++; };
-  }, [sheets, getDoc]);
+    // pageOf/onPages are stable per render pass — knownPages is the real signal
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sheets, getDoc, knownPages]);
 
   const allKeys = sheets.flatMap((s) => {
-    const n = pages[s.name];
+    const n = pageOf(s.name);
     if (!n) return [];
     return Array.from({ length: n }, (_, i) => (i ? `${s.name}#${i + 1}` : s.name));
   });
@@ -203,11 +225,11 @@ export default function PlanNavigator({
   // remount: reopening the gallery for a 1-sheet project would enumerate, auto-
   // open, and bounce straight back to the canvas — leaving Add plans / Browse
   // Drive permanently unreachable.
-  const enumerated = sheets.length > 0 && sheets.every((s) => pages[s.name] !== undefined);
+  const enumerated = sheets.length > 0 && sheets.every((s) => pageOf(s.name) !== undefined);
   useEffect(() => {
     if (mode === "plan" && enumerated && allKeys.length === 1 && openTabs.length === 0) onOpen([allKeys[0]], false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pages, mode]);
+  }, [pages, knownPages, mode]);
 
   const pump = async () => {
     if (pumpingRef.current) return;
@@ -288,14 +310,15 @@ export default function PlanNavigator({
       else setMode("plan");
       return;
     }
+    if (mode === "manage") { setMode("plan"); return; }
     if (canClose) onExit();
   }, [mode, path.length, canClose, onExit]);
-  const canGoBack = mode === "browse" || canClose;
-  // Esc: leave the current mode in one press (browse → plan, plan → canvas),
-  // independent of the back button's per-level folder climb.
+  const canGoBack = mode === "browse" || mode === "manage" || canClose;
+  // Esc: leave the current mode in one press (browse/manage → plan, plan →
+  // canvas), independent of the back button's per-level folder climb.
   useEffect(() => {
     escRef.current = () => {
-      if (mode === "browse") { setMode("plan"); return; }
+      if (mode === "browse" || mode === "manage") { setMode("plan"); return; }
       if (canClose) onExit();
     };
   }, [mode, canClose, onExit]);
@@ -314,10 +337,12 @@ export default function PlanNavigator({
   };
 
   // ══ RENDER ════════════════════════════════════════════════════════════════
-  const title = mode === "browse" ? "Add sheets from Drive" : "Plan set";
+  const title = mode === "browse" ? "Add sheets from Drive" : mode === "manage" ? "Manage plan set" : "Plan set";
   const subtitle = mode === "browse"
     ? "pick the PDFs to open — specs & as-builts stay unopened"
-    : `${allKeys.length || "…"} sheets · pick one or several — the order you pick is the left-to-right order`;
+    : mode === "manage"
+      ? `${sheets.length} PDF${sheets.length === 1 ? "" : "s"} stored in this workspace — remove what this takeoff doesn't need`
+      : `${allKeys.length || "…"} sheets · pick one or several — the order you pick is the left-to-right order`;
 
   const header = (
     <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 18px", borderBottom: "1px solid var(--ink)", background: "var(--paper-bright)", flexWrap: "wrap" }}>
@@ -370,6 +395,13 @@ export default function PlanNavigator({
             <option value="date">Modified</option>
           </select>
         </>
+      )}
+      {mode === "plan" && sheets.length > 0 && (onCloseMany || onClearWorkspace) && (
+        <button onClick={() => { setMSel([]); setMode("manage"); }}
+          title="Manage the plan set — remove several PDFs at once, or clear the whole workspace"
+          style={ctrlBtn}>
+          <Icon name="sheets" size={13} />Manage
+        </button>
       )}
       {mode === "plan" && onAddFiles && (
         <div style={{ position: "relative" }}>
@@ -633,6 +665,106 @@ export default function PlanNavigator({
     </>
   );
 
+  // ── MANAGE body + footer (#301) ─────────────────────────────────────────
+  // The bulk counterpart of the per-card ✕: pick several PDFs and remove them
+  // in one operation, or clear the whole workspace. Removal here is closePdf's
+  // semantics exactly — takeoffs persist in the project and restore on re-add —
+  // the row says which PDFs actually carry takeoffs so nothing is assumed unused.
+  const mToggle = (name) => setMSel((g) => (g.includes(name) ? g.filter((n) => n !== name) : [...g, name]));
+  const mAll = sheets.length > 0 && mSel.length === sheets.length;
+  const mSelShapes = mSel.reduce((n, f) => n + pdfShapeCount(f), 0);
+  const doBulkRemove = async () => {
+    setConfirmBulk(false); setWorking(true);
+    try { await onCloseMany(mSel); setMSel([]); setMode("plan"); }
+    finally { setWorking(false); }
+  };
+  const doClear = async () => {
+    setConfirmClear(false); setWorking(true);
+    try { await onClearWorkspace(); setMSel([]); setMode("plan"); }
+    finally { setWorking(false); }
+  };
+  const manageBody = (
+    <>
+      <div style={{ flex: 1, overflow: "auto" }}>
+        <label style={{ ...rowBase, cursor: "pointer", background: "var(--well)" }}>
+          <input name="manage-all" type="checkbox" checked={mAll} onChange={() => setMSel(mAll ? [] : sheets.map((s) => s.name))} style={{ width: 16, height: 16, cursor: "pointer" }} />
+          <span style={{ fontFamily: "var(--f-mono)", fontSize: 10.5, letterSpacing: "0.1em", textTransform: "uppercase", color: "var(--ink-muted)" }}>{mAll ? "Clear selection" : "Select all"}</span>
+        </label>
+        {sheets.map((s) => {
+          const pg = pageOf(s.name);
+          const cnt = pdfShapeCount(s.name);
+          const tabsOpen = openTabs.filter((k) => parseSheetKey(k).file === s.name).length;
+          return (
+            <label key={s.name} style={{ ...rowBase, cursor: "pointer" }}>
+              <input name="manage-pick" type="checkbox" checked={mSel.includes(s.name)} onChange={() => mToggle(s.name)} style={{ width: 16, height: 16, cursor: "pointer" }} />
+              <span style={{ fontFamily: "var(--f-mono)", fontSize: 13, color: "var(--ink)", flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={s.name}>{s.name}</span>
+              {tabsOpen > 0 && <span style={{ fontFamily: "var(--f-mono)", fontSize: 9.5, color: "var(--cobalt)", textTransform: "uppercase", letterSpacing: "0.08em" }}>{tabsOpen} open</span>}
+              <span style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--ink-muted)", minWidth: 74, textAlign: "right" }}>{pg !== undefined ? `${pg || "?"} sheet${pg === 1 ? "" : "s"}` : "…"}</span>
+              <span title={cnt ? "This PDF carries takeoffs — they persist in the project and restore if you re-add the same file" : undefined}
+                style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: cnt ? "var(--c-warning)" : "var(--text-faint)", minWidth: 88, textAlign: "right" }}>
+                {cnt ? `${cnt} takeoff${cnt === 1 ? "" : "s"}` : "no takeoffs"}
+              </span>
+            </label>
+          );
+        })}
+        {!sheets.length && (
+          <div style={{ padding: 40, textAlign: "center", color: "var(--ink-muted)", fontSize: 13 }}>The workspace is empty — nothing stored.</div>
+        )}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 18px", borderTop: "1px solid var(--ink)", background: "var(--paper-bright)", flexWrap: "wrap" }}>
+        <span style={{ fontFamily: "var(--f-mono)", fontSize: 11.5, color: "var(--ink-muted)" }}>
+          {working ? "Working…" : mSel.length ? `${mSel.length} PDF${mSel.length === 1 ? "" : "s"} selected${mSelShapes ? ` · ${mSelShapes} takeoff${mSelShapes === 1 ? "" : "s"} on them` : ""}` : "check the PDFs to remove — removing never deletes takeoff data"}
+        </span>
+        <div style={{ flex: 1 }} />
+        {onClearWorkspace && (
+          <button onClick={() => setConfirmClear(true)} disabled={working}
+            title="Remove every stored PDF and reset the takeoff — a snapshot of a non-empty takeoff is saved first (Revisions restores it)"
+            style={{ ...ctrlBtn, border: "1px solid var(--c-danger)", color: "var(--c-danger)", opacity: working ? 0.5 : 1 }}>Clear workspace…</button>
+        )}
+        <button onClick={() => setConfirmBulk(true)} disabled={!mSel.length || working}
+          style={{ display: "inline-flex", alignItems: "center", gap: 7, padding: "8px 16px", border: "1px solid var(--ink)", background: mSel.length && !working ? "var(--ink)" : "var(--ink-faint)", color: "var(--paper-bright)", cursor: mSel.length && !working ? "pointer" : "default", fontWeight: 700, fontSize: 13 }}>
+          Remove {mSel.length || ""} selected
+        </button>
+      </div>
+    </>
+  );
+
+  const bulkDialog = confirmBulk && (
+    <div onClick={() => setConfirmBulk(false)} style={{ position: "absolute", inset: 0, zIndex: 5, background: "var(--scrim)", display: "flex", alignItems: "center", justifyContent: "center", padding: 24 }}>
+      <div onClick={(e) => e.stopPropagation()} className="panel" style={{ width: 460, maxWidth: "100%", background: "var(--paper-bright)", boxShadow: "var(--shadow-2)", padding: "18px 20px" }}>
+        <strong style={{ fontFamily: "var(--f-display)", fontSize: 15, color: "var(--ink)" }}>Remove {mSel.length} PDF{mSel.length === 1 ? "" : "s"} from the plan set?</strong>
+        <p style={{ fontSize: 12.5, color: "var(--ink-muted)", lineHeight: 1.6, margin: "10px 0 4px" }}>
+          {cloudMode
+            ? "They stop loading in this plan set — the files stay in your Drive project and re-add any time from Browse Drive."
+            : "Their stored bytes are removed from this browser. Local plans aren't stored anywhere else, so you'd re-open the files to get them back."}
+          {mSelShapes > 0 && (
+            <><br /><span style={{ color: "var(--c-warning)" }}>{mSelShapes} takeoff{mSelShapes === 1 ? "" : "s"} live on these PDFs — they're preserved in the project and restore if you re-add the same files.</span></>
+          )}
+        </p>
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 16 }}>
+          <button onClick={() => setConfirmBulk(false)} style={{ ...ctrlBtn, color: "var(--ink-muted)" }}>Cancel</button>
+          <button onClick={doBulkRemove} style={{ ...ctrlBtn, border: "1px solid var(--ink)", background: "var(--ink)", color: "var(--paper-bright)", fontWeight: 700 }}>Remove {mSel.length}</button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const clearDialog = confirmClear && (
+    <div onClick={() => setConfirmClear(false)} style={{ position: "absolute", inset: 0, zIndex: 5, background: "var(--scrim)", display: "flex", alignItems: "center", justifyContent: "center", padding: 24 }}>
+      <div onClick={(e) => e.stopPropagation()} className="panel" style={{ width: 460, maxWidth: "100%", background: "var(--paper-bright)", boxShadow: "var(--shadow-2)", padding: "18px 20px" }}>
+        <strong style={{ fontFamily: "var(--f-display)", fontSize: 15, color: "var(--c-danger)" }}>Clear the whole workspace?</strong>
+        <p style={{ fontSize: 12.5, color: "var(--ink-muted)", lineHeight: 1.6, margin: "10px 0 4px" }}>
+          Every stored PDF ({sheets.length}) is removed and the takeoff resets to empty — a clean start without touching browser storage by hand.
+          <br /><span style={{ color: "var(--ink)" }}>A non-empty takeoff is snapshotted first</span> — Revisions → restore brings it back (you'd re-open the same PDFs to see its shapes). The PDFs themselves aren't stored anywhere else.
+        </p>
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 16 }}>
+          <button onClick={() => setConfirmClear(false)} style={{ ...ctrlBtn, color: "var(--ink-muted)" }}>Cancel</button>
+          <button onClick={doClear} style={{ ...ctrlBtn, border: "1px solid var(--c-danger)", background: "var(--c-danger)", color: "var(--paper-bright)", fontWeight: 700 }}>Clear workspace</button>
+        </div>
+      </div>
+    </div>
+  );
+
   // ── close/remove confirmation ───────────────────────────────────────────
   const confirmDialog = confirmClose && (
     <div onClick={() => setConfirmClose(null)} style={{ position: "absolute", inset: 0, zIndex: 5, background: "var(--scrim)", display: "flex", alignItems: "center", justifyContent: "center", padding: 24 }}>
@@ -670,8 +802,10 @@ export default function PlanNavigator({
         ? { position: "relative", width: "min(1100px, 92vw)", height: "85vh", display: "flex", flexDirection: "column", background: "var(--paper-cream)", boxShadow: "var(--shadow-2)", overflow: "hidden" }
         : { position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--paper-cream)" }}>
       {header}
-      {mode === "browse" ? browseBody : planBody}
+      {mode === "browse" ? browseBody : mode === "manage" ? manageBody : planBody}
       {confirmDialog}
+      {bulkDialog}
+      {clearDialog}
     </div>
   );
 

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -17,7 +17,7 @@ import { flushSync } from "react-dom";
 import { Link, useNavigate } from "react-router";
 import * as pdfjsLib from "pdfjs-dist";
 import workerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
-import { store, isStaleTabError, STALE_TAB_MESSAGE, projectIdFromUrl, ANN_SCHEMA } from "../lib/store.js";
+import { store, isStaleTabError, STALE_TAB_MESSAGE, projectIdFromUrl, ANN_SCHEMA, emptyAnnotations, metaGet, metaPut } from "../lib/store.js";
 import { Z } from "../lib/ui.js";
 import { getFocusMode, toggleFocusMode, onFocusModeChange } from "../lib/focusMode.js";
 import { seedStampLibrary, instantiateStamp, markupToStampElement } from "../lib/stamps.js";
@@ -1131,6 +1131,50 @@ export default function TakeoffCanvas() {
   // read at call time, so [] deps are correct.
   const pickerListFolder = useCallback((id) => store.listFolder(id), []);
   const pickerAddSheets = useCallback((items) => store.addSheets(items), []);
+  // ── page-count cache (#302) ────────────────────────────────────────────────
+  // The gallery used to learn every file's page count by loading its FULL bytes
+  // into a pdf.js doc the moment it opened — the one eager read left in an
+  // otherwise lazy pipeline (thumbnails render on scroll, the canvas rasters
+  // only open tabs). On a large plan set that read IS the sluggishness, so
+  // counts persist in the meta store once discovered and the gallery opens a
+  // known set without touching a byte of it. Keyed per project scope; entries
+  // drop on the only two paths that can change a file's pages — a revision
+  // (addPdf revised) and a removal — so the cache can't go stale.
+  const pageCacheKey = "sheet_pages:" + (projectIdFromUrl() || "local");
+  const [knownPages, setKnownPages] = useState({});
+  const knownPagesRef = useRef(knownPages);
+  useEffect(() => {
+    let off = false;
+    metaGet(pageCacheKey).then((m) => {
+      if (off || !m || typeof m !== "object") return;
+      knownPagesRef.current = m;
+      setKnownPages(m);
+    }).catch(() => {});
+    return () => { off = true; };
+  }, [pageCacheKey]);
+  const rememberPages = useCallback((name, count) => {
+    if (!Number.isFinite(count) || count < 1 || knownPagesRef.current[name] === count) return;
+    const next = { ...knownPagesRef.current, [name]: count };
+    knownPagesRef.current = next;
+    setKnownPages(next);
+    metaPut(pageCacheKey, next).catch(() => { /* cache only — rediscovered next open */ });
+  }, [pageCacheKey]);
+  const forgetPages = useCallback((names) => {
+    const next = { ...knownPagesRef.current };
+    let hit = false;
+    for (const n of names) if (n in next) { delete next[n]; hit = true; }
+    if (!hit) return;
+    knownPagesRef.current = next;
+    setKnownPages(next);
+    metaPut(pageCacheKey, next).catch(() => {});
+  }, [pageCacheKey]);
+  // Free a departing file's pdf.js worker doc — the doc cache is deliberately
+  // long-lived (thumbnails + reopen speed), but a file that LEFT the working
+  // set would otherwise hold worker memory for the rest of the session (#302).
+  const evictDoc = useCallback((name) => {
+    const t = pdfDocsRef.current.get(name);
+    if (t) { t.then((task) => { try { task.destroy(); } catch { /* already gone */ } }).catch(() => {}); pdfDocsRef.current.delete(name); }
+  }, []);
   // Reconcile the canvas after a PDF leaves the working set. For a non-empty
   // result the [sheets] effect already prunes openTabs/sheetGroup, but it can't:
   //   • fix `active` when the CLOSED pdf was the one on screen (it never resets
@@ -1151,8 +1195,21 @@ export default function TakeoffCanvas() {
   // Shapes on the closed sheets persist in annotations and restore on re-add.
   const closePdf = useCallback(async (name) => {
     await store.removePdf(name);
+    evictDoc(name);
+    forgetPages([name]);
     reconcileAfterRemoval(name, await refreshSheets());
-  }, [refreshSheets, reconcileAfterRemoval]);
+  }, [refreshSheets, reconcileAfterRemoval, evictDoc, forgetPages]);
+  // Bulk close (#301): one pass over the manage-mode selection, ONE refresh and
+  // reconcile at the end. Per-file semantics are exactly closePdf's — shapes
+  // persist in annotations and restore if the same file is re-added.
+  const closePdfs = useCallback(async (names) => {
+    if (!names.length) return;
+    for (const n of names) { await store.removePdf(n); evictDoc(n); }
+    forgetPages(names);
+    const list = await refreshSheets();
+    reconcileAfterRemoval(names.includes(active) ? active : "", list);
+    setCommitMsg(`Removed ${names.length} PDF${names.length === 1 ? "" : "s"} from the plan set — takeoffs on them stay in the project and restore on re-add.`);
+  }, [refreshSheets, reconcileAfterRemoval, evictDoc, forgetPages, active]);
   // Remove-from-project (cloud only): the DESTRUCTIVE variant — delete the Drive
   // file, then drop it from the working set.
   const removeFromProject = useCallback(async (name) => {
@@ -1184,10 +1241,10 @@ export default function TakeoffCanvas() {
     // must re-key so the new revision actually reaches the screen.
     const revised = results.filter((r) => r?.revised);
     if (revised.length) {
-      for (const r of revised) {
-        const t = pdfDocsRef.current.get(r.name);
-        if (t) { t.then((task) => { try { task.destroy(); } catch { /* already gone */ } }).catch(() => {}); pdfDocsRef.current.delete(r.name); }
-      }
+      for (const r of revised) evictDoc(r.name);
+      // a revision can change the page count — drop the cached counts so the
+      // gallery re-learns them from the new bytes (#302)
+      forgetPages(revised.map((r) => r.name));
       setDocEpoch((e) => e + 1);
     }
     const names = pdfs.map((f) => f.name);
@@ -1543,6 +1600,10 @@ export default function TakeoffCanvas() {
     let t = pdfDocsRef.current.get(file);
     if (!t) {
       t = store.loadPdfData(file).then((data) => pdfjsLib.getDocument({ data }));
+      // never cache a FAILED load: a file removed and re-added under the same
+      // name (Manage → remove, then re-open) would otherwise pin the removal-
+      // race rejection for the life of the view and refuse to ever render
+      t.catch(() => { if (pdfDocsRef.current.get(file) === t) pdfDocsRef.current.delete(file); });
       pdfDocsRef.current.set(file, t);
     }
     return t.then((task) => task.promise);
@@ -2005,6 +2066,32 @@ export default function TakeoffCanvas() {
     downloadText(`${base}.takeoff.json`, JSON.stringify(payload, null, 2), "application/json");
     const n = shapes.length;
     setCommitMsg(`Exported ${base}.takeoff.json — ${n} takeoff${n === 1 ? "" : "s"}, ${conditions.length} condition${conditions.length === 1 ? "" : "s"}. The plan PDF isn't in it: to restore, open the same PDF, then Import takeoff.`);
+  };
+
+  // "Clear workspace" (#301) — the deliberate start-fresh: every stored PDF
+  // goes and the takeoff resets to empty, without touching browser storage by
+  // hand. Local mode only (a cloud project's canon lives in Drive — Close
+  // project is that mode's exit). Commit before risk: a non-empty takeoff is
+  // snapshotted first, so the work is one Revisions-panel restore away — the
+  // PDFs themselves are gone either way (local plans aren't stored elsewhere);
+  // restored shapes re-attach by sheet name when the same files are re-opened.
+  const clearWorkspace = async () => {
+    const names = sheets.map((s) => s.name);
+    let saved = false;
+    if (shapes.length || conditions.length || markups.length) {
+      try { await store.saveSnapshot(`Before Clear workspace — ${new Date().toLocaleString()}`, buildPayload()); saved = true; }
+      catch { /* best-effort (quota) — clearing continues; message says what happened */ }
+    }
+    for (const n of names) { try { await store.removePdf(n); } catch { /* already gone */ } evictDoc(n); }
+    forgetPages(names);
+    thumbCacheRef.current.clear();
+    setGalleryLabels({});
+    setDetectedScales({});
+    reconcileAfterRemoval("", await refreshSheets());
+    restoreSavedPayload(emptyAnnotations());
+    setCommitMsg(saved
+      ? `Workspace cleared — ${names.length} PDF${names.length === 1 ? "" : "s"} removed. The takeoff was snapshotted first: Revisions → restore brings it back (re-open the same PDFs to see its shapes).`
+      : `Workspace cleared — ${names.length} PDF${names.length === 1 ? "" : "s"} removed.`);
   };
 
   // markups MUST be in the deps (a cloud/callout/text or an RFI link is real work);
@@ -8063,6 +8150,9 @@ export default function TakeoffCanvas() {
             return next;
           })}
           onClosePdf={closePdf}
+          onCloseMany={closePdfs}
+          onClearWorkspace={cloudMode ? undefined : clearWorkspace}
+          knownPages={knownPages} onPages={rememberPages}
           onRemoveFromProject={cloudMode ? removeFromProject : undefined}
           onCloseProject={cloudMode ? closeProject : undefined}
           onBrowseProjects={cloudMode ? browseProjects : undefined}


### PR DESCRIPTION
Manage mode in the PlanNavigator: per-PDF rows (pages, open tabs, takeoff
count), multi-select removal with closePdf's shape-preserving semantics, and
a local-mode Clear workspace that snapshots a non-empty takeoff first so the
work is one Revisions restore away.

Page counts persist in the meta store once discovered (scoped per project),
so a known plan set's gallery opens without loading a byte of it — counts
drop on the only two paths that can change them (revision, removal).
Removing a PDF now also frees its pdf.js worker doc, and docFor no longer
caches a FAILED load: a file removed and re-added under the same name used
to pin the removal-race rejection for the life of the view and refuse to
render.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
