### PR TITLE
Project archive (.otk): the whole job as one portable file (#300)

### DIFF
--- a/web/src/components/PlanNavigator.jsx
+++ b/web/src/components/PlanNavigator.jsx
@@ -426,7 +426,7 @@ export default function PlanNavigator({
         </div>
       )}
       {onAddFiles && (
-        <input name="sheet-file" ref={fileRef} type="file" accept=".pdf,application/pdf,image/*,.zip,application/zip,application/x-zip-compressed" multiple style={{ display: "none" }}
+        <input name="sheet-file" ref={fileRef} type="file" accept=".pdf,application/pdf,image/*,.zip,application/zip,application/x-zip-compressed,.otk" multiple style={{ display: "none" }}
           onChange={(e) => { onAddFiles(e.target.files); e.target.value = ""; }} />
       )}
       <AuthChip />

--- a/web/src/lib/projectArchive.js
+++ b/web/src/lib/projectArchive.js
@@ -1,0 +1,125 @@
+// Project archive (.otk) — the whole job as ONE portable file (#300).
+//
+// "Export takeoff…" (#285) deliberately writes the annotation record alone; the
+// fair follow-up ask was a self-contained bundle that carries the plans too, so
+// a job can be archived, moved to another machine, or handed to another
+// estimator without hunting down the original PDFs. This is that bundle:
+//
+//   project.otk  =  zip {
+//     opentakeoff.project.json   — versioned manifest + the EXACT autosave
+//                                  payload (takeoff_canvas.v1, no export-only
+//                                  shape), same document Export takeoff writes
+//     plans/<file>.pdf           — every stored plan, bytes verbatim
+//   }
+//
+// Plans are stored at compression level 0 — PDF streams are already deflated,
+// so recompressing a 500 MB set buys nothing and costs the whole export wait.
+// The manifest is tiny and compresses normally.
+//
+// Versioned by `schema`: readers refuse unknown MAJOR shapes loudly instead of
+// half-loading them. Additive fields ride on the manifest without a bump, the
+// same convention as the annotations payload itself.
+//
+// fflate is imported on demand (the ingest precedent) so the archive machinery
+// never weighs down the initial page load.
+
+const MANIFEST_NAME = "opentakeoff.project.json";
+const ARCHIVE_SCHEMA = "opentakeoff.project_archive.v1";
+const PLANS_DIR = "plans/";
+
+// The same hostile-archive budgets as ingest.js — a .otk is still a zip a
+// browser tab has to inflate. Sizes read from the central directory (see
+// ingest.js's unzipBytes comment for why that bounds a real bomb).
+const MAX_TOTAL_BYTES = 2 * 1024 * 1024 * 1024;
+const MAX_TOTAL_ENTRIES = 10_000;
+
+export function isProjectArchive(name) {
+  return /\.otk$/i.test(name || "");
+}
+
+/**
+ * Pack the current project into .otk bytes.
+ * @param {{
+ *   takeoff: object,                          // { schema, ...buildPayload() } — written verbatim
+ *   sheets: { name: string }[],               // the working set (store.listSheets shape)
+ *   loadPdfData: (name: string) => Promise<Uint8Array>,
+ *   projectName?: string,
+ *   onProgress?: (msg: string) => void,
+ * }} opts
+ * @returns {Promise<Uint8Array>}
+ */
+export async function buildProjectArchive({ takeoff, sheets, loadPdfData, projectName, onProgress }) {
+  const { zip, strToU8 } = await import("fflate");
+  const entries = {};
+  const packed = [];
+  for (const s of sheets) {
+    onProgress?.(`Packing ${s.name}…`);
+    const bytes = await loadPdfData(s.name);
+    entries[PLANS_DIR + s.name] = [bytes, { level: 0 }];
+    packed.push(s.name);
+  }
+  const manifest = {
+    schema: ARCHIVE_SCHEMA,
+    app: "opentakeoff",
+    created: new Date().toISOString(),
+    ...(projectName ? { project_name: projectName } : {}),
+    plans: packed,
+    takeoff,
+  };
+  entries[MANIFEST_NAME] = [strToU8(JSON.stringify(manifest, null, 2)), { level: 6 }];
+  onProgress?.("Writing archive…");
+  return new Promise((resolve, reject) => zip(entries, {}, (err, data) => (err ? reject(err) : resolve(data))));
+}
+
+/**
+ * Read .otk bytes back into { takeoff, pdfs, projectName }. Throws a
+ * "Couldn't open project…" error (the sticky-danger copy convention) on
+ * anything that isn't a well-formed v1 archive.
+ * @param {Uint8Array} bytes
+ * @returns {Promise<{ takeoff: object, pdfs: File[], projectName: string }>}
+ */
+export async function parseProjectArchive(bytes) {
+  const { unzip, strFromU8 } = await import("fflate");
+  const budget = { bytes: MAX_TOTAL_BYTES, entries: MAX_TOTAL_ENTRIES };
+  const entries = await new Promise((resolve, reject) => {
+    unzip(bytes, {
+      filter: (f) => {
+        if (budget.entries <= 0) return false;
+        const size = f.originalSize || 0;
+        if (size > budget.bytes) return false;
+        budget.bytes -= size;
+        budget.entries -= 1;
+        return f.name === MANIFEST_NAME || (f.name.startsWith(PLANS_DIR) && /\.pdf$/i.test(f.name));
+      },
+    }, (err, data) => (err ? reject(err) : resolve(data)));
+  });
+  const raw = entries[MANIFEST_NAME];
+  if (!raw) throw new Error(`Couldn't open project: no ${MANIFEST_NAME} inside — this isn't an OpenTakeoff project archive.`);
+  let manifest;
+  try { manifest = JSON.parse(strFromU8(raw)); }
+  catch { throw new Error("Couldn't open project: the archive's manifest isn't valid JSON."); }
+  if (manifest?.schema !== ARCHIVE_SCHEMA) {
+    // refuse loudly rather than half-load: a FUTURE major shape may relocate
+    // load-bearing data, and "opened but empty" is worse than a clear refusal
+    throw new Error(`Couldn't open project: archive version "${manifest?.schema || "unknown"}" — this build reads ${ARCHIVE_SCHEMA}. Update OpenTakeoff and try again.`);
+  }
+  const takeoff = manifest.takeoff;
+  if (!takeoff || typeof takeoff !== "object" || Array.isArray(takeoff)) {
+    throw new Error("Couldn't open project: the archive carries no takeoff document.");
+  }
+  const pdfs = Object.entries(entries)
+    .filter(([path]) => path.startsWith(PLANS_DIR))
+    .map(([path, data]) => new File([data], path.slice(PLANS_DIR.length), { type: "application/pdf" }))
+    .filter((f) => f.name);
+  return { takeoff, pdfs, projectName: typeof manifest.project_name === "string" ? manifest.project_name : "" };
+}
+
+/** Browser download of archive bytes (the downloadText pattern, binary-safe). */
+export function downloadArchive(filename, bytes) {
+  const blob = new Blob([bytes], { type: "application/zip" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url; a.download = filename;
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -25,6 +25,7 @@ import { extractSvgPrimitives, svgToStamp } from "../lib/svgImport.js";
 import { transformPath, svgPlacedBox } from "../lib/svgpath.js";
 import { ingestFiles } from "../lib/ingest.js";
 import { parseTakeoffImport, mergeTakeoffImport } from "../lib/importTakeoff.js";
+import { buildProjectArchive, parseProjectArchive, isProjectArchive, downloadArchive } from "../lib/projectArchive.js";
 import ToolMenu from "../components/ToolMenu.jsx";
 import PlanNavigator from "../components/PlanNavigator.jsx";
 import ReportPanel from "../components/ReportPanel.jsx";
@@ -1222,6 +1223,14 @@ export default function TakeoffCanvas() {
   async function handleFiles(fileList) {
     const incoming = Array.from(fileList || []);
     if (!incoming.length) return;
+    // a dropped .otk is a PROJECT, not a plan — it replaces the workspace
+    // (snapshot first) instead of joining the plan set (#300)
+    const otk = incoming.find((f) => isProjectArchive(f.name));
+    if (otk) {
+      await importProjectArchive(otk);
+      if (incoming.length > 1) setCommitMsg((m) => `${m} Other dropped files were ignored — open plans separately from a project archive.`);
+      return;
+    }
     setCommitMsg("Reading files…");
     let pdfs = [], skipped = [];
     try { ({ pdfs, skipped } = await ingestFiles(incoming, { onProgress: setCommitMsg })); }
@@ -2092,6 +2101,55 @@ export default function TakeoffCanvas() {
     setCommitMsg(saved
       ? `Workspace cleared — ${names.length} PDF${names.length === 1 ? "" : "s"} removed. The takeoff was snapshotted first: Revisions → restore brings it back (re-open the same PDFs to see its shapes).`
       : `Workspace cleared — ${names.length} PDF${names.length === 1 ? "" : "s"} removed.`);
+  };
+
+  // "Export project archive…" (#300) — the whole job as ONE portable .otk:
+  // every stored plan's bytes plus the exact autosave payload. The other half
+  // of the #285 pair: Export takeoff is the annotation record alone (open the
+  // same PDF to restore); this is the archive that carries its own paper.
+  const exportProjectArchive = async () => {
+    if (!sheets.length) { setCommitMsg("Couldn't export project: no plans are open."); return; }
+    const base = (projectName || "project").trim().replace(/[^\w.\- ]+/g, "").replace(/\s+/g, "-").replace(/^[-.]+|[-.]+$/g, "") || "project";
+    try {
+      const data = await buildProjectArchive({
+        takeoff: { schema: ANN_SCHEMA, ...buildPayload() },
+        sheets,
+        loadPdfData: (n) => store.loadPdfData(n),
+        projectName,
+        onProgress: setCommitMsg,
+      });
+      downloadArchive(`${base}.otk`, data);
+      setCommitMsg(`Exported ${base}.otk — ${sheets.length} PDF${sheets.length === 1 ? "" : "s"} + the full takeoff (${shapes.length} shape${shapes.length === 1 ? "" : "s"}). Self-contained: open it on any machine, or hand it to another estimator.`);
+    } catch (e) {
+      setCommitMsg(`Couldn't export project: ${e?.message || e}`);
+    }
+  };
+
+  // Open a .otk (drop or file picker): REPLACE the workspace with the archived
+  // project. Commit before risk — the current takeoff, if non-empty, is
+  // snapshotted first so opening an archive is never a silent overwrite.
+  const importProjectArchive = async (file) => {
+    try {
+      setCommitMsg(`Opening ${file.name}…`);
+      const { takeoff, pdfs } = await parseProjectArchive(new Uint8Array(await file.arrayBuffer()));
+      if (shapes.length || conditions.length || markups.length) {
+        try { await store.saveSnapshot(`Before opening ${file.name} — ${new Date().toLocaleString()}`, buildPayload()); }
+        catch { /* best-effort — the open continues; archives are additive to PDFs */ }
+      }
+      for (const f of pdfs) {
+        setCommitMsg(`Restoring ${f.name}…`);
+        await store.addPdf(f);        // same-name different-bytes archives a revision (CO-1), never a silent overwrite
+        evictDoc(f.name);             // stale docs must re-read the restored bytes
+      }
+      forgetPages(pdfs.map((f) => f.name));
+      setDocEpoch((e) => e + 1);
+      await refreshSheets();
+      restoreSavedPayload(takeoff);
+      const n = Array.isArray(takeoff.shapes) ? takeoff.shapes.length : 0;
+      setCommitMsg(`Opened ${file.name} — ${pdfs.length} PDF${pdfs.length === 1 ? "" : "s"}, ${n} takeoff${n === 1 ? "" : "s"}.${shapes.length || conditions.length ? " Your previous takeoff was snapshotted — Revisions restores it." : ""}`);
+    } catch (e) {
+      setCommitMsg(String(e?.message || "").startsWith("Couldn't") ? e.message : `Couldn't open project: ${e?.message || e}`);
+    }
   };
 
   // markups MUST be in the deps (a cloud/callout/text or an RFI link is real work);
@@ -6341,6 +6399,11 @@ export default function TakeoffCanvas() {
     title: "Load a takeoff JSON — the app's own export or an agent session's export_takeoff. Machine shapes land dashed in their condition colors for your review; on merge, your calibration, conditions, and workspace win.",
     onSelect: () => importInputRef.current?.click(),
   });
+  sheetMenuItems.push({
+    id: "export-project", icon: "document", label: "Export project archive…",
+    title: "Save the WHOLE job as one portable .otk file — every plan PDF plus the full takeoff. Open it on any machine (drop it like a plan, or Add plans), archive it, or hand it to another estimator; unlike Export takeoff, the plans travel inside.",
+    onSelect: exportProjectArchive,
+  });
 
   // deck-2 scale chip — the four scale controls collapsed to one status face:
   // red dashed = unset ("you can't trace yet"), green = set, warning = the
@@ -6489,7 +6552,7 @@ export default function TakeoffCanvas() {
       style={{ position: "relative", display: "flex", flexDirection: "column", height: "100vh" }}>
       {/* file inputs — always mounted (drag-drop and the ⋯ import path need
           the refs even while focus mode hides the bar) */}
-      <input name="sheet-file" ref={fileInputRef} type="file" accept=".pdf,application/pdf,image/*,.zip,application/zip,application/x-zip-compressed" multiple style={{ display: "none" }}
+      <input name="sheet-file" ref={fileInputRef} type="file" accept=".pdf,application/pdf,image/*,.zip,application/zip,application/x-zip-compressed,.otk" multiple style={{ display: "none" }}
         onChange={(e) => { handleFiles(e.target.files); e.target.value = ""; }} />
       <input name="takeoff-import" ref={importInputRef} type="file" accept=".json,application/json" style={{ display: "none" }}
         onChange={(e) => { importTakeoffFile(e.target.files?.[0]); e.target.value = ""; }} />

--- a/web/test/projectArchive.test.ts
+++ b/web/test/projectArchive.test.ts
@@ -1,0 +1,82 @@
+// Project archive (.otk) round-trip — pure zip/manifest machinery (#300), so it
+// runs straight under node. Run with: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildProjectArchive, parseProjectArchive, isProjectArchive } from "../src/lib/projectArchive.js";
+
+const enc = new TextEncoder();
+
+// deterministic fake plan bytes — content only matters for byte-equality
+const planBytes = (tag: string) => enc.encode(`%PDF-1.4 fake ${tag}`);
+
+const TAKEOFF = {
+  schema: "opentakeoff.takeoff_canvas.v1",
+  project_name: "School Renovation",
+  conditions: [{ id: "c1", finish_tag: "CPT-1" }],
+  shapes: [{ id: "s1", sheet_id: "A1.pdf", pts: [[0, 0], [1, 0], [1, 1]] }],
+  markups: [],
+  sheets: [{ sheet_id: "A1.pdf", units_per_px: 0.125 }],
+};
+
+async function buildFixture() {
+  return buildProjectArchive({
+    takeoff: TAKEOFF,
+    sheets: [{ name: "A1.pdf" }, { name: "S1.0 plan.pdf" }],
+    loadPdfData: async (name: string) => planBytes(name),
+    projectName: "School Renovation",
+  });
+}
+
+test("otk: extension detection", () => {
+  assert.equal(isProjectArchive("School-Renovation.otk"), true);
+  assert.equal(isProjectArchive("School-Renovation.OTK"), true);
+  assert.equal(isProjectArchive("plans.zip"), false);
+  assert.equal(isProjectArchive(""), false);
+});
+
+test("otk: build → parse round-trips the takeoff verbatim and every plan's bytes", async () => {
+  const bytes = await buildFixture();
+  const { takeoff, pdfs, projectName } = await parseProjectArchive(bytes);
+  // the takeoff document is the EXACT payload in, not an export-only reshaping
+  assert.deepEqual(takeoff, TAKEOFF);
+  assert.equal(projectName, "School Renovation");
+  assert.deepEqual(pdfs.map((f) => f.name).sort(), ["A1.pdf", "S1.0 plan.pdf"]);
+  for (const f of pdfs) {
+    const got = new Uint8Array(await f.arrayBuffer());
+    assert.deepEqual(got, planBytes(f.name), `bytes of ${f.name} survive the round trip`);
+  }
+});
+
+test("otk: refuses a zip with no manifest (a plain plan-set zip is not a project)", async () => {
+  const { zipSync, strToU8 } = await import("fflate");
+  const plain = zipSync({ "plans/A1.pdf": strToU8("%PDF-1.4") });
+  await assert.rejects(() => parseProjectArchive(plain), /isn't an OpenTakeoff project archive/);
+});
+
+test("otk: refuses an unknown archive schema loudly instead of half-loading", async () => {
+  const { zipSync, strToU8 } = await import("fflate");
+  const future = zipSync({
+    "opentakeoff.project.json": strToU8(JSON.stringify({ schema: "opentakeoff.project_archive.v9", takeoff: {} })),
+  });
+  await assert.rejects(() => parseProjectArchive(future), /archive version/);
+});
+
+test("otk: refuses a manifest with no takeoff document", async () => {
+  const { zipSync, strToU8 } = await import("fflate");
+  const hollow = zipSync({
+    "opentakeoff.project.json": strToU8(JSON.stringify({ schema: "opentakeoff.project_archive.v1", plans: [] })),
+  });
+  await assert.rejects(() => parseProjectArchive(hollow), /no takeoff document/);
+});
+
+test("otk: ignores non-plan entries smuggled into the archive", async () => {
+  const { zipSync, strToU8 } = await import("fflate");
+  const mixed = zipSync({
+    "opentakeoff.project.json": strToU8(JSON.stringify({ schema: "opentakeoff.project_archive.v1", takeoff: { schema: "x", shapes: [] } })),
+    "plans/A1.pdf": strToU8("%PDF-1.4"),
+    "plans/evil.html": strToU8("<script>"),
+    "unrelated.txt": strToU8("junk"),
+  });
+  const { pdfs } = await parseProjectArchive(mixed);
+  assert.deepEqual(pdfs.map((f) => f.name), ["A1.pdf"]);
+});


### PR DESCRIPTION
Export project archive… packs every stored plan's bytes (level 0 — PDF
streams are already deflated) plus the EXACT autosave payload into a
versioned zip manifest; dropping a .otk (or picking it from Add plans)
replaces the workspace with the archived project. Commit before risk: a
non-empty takeoff is snapshotted before the replace, and same-name
different-bytes plans archive a revision (CO-1), never a silent overwrite.
Readers refuse unknown archive schemas loudly instead of half-loading.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
