### PR TITLE
Estimator profile (.otprofile): export, import, and reset the working environment (#299)

### DIFF
--- a/web/src/lib/profile.js
+++ b/web/src/lib/profile.js
@@ -1,0 +1,114 @@
+// Estimator profile (.otprofile) — the working environment as ONE portable
+// file (#299): who am I and how do I have OpenTakeoff configured, as opposed
+// to what job am I on (that's the project — annotations payload / .otk).
+//
+// Scope v1 — exactly the browser-global, cross-project records:
+//   condition_templates   meta store   (store.loadTemplates)
+//   material_library      meta store   (store.loadMaterialLibrary)
+//   stamp_library         meta store   (store.loadStampLibrary)
+//   report_templates      localStorage (lib/reportTemplates.js)
+//   report_theme          localStorage (lib/reportTheme.js — the RAW file, so
+//                                       re-parsing always reflects the import)
+//   report_cols/groupby   localStorage (lib/reportColumns.js)
+//
+// Project data (shapes, conditions in the payload, scales, markups) is
+// deliberately NOT here — switching profiles must never touch a takeoff.
+//
+// Apply is REPLACE, not merge, and every incoming list rides the same
+// sanitize gate its store-load path uses, so a hand-edited or hostile file
+// degrades to empty sections instead of wedging every project's hydrate.
+// Versioned like the project archive: unknown MAJOR schemas refuse loudly.
+
+import { store } from "./store.js";
+import { sanitizeTemplates } from "./templates.js";
+import { sanitizeMaterialLibrary } from "./materials.js";
+import { sanitizeStampLibrary, seedStampLibrary } from "./stamps.js";
+import { loadTemplates as loadReportTemplates, overwriteTemplates as overwriteReportTemplates, sanitizeTemplates as sanitizeReportTemplates } from "./reportTemplates.js";
+import { activeThemeFileRaw, saveActiveThemeFile, clearActiveTheme } from "./reportTheme.js";
+import { loadColPrefs, saveColPrefs, loadGroupBy, saveGroupBy } from "./reportColumns.js";
+
+export const PROFILE_SCHEMA = "opentakeoff.profile.v1";
+
+export function isProfileFile(name) {
+  return /\.otprofile$/i.test(name || "");
+}
+
+/** Gather the whole working environment into one plain object. */
+export async function buildProfile(name) {
+  const [templates, materials, stamps] = await Promise.all([
+    store.loadTemplates().catch(() => []),
+    store.loadMaterialLibrary().catch(() => []),
+    store.loadStampLibrary().catch(() => ({ stamps: [], sets: [] })),
+  ]);
+  let theme = null;
+  try { const raw = activeThemeFileRaw(); theme = raw ? JSON.parse(raw) : null; } catch { theme = null; }
+  return {
+    schema: PROFILE_SCHEMA,
+    app: "opentakeoff",
+    created: new Date().toISOString(),
+    ...(name ? { name } : {}),
+    condition_templates: templates,
+    material_library: materials,
+    stamp_library: stamps,
+    report_templates: loadReportTemplates(),
+    ...(theme ? { report_theme: theme } : {}),
+    report_cols: loadColPrefs(),
+    report_groupby: loadGroupBy(),
+  };
+}
+
+/**
+ * Parse profile-file text. Throws "Couldn't apply profile…" on anything that
+ * isn't a well-formed v1 profile.
+ */
+export function parseProfile(text) {
+  let p;
+  try { p = JSON.parse(text); }
+  catch { throw new Error("Couldn't apply profile: the file isn't valid JSON."); }
+  if (!p || typeof p !== "object" || Array.isArray(p)) throw new Error("Couldn't apply profile: not a profile file.");
+  if (p.schema !== PROFILE_SCHEMA) {
+    throw new Error(`Couldn't apply profile: version "${p.schema || "unknown"}" — this build reads ${PROFILE_SCHEMA}. Update OpenTakeoff and try again.`);
+  }
+  return p;
+}
+
+/**
+ * REPLACE the working environment with a parsed profile. Each section rides
+ * its own sanitize gate; absent sections clear to their defaults, so applying
+ * a profile always lands the full, self-consistent environment it describes.
+ * @returns {{ templates: number, materials: number, stamps: number, reportTemplates: number }} counts for the receipt line
+ */
+export async function applyProfile(p) {
+  const templates = sanitizeTemplates(p.condition_templates);
+  const materials = sanitizeMaterialLibrary(p.material_library);
+  const stamps = sanitizeStampLibrary(p.stamp_library);
+  const reportTemplates = sanitizeReportTemplates(p.report_templates);
+  await store.saveTemplates(templates);
+  await store.saveMaterialLibrary(materials);
+  await store.saveStampLibrary(stamps);
+  overwriteReportTemplates(reportTemplates);
+  if (p.report_theme) saveActiveThemeFile(p.report_theme); else clearActiveTheme();
+  saveColPrefs(p.report_cols && typeof p.report_cols === "object" ? p.report_cols : {});
+  saveGroupBy(typeof p.report_groupby === "string" ? p.report_groupby : "");
+  return {
+    templates: templates.length,
+    materials: materials.length,
+    stamps: (stamps.stamps || []).length,
+    reportTemplates: reportTemplates.length,
+  };
+}
+
+/**
+ * Factory reset: the environment a fresh browser profile gets — empty
+ * template/material libraries, the SEEDED default stamp set, no report
+ * customization. Distinct from deleting anything project-side.
+ */
+export async function resetProfileDefaults() {
+  await store.saveTemplates([]);
+  await store.saveMaterialLibrary([]);
+  await store.saveStampLibrary(seedStampLibrary({ stamps: [], sets: [] }));
+  overwriteReportTemplates([]);
+  clearActiveTheme();
+  saveColPrefs({});
+  saveGroupBy("");
+}

--- a/web/src/lib/reportTheme.js
+++ b/web/src/lib/reportTheme.js
@@ -153,6 +153,11 @@ export function activeThemeVars() {
 
 // saveActiveThemeFile(json)/clearActiveTheme() — the import + reset seam a UI
 // picker calls. Stores the raw file so re-parsing always reflects the importer.
+// The RAW stored file (or null) — what a profile export must carry so the
+// re-parse on another machine reflects the original import, not a re-render.
+export function activeThemeFileRaw() {
+  try { return localStorage.getItem(ACTIVE_KEY); } catch { return null; }
+}
 export function saveActiveThemeFile(json) {
   try { localStorage.setItem(ACTIVE_KEY, typeof json === "string" ? json : JSON.stringify(json)); } catch { /* private mode */ }
 }

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -26,6 +26,7 @@ import { transformPath, svgPlacedBox } from "../lib/svgpath.js";
 import { ingestFiles } from "../lib/ingest.js";
 import { parseTakeoffImport, mergeTakeoffImport } from "../lib/importTakeoff.js";
 import { buildProjectArchive, parseProjectArchive, isProjectArchive, downloadArchive } from "../lib/projectArchive.js";
+import { buildProfile, parseProfile, applyProfile, resetProfileDefaults, isProfileFile } from "../lib/profile.js";
 import ToolMenu from "../components/ToolMenu.jsx";
 import PlanNavigator from "../components/PlanNavigator.jsx";
 import ReportPanel from "../components/ReportPanel.jsx";
@@ -602,6 +603,7 @@ export default function TakeoffCanvas() {
   const [clientInfo, setClientInfo] = useState({});      // per-project client/job fields for branded output; additive payload field
   const fileInputRef = useRef(null);                    // hidden <input type=file> for "Open PDF"
   const importInputRef = useRef(null);                  // hidden <input type=file> for "Import takeoff…" (the agent-JSON handoff)
+  const profileInputRef = useRef(null);                 // hidden <input type=file> for "Import profile…" (#299)
 
   const containerRef = useRef(null);
   const stageRef = useRef(null);
@@ -1231,6 +1233,10 @@ export default function TakeoffCanvas() {
       if (incoming.length > 1) setCommitMsg((m) => `${m} Other dropped files were ignored — open plans separately from a project archive.`);
       return;
     }
+    // a dropped .otprofile is the working ENVIRONMENT (#299) — apply it, never
+    // ingest it as a plan
+    const prof = incoming.find((f) => isProfileFile(f.name));
+    if (prof) { await importProfileFile(prof); return; }
     setCommitMsg("Reading files…");
     let pdfs = [], skipped = [];
     try { ({ pdfs, skipped } = await ingestFiles(incoming, { onProgress: setCommitMsg })); }
@@ -2150,6 +2156,52 @@ export default function TakeoffCanvas() {
     } catch (e) {
       setCommitMsg(String(e?.message || "").startsWith("Couldn't") ? e.message : `Couldn't open project: ${e?.message || e}`);
     }
+  };
+
+  // ── estimator profile (#299) — export / import / reset the working
+  // environment (condition templates, materials, stamps, report setup),
+  // never project data. Import and reset both DOWNLOAD the current profile
+  // first: the receipt is the rollback (Import profile restores it), so
+  // neither needs a second confirmation step.
+  const refreshLibraries = async () => {
+    const tpl = await store.loadTemplates().catch(() => []);
+    templatesRef.current = tpl; setTemplates(tpl);
+    setMatLib(await store.loadMaterialLibrary().catch(() => []));
+    const lib = await store.loadStampLibrary().catch(() => ({ stamps: [], sets: [] }));
+    stampLibRef.current = lib; setStampLib(lib);
+  };
+  const profileSummary = (p) =>
+    `${(p.condition_templates || []).length} condition template${(p.condition_templates || []).length === 1 ? "" : "s"}, ${(p.material_library || []).length} material${(p.material_library || []).length === 1 ? "" : "s"}, ${(p.stamp_library?.stamps || []).length} stamp${(p.stamp_library?.stamps || []).length === 1 ? "" : "s"}, ${(p.report_templates || []).length} report template${(p.report_templates || []).length === 1 ? "" : "s"}`;
+  const exportProfileFile = async () => {
+    try {
+      const p = await buildProfile();
+      downloadText("opentakeoff-profile.otprofile", JSON.stringify(p, null, 2), "application/json");
+      setCommitMsg(`Exported opentakeoff-profile.otprofile — ${profileSummary(p)}. Import it on another machine to carry your setup over.`);
+    } catch (e) { setCommitMsg(`Couldn't export profile: ${e?.message || e}`); }
+  };
+  const backupProfileFile = async () => {
+    const backup = await buildProfile();
+    downloadText("opentakeoff-profile-backup.otprofile", JSON.stringify(backup, null, 2), "application/json");
+  };
+  const importProfileFile = async (file) => {
+    if (!file) return;
+    try {
+      const p = parseProfile(await file.text());
+      await backupProfileFile();
+      const n = await applyProfile(p);
+      await refreshLibraries();
+      setCommitMsg(`Applied profile${p.name ? ` "${p.name}"` : ""} — ${n.templates} condition template${n.templates === 1 ? "" : "s"}, ${n.materials} material${n.materials === 1 ? "" : "s"}, ${n.stamps} stamp${n.stamps === 1 ? "" : "s"}, ${n.reportTemplates} report template${n.reportTemplates === 1 ? "" : "s"}. Your previous setup downloaded as opentakeoff-profile-backup.otprofile.`);
+    } catch (e) {
+      setCommitMsg(String(e?.message || "").startsWith("Couldn't") ? e.message : `Couldn't apply profile: ${e?.message || e}`);
+    }
+  };
+  const resetProfile = async () => {
+    try {
+      await backupProfileFile();
+      await resetProfileDefaults();
+      await refreshLibraries();
+      setCommitMsg("Profile reset to OpenTakeoff defaults — your previous setup downloaded as opentakeoff-profile-backup.otprofile (Import profile restores it). Project takeoffs are untouched.");
+    } catch (e) { setCommitMsg(`Couldn't reset profile: ${e?.message || e}`); }
   };
 
   // markups MUST be in the deps (a cloud/callout/text or an RFI link is real work);
@@ -6404,6 +6456,22 @@ export default function TakeoffCanvas() {
     title: "Save the WHOLE job as one portable .otk file — every plan PDF plus the full takeoff. Open it on any machine (drop it like a plan, or Add plans), archive it, or hand it to another estimator; unlike Export takeoff, the plans travel inside.",
     onSelect: exportProjectArchive,
   });
+  sheetMenuItems.push({ section: "Profile — your templates, stamps & report setup" });
+  sheetMenuItems.push({
+    id: "export-profile", icon: "document", label: "Export profile…",
+    title: "Save your working environment — condition templates, material library, stamps, report templates/theme/columns — as one portable .otprofile. Import it on another machine or hand a company setup to another estimator; project takeoffs are never in it.",
+    onSelect: exportProfileFile,
+  });
+  sheetMenuItems.push({
+    id: "import-profile", icon: "document", label: "Import profile…",
+    title: "Replace your working environment with a .otprofile (you can also drop the file on the canvas). Your current setup downloads as a backup first — importing that backup restores it. Project takeoffs are untouched.",
+    onSelect: () => profileInputRef.current?.click(),
+  });
+  sheetMenuItems.push({
+    id: "reset-profile", icon: "undo", label: "Reset profile to defaults",
+    title: "Back to a stock OpenTakeoff setup — empty template/material libraries, the default stamps, no report customization. Your current setup downloads as a backup first; project takeoffs are untouched.",
+    onSelect: resetProfile,
+  });
 
   // deck-2 scale chip — the four scale controls collapsed to one status face:
   // red dashed = unset ("you can't trace yet"), green = set, warning = the
@@ -6554,6 +6622,8 @@ export default function TakeoffCanvas() {
           the refs even while focus mode hides the bar) */}
       <input name="sheet-file" ref={fileInputRef} type="file" accept=".pdf,application/pdf,image/*,.zip,application/zip,application/x-zip-compressed,.otk" multiple style={{ display: "none" }}
         onChange={(e) => { handleFiles(e.target.files); e.target.value = ""; }} />
+      <input name="profile-import" ref={profileInputRef} type="file" accept=".otprofile,application/json" style={{ display: "none" }}
+        onChange={(e) => { importProfileFile(e.target.files?.[0]); e.target.value = ""; }} />
       <input name="takeoff-import" ref={importInputRef} type="file" accept=".json,application/json" style={{ display: "none" }}
         onChange={(e) => { importTakeoffFile(e.target.files?.[0]); e.target.value = ""; }} />
       {/* THE top bar — one row (the two decks of issue #61 merged once the

--- a/web/test/profile.test.ts
+++ b/web/test/profile.test.ts
@@ -1,0 +1,32 @@
+// Estimator profile (.otprofile) — the pure parse/validate gate (#299). The
+// store-backed halves (buildProfile/applyProfile) ride IndexedDB and are
+// exercised in the running app; what node can hold is the file-format door:
+// what gets in, what is refused, and how it is refused.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseProfile, isProfileFile, PROFILE_SCHEMA } from "../src/lib/profile.js";
+
+test("otprofile: extension detection", () => {
+  assert.equal(isProfileFile("John-ABC-Construction.otprofile"), true);
+  assert.equal(isProfileFile("SETUP.OTPROFILE"), true);
+  assert.equal(isProfileFile("takeoff.json"), false);
+  assert.equal(isProfileFile(""), false);
+});
+
+test("otprofile: a well-formed v1 profile parses through", () => {
+  const p = parseProfile(JSON.stringify({
+    schema: PROFILE_SCHEMA,
+    name: "John — ABC Construction",
+    condition_templates: [],
+    material_library: [],
+  }));
+  assert.equal(p.name, "John — ABC Construction");
+});
+
+test("otprofile: refuses non-JSON, non-objects, and unknown schemas loudly", () => {
+  assert.throws(() => parseProfile("not json {"), /isn't valid JSON/);
+  assert.throws(() => parseProfile('"a string"'), /not a profile file/);
+  assert.throws(() => parseProfile("[1,2]"), /not a profile file/);
+  assert.throws(() => parseProfile(JSON.stringify({ schema: "opentakeoff.profile.v9" })), /version/);
+  assert.throws(() => parseProfile(JSON.stringify({ conditions: [] })), /version/);
+});


### PR DESCRIPTION
Profile = who am I / how do I work: condition templates, material library,
stamps, report templates/theme/columns — exactly the browser-global records,
never project data, so switching profiles can't touch a takeoff. Import and
reset both download the current profile FIRST: the receipt is the rollback.
Apply is replace-not-merge and every section rides the same sanitize gate
its store-load path uses; unknown profile schemas refuse loudly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
