### PR TITLE
derive_transitions: fold session orchestration onto deriveTransitionRuns (#208 cleanup)

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.62",
+  "version": "0.9.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.62",
+      "version": "0.9.63",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.62",
+  "version": "0.9.63",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.62",
+  "version": "0.9.63",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.62",
+      "version": "0.9.63",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -40,7 +40,7 @@ import { ROOM_LABEL_RE, seedLadderPx, isLabelBubblePx, floodAtSeed, type LabelBB
 import { fingerprintSymbol, matchSymbol, buildNegative, SWEEP_TOL_PX, type SweepOptions, type SymbolFingerprint, type SymbolMatchResult, type SweepMatch, type SweepWithheld, type SweepRejected, type SymbolNegative } from "../../web/src/lib/symbolsweep.ts";
 import { labelPlacements, type PlacementLabel } from "../../web/src/lib/symbollabels.ts";
 import { buildSnapGrid, nearestSnap, closedMetrics, openLen } from "../../web/src/lib/geometry.js";
-import { sharedRuns, type SharedRun } from "../../web/src/lib/transitions.ts";
+import { deriveTransitionRuns, type SheetFrame, type TransitionSourceShape } from "../../web/src/lib/transitions.ts";
 // Real polygon boolean subtraction (#137/#206) — the canvas's own module, so a
 // headless cut and the app's Eraser can never disagree about what a hole holds.
 import { subtractCutout, recomposeCutouts, ringFullyInside, cutRun } from "../../web/src/lib/cutout.js";
@@ -1897,24 +1897,41 @@ export class Session {
       if (s.upp == null) throw new UserError(`${key} has no scale — a transition is a real length, so set_scale first (${this.scaleGate(s)})`);
     }
 
-    const committed: any[] = [], withheld: any[] = [];
+    // the sheet/pair sweep, the sampling opts and the butt-vs-wall decision are
+    // deriveTransitionRuns' — one orchestration, driven by the canvas and this
+    // verb alike (the #208 fold). This side keeps the store: refusals above,
+    // the journal commit below, and the wire rows the schema promises.
+    const frames = new Map<string, SheetFrame>();
     for (const key of sheetsInPlay) {
       const s = this.sheet(key);
-      const upp = s.upp!;                       // feet per image px, checked above
-      const pxPerFt = 1 / upp;
-      const toPx = (sh: typeof fa[number]) => sh.verts_norm.map(([x, y]) => [x * s.widthPx, y * s.heightPx] as [number, number]);
-      const onSheetA = fa.filter((x) => x.sheet_id === key), onSheetB = fb.filter((x) => x.sheet_id === key);
-      for (const ra of onSheetA) {
-        for (const rb of onSheetB) {
-          const runs = sharedRuns(toPx(ra), toPx(rb), {
-            step_px: Math.max(1, pxPerFt * 0.25),          // a quarter-foot walk — finer than any transition matters
-            touch_px: pxPerFt * (1 / 12),                  // within an inch: one open space, not two rooms
-            max_gap_px: pxPerFt * (maxGapIn / 12),
-            min_len_px: pxPerFt * (minRunIn / 12),
-          });
-          for (const r of runs) this.recordRun(s, r, upp, opts.condition, ra.id, rb.id, a.finish_tag, b.finish_tag, committed, withheld);
-        }
-      }
+      frames.set(key, { widthPx: s.widthPx, heightPx: s.heightPx, upp: s.upp! });
+    }
+    const src = (sh: typeof fa[number]): TransitionSourceShape => ({ id: sh.id, sheet_id: sh.sheet_id, verts_norm: sh.verts_norm });
+    const derived = deriveTransitionRuns(
+      { tag: a.finish_tag, shapes: fa.map(src) },
+      { tag: b.finish_tag, shapes: fb.map(src) },
+      frames,
+      { max_gap_in: maxGapIn, min_run_in: minRunIn },
+    );
+
+    const committed: any[] = [], withheld: any[] = [];
+    for (const w of derived.withheld) {
+      withheld.push({
+        sheet: w.sheet_id, between_shape_ids: w.between_shape_ids, length_lf: w.length_lf, gap_in: w.gap_in, at: w.at,
+        reason: "wall_separated",
+        detail: `${a.finish_tag} and ${b.finish_tag} run ${w.length_lf} LF apart across ${w.gap_in}" of wall — adjacent rooms, not a butt joint. If a door opens here the transition is a threshold at the door, which this cannot see.`,
+      });
+    }
+    for (const r of derived.runs) {
+      const s = this.sheet(r.sheet_id);
+      const pathPx = r.verts_norm.map(([x, y]) => [x * s.widthPx, y * s.heightPx] as Point);
+      const shape = this.commit(s, opts.condition, "linear", pathPx, { area_sf: 0, perimeter_lf: r.length_lf }, {
+        method: "agent_v1",
+        actor: "agent",
+        reviewed: false,
+        derived: { between_shape_ids: r.between_shape_ids, between: [a.finish_tag, b.finish_tag], case: "butt", gap_in: r.gap_in },
+      });
+      committed.push({ sheet: r.sheet_id, between_shape_ids: r.between_shape_ids, length_lf: r.length_lf, gap_in: r.gap_in, at: r.at, shape_id: shape.id });
     }
     if (committed.length) this.flushCommits("derive_transitions");
     return {
@@ -1929,26 +1946,6 @@ export class Session {
         ? `${withheld.length} run(s) are adjacency ACROSS A WALL, not a butt joint — the transition there is a threshold in the doorway, and the trace record does not say where the doorway is. view_sheet each \`at\` and place them with measure_line / place_count.`
         : "Every run was a butt joint inside one open space. Verify with view_sheet overlay:true before trusting the total.",
     };
-  }
-
-  /** One shared run → committed transition, or a disclosed question. */
-  private recordRun(s: SheetState, r: SharedRun, upp: number, condition: string,
-                    aId: string, bId: string, aTag: string, bTag: string,
-                    committed: any[], withheld: any[]) {
-    const length_lf = round2(r.length_px * upp);
-    const gap_in = round1(r.gap_px * upp * 12);
-    const row = { sheet: s.key, between_shape_ids: [aId, bId], length_lf, gap_in, at: [Math.round(r.at[0]), Math.round(r.at[1])] };
-    if (r.kind === "wall") {
-      withheld.push({ ...row, reason: "wall_separated", detail: `${aTag} and ${bTag} run ${length_lf} LF apart across ${gap_in}" of wall — adjacent rooms, not a butt joint. If a door opens here the transition is a threshold at the door, which this cannot see.` });
-      return;
-    }
-    const shape = this.commit(s, condition, "linear", r.path, { area_sf: 0, perimeter_lf: length_lf }, {
-      method: "agent_v1",
-      actor: "agent",
-      reviewed: false,
-      derived: { between_shape_ids: [aId, bId], between: [aTag, bTag], case: "butt", gap_in },
-    });
-    committed.push({ ...row, shape_id: shape.id });
   }
 
   /** Count markers — the canvas's Count tool (commitCount): one point, one EA,

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -808,6 +808,13 @@ test("derive_transitions: commits butt joints, withholds wall adjacency, refuses
     assert.equal(shp.origin.derived.case, "butt");
     assert.deepEqual(shp.origin.derived.between, ["CPT-1", "PT-1"]);
     assert.equal(shp.origin.derived.between_shape_ids.length, 2);
+    // the fold onto deriveTransitionRuns commits the CLEANED path (canvas
+    // parity, #208): a straight run is two ends, not a quarter-foot sample
+    // every step — but its LF was measured on the full walk before the cut
+    assert.ok(
+      shp.verts_norm.length <= Math.max(4, Math.ceil(r.data.runs[0].length_lf)),
+      `committed run keeps corners, not samples (${shp.verts_norm.length} verts for ${r.data.runs[0].length_lf} LF)`,
+    );
     await call(client, "undo_last", { n: 1 });   // the whole sweep is one step
     const after = (await call(client, "takeoff_summary")).data.conditions.find((c: any) => c.finish_tag === "T-1");
     assert.ok(!after || after.lf === 0, "one undo removes the whole derivation");

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.62",
+  "version": "0.9.63",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.62",
+      "version": "0.9.63",
       "transport": {
         "type": "stdio"
       }

--- a/web/src/lib/transitions.ts
+++ b/web/src/lib/transitions.ts
@@ -224,10 +224,9 @@ export function sharedRuns(ringA: Pt[], ringB: Pt[], opts: SharedRunOpts): Share
 // can accept, or a question you cannot.
 //
 // It is deliberately a SEPARATE, pure entry point rather than a canvas method:
-// the same orchestration is what mcp/src/session.ts deriveTransitions does
-// around its own store, and pulling it here means the two can be reconciled in
-// the next MCP release without the canvas having to grow a session. Until then
-// the sequencing exists twice on purpose and this is the copy the UI drives.
+// this is the ONE copy of the sequencing — the canvas drives it for the
+// Transitions button, and mcp/src/session.ts deriveTransitions drives it around
+// its own store (refusals, journal commit, wire rows stay session-side).
 
 /** A committed floor shape, as little of one as the derivation needs. */
 export interface TransitionSourceShape {


### PR DESCRIPTION
The sheet/pair sweep, sampling opts, and butt-vs-wall decision now live only
in web/src/lib/transitions.ts — the canvas and the MCP verb drive the same
engine. Session keeps what is session's: refusals, the journal commit, and
the wire rows the schema promises (wire format unchanged).

One behavior change, deliberate: committed runs store the dropCollinear'd
path (canvas parity) instead of the raw quarter-foot samples — a straight
joint is two ends, not 120 drag handles. LF is still measured on the full
walk before the cut; the tools test pins both.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
