### PR TITLE
Label shortcuts for the keyboard in front of you, and say Windows out loud

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ what makes it training data.
 | **An AI agent**—or the person wiring one up | `npx -y opentakeoff-mcp`, then the [**agent manual**](docs/AGENT_GUIDE.md): the operating model, the standard finish every takeoff ends with, what the engine refuses to guess, and why. Tool-by-tool reference is [`mcp/README.md`](mcp/README.md). |
 | **A developer building on the engine** | [`AGENTS.md`](AGENTS.md) is the repo map and the ship discipline; [`FEATURES.md`](FEATURES.md) maps every capability to the code that does it. Apache-2.0—fork it. |
 
+### Windows, macOS, Linux — all of it
+
+OpenTakeoff is a **client-only browser app**, so the canvas runs the same on Windows, macOS,
+ChromeOS and Linux in any current Chrome, Edge, Firefox or Safari. Nothing installs, nothing
+uploads, and no feature is gated on an operating system.
+
+- **Shortcuts are platform-aware.** The app labels modifiers for the keyboard in front of you —
+  `Ctrl` / `Alt` / `Shift` on Windows and Linux, `⌘` / `⌥` / `⇧` on a Mac — and the handlers have
+  always treated `⌘` and `Ctrl` as the same key. Press `?` in the canvas for the current list.
+- **The MCP server is tested on Windows.** `npx -y opentakeoff-mcp` runs on Windows, macOS and
+  Linux, and CI runs the full MCP suite — typecheck, tests, build and the packaged smoke test — on
+  `windows-latest` as well as `ubuntu-latest` on every change.
+- **Optional extras.** The bundled [capture server](capture/) is stdlib Python 3 and runs anywhere
+  Python does — on Windows invoke it with `python capture\capture_server.py selftest` (or the `py`
+  launcher) rather than `python3`. Neither it nor the optional [`server/`](server/) AI sandbox is
+  needed to use the canvas.
+- **Locked-down enterprise fleets** (MSIX packaging, Windows Sandbox, Intune silent deploy) are
+  tracked in [#226](https://github.com/Kentucky-ai/opentakeoff/issues/226) and not yet built.
+
 ## What this is
 
 Measuring quantities off a plan is the input to every construction bid—how much floor, how

--- a/web/src/components/AgentPanel.jsx
+++ b/web/src/components/AgentPanel.jsx
@@ -7,6 +7,7 @@
 // Create gate. Unconfigured builds get the honest empty state (the Contribute
 // modal pattern): no key, no run, and a link to AI settings.
 import { useEffect, useRef, useState } from "react";
+import { keyText } from "../lib/keys.ts";
 import { Icon } from "../brand/icons.jsx";
 
 const evidenceText = (ev) => {
@@ -74,7 +75,7 @@ export default function AgentPanel({
               ) : (
                 <button onClick={run} disabled={!goal.trim()} className="btn-primary" style={{ padding: "5px 14px", fontSize: 12, cursor: goal.trim() ? "pointer" : "default", opacity: goal.trim() ? 1 : 0.5 }}>Run</button>
               )}
-              <span style={{ fontSize: 10.5, color: "var(--ink-muted)" }}>{running ? "Working — proposals land as dashed outlines." : "⌘⏎ runs. Your key, your endpoint."}</span>
+              <span style={{ fontSize: 10.5, color: "var(--ink-muted)" }}>{running ? "Working — proposals land as dashed outlines." : keyText("⌘⏎ runs. Your key, your endpoint.")}</span>
               <span style={{ flex: 1 }} />
               <button onClick={onOpenSettings} title="AI settings (endpoint / model / key)" style={{ border: "none", background: "transparent", cursor: "pointer", color: "var(--ink-muted)" }}><Icon name="sliders" size={13} /></button>
             </div>
@@ -94,7 +95,7 @@ export default function AgentPanel({
               <strong style={{ flex: 1, fontSize: 11.5 }}>Proposals · {proposals.length}</strong>
               {proposals.length > 0 && (
                 <>
-                  <button onClick={onAcceptAll} style={{ ...ctl, color: "var(--c-positive)", fontWeight: 600 }} title="Accept every visible proposal (⏎ on the canvas does the same)">Accept all</button>
+                  <button onClick={onAcceptAll} style={{ ...ctl, color: "var(--c-positive)", fontWeight: 600 }} title={keyText("Accept every visible proposal (⏎ on the canvas does the same)")}>Accept all</button>
                   <button onClick={onRejectAll} style={{ ...ctl, color: "var(--c-danger)" }} title="Discard every pending proposal (local only — nothing is recorded)">Reject all</button>
                 </>
               )}

--- a/web/src/components/TakeoffsPanel.jsx
+++ b/web/src/components/TakeoffsPanel.jsx
@@ -25,6 +25,7 @@
 // that transient state survives a collapse/expand round-trip.
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { keyText } from "../lib/keys.ts";
 import { Icon } from "../brand/icons.jsx";
 import { attrValue, columnLabel } from "../lib/conditionColumns.js";
 import { SPEC_FIELDS } from "../lib/reportColumns.js";
@@ -896,7 +897,7 @@ function TakeoffsPanel({
             onActivate(c.id);
           }}
           onDoubleClick={() => onLocate(c.id)}
-          title={reassigning ? "Reassign selected shape to this condition" : "Make this the active condition (double-click zooms to its takeoffs · ⌘-click / ⇧-click selects for bulk edit · drag to the top-bar palette for one-click access)"}
+          title={reassigning ? "Reassign selected shape to this condition" : keyText("Make this the active condition (double-click zooms to its takeoffs · ⌘-click / ⇧-click selects for bulk edit · drag to the top-bar palette for one-click access)")}
           style={{ display: "flex", alignItems: "center", gap: 8, padding: "9px 12px", cursor: "pointer", outline: reassigning ? "1px dashed var(--cobalt)" : "none", outlineOffset: -3, userSelect: "none" }}>
           {hot && <span title={pinned ? `Palette shortcut — press ${hIdx + 1} to activate` : `Press ${hIdx + 1} to activate (pin to lock this number)`} style={{ fontSize: 9, fontFamily: "var(--f-mono,monospace)", color: pinned ? "var(--cobalt)" : "var(--ink-muted)", border: `1px solid ${pinned ? "var(--cobalt)" : "var(--ink-faint)"}`, borderRadius: 3, padding: "0 3px", flexShrink: 0 }}>{hIdx + 1}</span>}
           <span style={{ borderRadius: 4, overflow: "hidden", lineHeight: 0, flexShrink: 0 }}><HatchSwatch type={c.hatch || "solid"} line={c.color} fill={c.fill} /></span>
@@ -1104,7 +1105,7 @@ function TakeoffsPanel({
             <button onClick={onAddCondition} style={{ width: "100%", padding: "6px 10px", borderRadius: 0, border: "1px dashed var(--ink-faint)", background: "transparent", cursor: "pointer", fontSize: 12.5, color: "var(--ink-muted)" }}>+ condition</button>
           </div>
           <div style={{ padding: "8px 12px", borderTop: "1px solid var(--ink-faint)", color: "var(--ink-muted)", fontSize: 10.5 }}>
-            Select a shape on the plan, then ⧉ Copy / ⎘ Paste (⌘C / ⌘V) — it lands on the sheet under your cursor.
+            {keyText("Select a shape on the plan, then ⧉ Copy / ⎘ Paste (⌘C / ⌘V) — it lands on the sheet under your cursor.")}
             <br />⌫ undo point · Esc cancel · scroll = zoom · pan mid-measure: press-and-drag (a click without dragging places the point).
           </div>
         </div>

--- a/web/src/components/ToolMenu.jsx
+++ b/web/src/components/ToolMenu.jsx
@@ -11,6 +11,7 @@
 // preview its effect while pointed at (the scale menu's plan-says item shows
 // the calibrated guide bar on the sheet behind the open menu).
 import React, { useEffect, useRef, useState } from "react";
+import { keyText } from "../lib/keys.ts";
 import { Icon } from "../brand/icons.jsx";
 
 const MENU_W = 232;
@@ -111,7 +112,7 @@ export default function ToolMenu({ face, active = false, accent = "cobalt", titl
                 {checkable && <span style={{ display: "inline-flex", width: 15, justifyContent: "center", color: "var(--c-positive)", visibility: it.checked ? "visible" : "hidden" }}><Icon name="check" size={14} /></span>}
                 {it.icon && <span style={{ display: "inline-flex", width: 17, justifyContent: "center", color: it.tint || fg }}><Icon name={it.icon} size={16} /></span>}
                 <span style={{ flex: 1, fontFamily: "var(--f-body)", fontSize: 13, fontWeight: it.active ? 600 : 400 }}>{it.label}</span>
-                {it.shortcut && <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-muted)" }}>{it.shortcut}</span>}
+                {it.shortcut && <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-muted)" }}>{keyText(it.shortcut)}</span>}
               </button>
             );
           })}

--- a/web/src/components/UserGuide.jsx
+++ b/web/src/components/UserGuide.jsx
@@ -15,6 +15,7 @@
 // shortcut changes, §15 and this table move together.
 import { useEffect } from "react";
 import { Z } from "../lib/ui.js";
+import { keyLabel, keyText, isApplePlatform } from "../lib/keys.ts";
 
 const GUIDE_URL = "https://github.com/Kentucky-ai/opentakeoff/blob/main/docs/USER_GUIDE.md";
 
@@ -28,9 +29,11 @@ function Kbd({ children }) {
 }
 
 function Keys({ combo }) {
+  // Labels only — the handlers already treat ⌘ and Ctrl as one key. See lib/keys.ts.
+  const apple = isApplePlatform();
   return (
     <span style={{ display: "inline-flex", gap: 3, alignItems: "center" }}>
-      {combo.map((k, i) => <Kbd key={i}>{k}</Kbd>)}
+      {combo.map((k, i) => <Kbd key={i}>{keyLabel(k, apple)}</Kbd>)}
     </span>
   );
 }
@@ -41,7 +44,7 @@ function Table({ rows }) {
       {rows.map(([combo, what], i) => (
         <div key={i} style={{ display: "contents" }}>
           <div style={{ justifySelf: "start" }}><Keys combo={combo} /></div>
-          <div style={{ fontSize: 12.5, color: "var(--ink-soft)", lineHeight: 1.45 }}>{what}</div>
+          <div style={{ fontSize: 12.5, color: "var(--ink-soft)", lineHeight: 1.45 }}>{keyText(what)}</div>
         </div>
       ))}
     </div>
@@ -150,7 +153,7 @@ export default function UserGuide({ onClose }) {
             {START.map(([t, d]) => (
               <li key={t} style={{ fontSize: 12.5, lineHeight: 1.5 }}>
                 <strong style={{ color: "var(--ink)" }}>{t}</strong>
-                <span style={{ color: "var(--ink-soft)" }}> — {d}</span>
+                <span style={{ color: "var(--ink-soft)" }}> — {keyText(d)}</span>
               </li>
             ))}
           </ol>

--- a/web/src/lib/keys.ts
+++ b/web/src/lib/keys.ts
@@ -1,0 +1,55 @@
+// Modifier-key labels — the one place this app has to know what computer it is
+// running on.
+//
+// Every shortcut in the canvas is already platform-correct in BEHAVIOUR: the
+// handlers test `e.metaKey || e.ctrlKey` together, and `altKey` is the same key
+// on every platform. What was never correct is the LABEL. The tables, tooltips
+// and commit messages were transcribed from a Mac and shipped Mac glyphs —
+// so a Windows estimator opening the shortcut list saw ⌘ and ⌥, symbols that
+// are not on the keyboard in front of them, describing shortcuts that in fact
+// work fine. That reads as "this app is not for me", which is the complaint
+// this module exists to remove.
+//
+// Pure and total: the mapping takes the platform as an argument, so it is
+// testable without a DOM and never throws on a server render.
+
+/** Mac glyph → the label the same key carries on a PC keyboard. */
+const PC_LABEL: Readonly<Record<string, string>> = Object.freeze({
+  "⌘": "Ctrl",       // ⌘ command → control
+  "⌥": "Alt",        // ⌥ option  → alt
+  "⇧": "Shift",      // ⇧
+  "⏎": "Enter",      // ⏎
+  "⌫": "Backspace",  // ⌫
+});
+
+/** Glyphs that combine into a chord when written adjacently (⇧⌘Z). */
+const GLYPHS = "⌘⌥⇧⏎⌫";
+const CHORD_RE = new RegExp(`([${GLYPHS}]+)([A-Za-z0-9])?`, "g");
+
+/** True on macOS/iOS/iPadOS, where the Mac glyphs are the right labels.
+ *  Defensive: any absent or hostile `navigator` reads as "not Apple", because
+ *  spelling out Ctrl/Alt is legible on every platform while ⌘ is not. */
+export function isApplePlatform(nav: unknown = typeof navigator === "undefined" ? null : navigator): boolean {
+  const n = nav as { platform?: unknown; userAgent?: unknown } | null;
+  if (!n) return false;
+  const s = `${typeof n.platform === "string" ? n.platform : ""} ${typeof n.userAgent === "string" ? n.userAgent : ""}`;
+  return /Mac|iPhone|iPad|iPod/i.test(s);
+}
+
+/** One key's label: a lone glyph from a shortcut table. Non-glyphs pass through. */
+export function keyLabel(key: string, apple: boolean = isApplePlatform()): string {
+  if (apple) return key;
+  return PC_LABEL[key] ?? key;
+}
+
+/** Glyphs embedded in a sentence — "⌥-click carves…", "one undo step (⌘Z)".
+ *  Adjacent glyphs plus an immediately following alphanumeric are one chord,
+ *  so ⇧⌘Z becomes Shift+Ctrl+Z rather than three loose words. */
+export function keyText(text: string, apple: boolean = isApplePlatform()): string {
+  if (apple || !text) return text;
+  return String(text).replace(CHORD_RE, (_m, glyphs: string, tail?: string) => {
+    const parts = Array.from(glyphs).map((g) => PC_LABEL[g] ?? g);
+    if (tail) parts.push(tail);
+    return parts.join("+");
+  });
+}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -13,6 +13,7 @@
 // pans. Geometry math reads tfRef (always current), so drawing stays accurate.
 
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { keyText } from "../lib/keys.ts";
 import { flushSync } from "react-dom";
 import { Link, useNavigate } from "react-router";
 import * as pdfjsLib from "pdfjs-dist";
@@ -3923,7 +3924,7 @@ export default function TakeoffCanvas() {
       origin: { method: "symbol_sweep", symbol: { score: m.score, rotation: m.rotation, mirrored: m.mirrored, seed: { source: "instance", sheet: sw.key, ...(m.seedRow ? { seed_instance: true } : {}) } } },
     })) });
     const skippedN = sw.matches.length - sw.matches.filter((m) => !off.has(tagKey(m))).length;
-    setCommitMsg(`Committed ${rows.length} EA under ${condById[activeCond]?.finish_tag || "condition"}${sw.includeSeed ? " — seed included" : ""}${skippedN ? ` · ${skippedN} excluded by label` : ""} · one undo step (⌘Z).`);
+    setCommitMsg(`Committed ${rows.length} EA under ${condById[activeCond]?.finish_tag || "condition"}${sw.includeSeed ? " — seed included" : ""}${skippedN ? ` · ${skippedN} excluded by label` : ""} · one undo step (${keyText("⌘Z")}).`);
     setSweep(null);
   }
 
@@ -4146,13 +4147,13 @@ export default function TakeoffCanvas() {
         return { key: tp.key, regions: [...rs, region] };
       });
     });
-    if (outcome === "dup") setCommitMsg(negative ? "That cutout is already carved." : "Already selected — ⌥-click carves an enclosed cutout; ⏎ creates.");
-    else if (outcome === "needsPos") setCommitMsg("⌥-click carves an enclosed area INSIDE the selection (a column or shaft) — click its room first.");
+    if (outcome === "dup") setCommitMsg(negative ? "That cutout is already carved." : keyText("Already selected — ⌥-click carves an enclosed cutout; ⏎ creates."));
+    else if (outcome === "needsPos") setCommitMsg(keyText("⌥-click carves an enclosed area INSIDE the selection (a column or shaft) — click its room first."));
     // The measurement-policy receipts: when the engine sealed, wedged, or
     // ruled a passage out, the estimator hears it at stage time — the trace is
     // reviewable while the edge in question is still under the cursor.
-    else if (f.wedges && f.ringWedges >= f.wedges) setCommitMsg(`Measured to include the floor inside ${f.ringWedges === 1 ? "a closed ring" : `${f.ringWedges} closed rings`} drawn on the plan (a round column or a callout bubble) — no door swing was involved. If that is a column you deduct rather than floor you cover, ⌥-click carves it out. ⏎ creates.`);
-    else if (f.wedges && f.ringWedges) setCommitMsg(`Measured through the drawn door to the wall opening — the swing area is included. It also includes the floor inside ${f.ringWedges === 1 ? "a closed ring" : `${f.ringWedges} closed rings`} (a round column or callout bubble), which is not a door swing; ⌥-click carves one out if it should be deducted. ⏎ creates.`);
+    else if (f.wedges && f.ringWedges >= f.wedges) setCommitMsg(`Measured to include the floor inside ${f.ringWedges === 1 ? "a closed ring" : `${f.ringWedges} closed rings`} drawn on the plan (a round column or a callout bubble) — no door swing was involved. If that is a column you deduct rather than floor you cover, ${keyText("⌥-click carves it out. ⏎ creates.")}`);
+    else if (f.wedges && f.ringWedges) setCommitMsg(`Measured through the drawn door to the wall opening — the swing area is included. It also includes the floor inside ${f.ringWedges === 1 ? "a closed ring" : `${f.ringWedges} closed rings`} (a round column or callout bubble), which is not a door swing; ${keyText("⌥-click carves one out if it should be deducted. ⏎ creates.")}`);
     else if (f.wedges) setCommitMsg("Measured through the drawn door to the wall opening — the swing area is included. ⏎ creates.");
     else if (f.sealedPx) setCommitMsg(f.minPassPx
       ? `That space isn't closed on the drawing — the gap is under ${MIN_PASS_FT} ft, so the minimum-passage rule bridged it rather than measuring through it. That call is at the limit of what this sheet's resolution can decide; review the edge, then ⏎ creates.`
@@ -6571,10 +6572,10 @@ export default function TakeoffCanvas() {
     const armed = opts.armed ?? (tool === id);
     return (
       <button key={id} type="button" onClick={onArm || (() => setTool(id))}
-        title={shortcut ? `${label} · ${shortcut}` : label} aria-label={label} aria-pressed={armed}
+        title={shortcut ? keyText(`${label} · ${shortcut}`) : label} aria-label={label} aria-pressed={armed}
         style={{ position: "relative", width: "var(--ctl-l)", height: "var(--ctl-l)", flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center", border: "1px solid transparent", borderRadius: "var(--r-1)", background: armed ? (opts.tint || "var(--cobalt)") : "transparent", color: armed ? "var(--accent-contrast)" : (opts.tint || "var(--ink)"), boxShadow: armed ? "var(--glow)" : "none", cursor: "pointer", lineHeight: 1 }}>
         <Icon name={iconName} size={17} />
-        {shortcut && <span aria-hidden="true" style={{ position: "absolute", bottom: 1, right: 3, fontFamily: "var(--f-mono)", fontSize: 8, color: armed ? "var(--accent-contrast)" : "var(--ink-muted)", opacity: armed ? 0.75 : 1 }}>{shortcut}</span>}
+        {shortcut && <span aria-hidden="true" style={{ position: "absolute", bottom: 1, right: 3, fontFamily: "var(--f-mono)", fontSize: 8, color: armed ? "var(--accent-contrast)" : "var(--ink-muted)", opacity: armed ? 0.75 : 1 }}>{keyText(shortcut)}</span>}
       </button>
     );
   };

--- a/web/test/keys.test.ts
+++ b/web/test/keys.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isApplePlatform, keyLabel, keyText } from "../src/lib/keys.ts";
+
+test("apple platforms keep the glyphs they own", () => {
+  assert.equal(keyLabel("⌘", true), "⌘");
+  assert.equal(keyText("one undo step (⌘Z).", true), "one undo step (⌘Z).");
+});
+
+test("each modifier maps to its PC label", () => {
+  assert.equal(keyLabel("⌘", false), "Ctrl");
+  assert.equal(keyLabel("⌥", false), "Alt");
+  assert.equal(keyLabel("⇧", false), "Shift");
+  assert.equal(keyLabel("⏎", false), "Enter");
+  assert.equal(keyLabel("⌫", false), "Backspace");
+});
+
+test("non-modifier keys pass through untouched", () => {
+  for (const k of ["D", "Z", "click", "scroll", "hold", "1", "–", "9"]) {
+    assert.equal(keyLabel(k, false), k);
+    assert.equal(keyLabel(k, true), k);
+  }
+});
+
+test("adjacent glyphs become one chord, not loose words", () => {
+  assert.equal(keyText("⌘Z", false), "Ctrl+Z");
+  assert.equal(keyText("⇧⌘Z", false), "Shift+Ctrl+Z");
+  assert.equal(keyText("⌘⏎ runs.", false), "Ctrl+Enter runs.");
+});
+
+test("a glyph followed by a non-alphanumeric keeps the punctuation", () => {
+  assert.equal(keyText("⌥-click carves an enclosed cutout; ⏎ creates.", false),
+    "Alt-click carves an enclosed cutout; Enter creates.");
+  assert.equal(keyText("⌘/⇧ multi-select", false), "Ctrl/Shift multi-select");
+});
+
+test("several chords in one sentence each convert", () => {
+  assert.equal(keyText("⧉ Copy / ⎘ Paste (⌘C / ⌘V)", false), "⧉ Copy / ⎘ Paste (Ctrl+C / Ctrl+V)");
+});
+
+test("keyText is a no-op on text with no glyphs", () => {
+  assert.equal(keyText("Load sample plan", false), "Load sample plan");
+  assert.equal(keyText("", false), "");
+});
+
+test("platform detection is defensive about a missing or hostile navigator", () => {
+  assert.equal(isApplePlatform(null), false);   // explicit "no navigator" ⇒ spell the keys out
+  assert.equal(isApplePlatform({}), false);
+  assert.equal(isApplePlatform({ platform: 123, userAgent: {} }), false);
+  assert.equal(isApplePlatform({ platform: "MacIntel" }), true);
+  assert.equal(isApplePlatform({ userAgent: "Mozilla/5.0 (iPad; CPU OS 17_0)" }), true);
+  assert.equal(isApplePlatform({ platform: "Win32" }), false);
+  assert.equal(isApplePlatform({ platform: "Linux x86_64" }), false);
+});


### PR DESCRIPTION
Every shortcut in the canvas has always BEHAVED correctly on Windows — the
handlers test `e.metaKey || e.ctrlKey` together and `altKey` is the same key
everywhere. What was never correct is the LABEL. The tables, tooltips, toolbar
badges and commit messages were transcribed from a Mac and shipped Mac glyphs,
so a Windows estimator opening the shortcut list saw ⌘ and ⌥ — symbols that are
not on the keyboard in front of them, describing shortcuts that in fact work
fine. That reads as "this app is not for me", and it is the reported complaint.

Adds `web/src/lib/keys.ts` — pure, total, platform passed in as an argument so
it is testable without a DOM and never throws on a server render:

  keyLabel(key, apple)  one key from a shortcut table  ⌘ → Ctrl
  keyText(text, apple)  glyphs inside a sentence, adjacent glyphs read as one
                        chord, so ⇧⌘Z becomes Shift+Ctrl+Z and not three words
  isApplePlatform(nav)  defensive: an absent or hostile navigator reads as NOT
                        Apple, because Ctrl/Alt is legible everywhere and ⌘ is
                        not

Wired into every surface that shows a key to a person: the in-app guide (tables
and the five-minute prose), the tool rail badges and their tooltips, the tool
menu, the takeoffs panel, the agent panel, and the One-Click commit messages
that name ⌥-click and ⏎. Comments and source data keep the glyphs — conversion
happens at render.

README gains a "Windows, macOS, Linux" section under Start here: no feature is
gated on an OS, the MCP server is CI-tested on windows-latest, the capture
server wants `python` rather than `python3` there, and locked-down enterprise
fleets are #226 and not yet built.

Verified in the running app on both branches: with the platform spoofed to
Win32 the guide renders Ctrl/Alt/Shift/Enter/Backspace, the five-minute prose
reads "In One-Click, Enter creates it", and the rail badge shows Shift+D at
34px inside a 36px button — no clipping. Letter keys pass through untouched.
8 new unit tests; `npm run check` green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
