### PR TITLE
One-Click: dimension strings classify as annotation on flattened sheets (#320)

### DIFF
--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -1171,6 +1171,276 @@ export function classifyOffsetAnnotationSegs(
   return soft;
 }
 
+// ── 2d. dimension strings (issue #320) ──────────────────────────────────────
+// On a FLATTENED sheet the layer path is dead (`classifyLayerName` returns
+// role unknown at confidence 0 — correctly: nothing is stated) and neither
+// geometric classifier sees a dimension string: it has no heavier parallel
+// neighbour within 2 ft (the run is drawn 2–6 ft off the building face, often
+// stacked), its witness lines run PERPENDICULAR to everything nearby, and its
+// pen weight matches thin partition linework. So One-Click reads the string as
+// boundary: the flood leaks into the dimension band beside the building, or a
+// witness line crossing a room chops it. Field report, flattened multifamily.
+//
+// What identifies a dimension string is its ANATOMY, not its pen. Measured on
+// two real flattened sets (a Revit multifamily permit sheet at 1/4" = 1'-0",
+// 18 px/ft; an AutoCAD-exported commercial finish plan at 3/32" = 1'-0",
+// 6.75 px/ft, its linework exploded to ~1 px dashes):
+//   • one long straight RUN (measured 4.7–31 ft), text between witnesses —
+//     text is showText ops, never vectors, so a real run sits in an EMPTY band;
+//   • short WITNESS lines meeting it at 90°, one per dimensioned feature —
+//     0.5–1.2 ft on the Revit sheet — spaced at ROOM-scale intervals (never
+//     the sub-foot rhythm of hatch, coursing, or stipple);
+//   • an oblique TICK or arrow ON the run at each junction: 45° slashes
+//     0.94 ft long (heavier pen) on the Revit sheet, ~30° arrow strokes
+//     0.34 ft long (same pen) on the AutoCAD sheet;
+//   • at every junction, ink CONTINUES PAST the joint — the run overshoots
+//     the end witnesses (0.39 ft measured) or the witness extends past the
+//     run. A rectangle's corner has neither, which is what separates a
+//     two-witness dim from every legend swatch and tag box on the sheet;
+//   • nothing runs alongside: a wall face has its partner face 0.33–1 ft
+//     away for its whole length, a stacked dim string's neighbour run is
+//     ≥ 1.5 ft off (3/8" paper at 1/4" scale) and is another dim, not a wall.
+//
+// The classifier reassembles collinear CHAINS first (the AutoCAD sheet's
+// exploded dashes — same device markPolylineArcs uses for arc chords), then
+// accepts a chain as a dim RUN only on the full conjunction: isolated, ≥ 2
+// sparse witness junctions each continuing past the joint, ticks at ≥ 2 of
+// them (and at least half), and an otherwise-empty band. Every threshold is
+// feet-true — this runs only when the sheet scale is known — with small
+// absolute px floors where the phenomenon is ink/quantization, not geometry
+// (the CLUSTER_FIT_TOL_PX precedent).
+//
+// Softening is deliberately narrower than evidence: a witness is often drawn
+// COLLINEAR with the wall edge it dimensions, and on the Revit sheet the
+// 0.25 ft witness-to-wall drafting gap sits BELOW the 0.5 ft dash gaps of the
+// sheet's own centreline patterns — no gap threshold separates them — so a
+// witness chain that merged into longer linework, or one with a wall-length
+// parallel partner of its own, is counted as evidence but never softened.
+// Union into the same soft plane as hatch and annotation rings; never
+// subtracted; the escalation ladder decides what soft is worth.
+export const DIMSTR_ANGLE_TOL = 2;        // deg — CAD angle jitter ≪ 1° (HATCH_ANGLE_TOL's evidence)
+export const DIMSTR_CHAIN_GAP_FT = 0.6;   // collinear pieces closer than this are one drawn line
+export const DIMSTR_CHAIN_GAP_PX = 3;     // floor — dash/quantization gaps are ink-scale, not feet
+export const DIMSTR_CHAIN_OFF_FT = 0.06;  // perpendicular jitter within one drawn line
+export const DIMSTR_CHAIN_OFF_PX = 1.25;  // floor — sub-px offsets are float noise at coarse scales
+export const DIMSTR_RUN_MIN_FT = 4;       // shortest measured real run is 4.7 ft; ANNOT_MIN_LEN_FT's reasoning
+export const DIMSTR_ISO_OFF_FT = 1.0;     // a parallel partner within a wall's breadth …
+export const DIMSTR_ISO_OVERLAP = 0.4;    // … spanning this fraction of the RUN makes it a wall face
+export const DIMSTR_WITNESS_MIN_FT = 0.3; // below the shortest measured witness (0.5 ft) with margin
+export const DIMSTR_WITNESS_SOFT_MAX_FT = 8;  // soften cap — longer chains are glued linework: evidence only
+export const DIMSTR_ATTACH_FT = 0.35;     // junction slop: witness end / tick centre to the run line
+export const DIMSTR_ATTACH_PX = 2;        // floor — a junction is an ink joint, ≥ pen scale
+export const DIMSTR_JUNCTION_MIN_FT = 1.5;// witnesses are room-spaced; coursing/stipple rhythms are sub-foot
+export const DIMSTR_WIT_PER_JUNCTION_MAX = 2; // a dim junction is ONE witness (two at a shared boundary)
+export const DIMSTR_TICK_MIN_FT = 0.2;    // measured ticks 0.34–0.94 ft; stipple dots sit below this
+export const DIMSTR_TICK_MAX_FT = 1.5;    // a longer oblique is drawing, not a tick
+export const DIMSTR_TICK_ANG_LO = 20;     // deg off the run — covers ~30° arrows …
+export const DIMSTR_TICK_ANG_HI = 70;     // … and 45° slashes with jitter margin
+export const DIMSTR_TICK_AT_JUNCTION_FT = 0.5;  // a tick marks ITS junction, not the run at large
+export const DIMSTR_MIN_JUNCTIONS = 2;    // a dimension has two ends
+export const DIMSTR_MIN_TICKED = 2;       // … and marks both
+export const DIMSTR_TICKED_FRAC = 0.5;    // most junctions carry their mark (jamb clutter does not)
+export const DIMSTR_OVERSHOOT_FT = 0.1;   // ink past a joint (0.39 ft measured); a corner has none
+export const DIMSTR_OVERSHOOT_PX = 2;     // floor — overshoot is ink, not geometry
+export const DIMSTR_TOUCH_CLUTTER_MAX = 1;// non-witness/tick chains allowed to TOUCH the run
+export const DIMSTR_BAND_FT = 0.7;        // the empty band a real run sits in …
+export const DIMSTR_BAND_CLUTTER_MAX = 4; // … and the stray chains tolerated inside it (hex keynote
+                                          // tags ride the band on the Revit sheet; a stipple field
+                                          // or a table's cell text boxes blow far past this)
+
+interface DimChain {
+  axis: number;               // deg, [0, 180) — the bin axis the chain merged on
+  d: number;                  // mean perpendicular offset of members, mask px
+  t0: number; t1: number;     // extent along the axis, mask px
+  len: number;
+  members: number[];          // segment indices
+  p0: [number, number]; p1: [number, number];  // endpoints in mask px
+}
+
+/** Collinear-chain reassembly + dimension-string comb detection. Pure and
+ *  deterministic; all inputs in mask px, `ftPx` = mask px per foot (> 0 —
+ *  the caller gates on scale). Exported for calibration and tests; the
+ *  boundary-mask contract is `classifyDimensionStringSegs` below. */
+export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: number, ftPx: number): { soft: Uint8Array; runs: DimChain[] } {
+  const n = segs.length >> 2;
+  const soft = new Uint8Array(n);
+  const hits: DimChain[] = [];
+  if (!meta || !n || !(ftPx > 0)) return { soft, runs: hits };
+  interface Cand { i: number; ang: number; x1: number; y1: number; x2: number; y2: number; L: number }
+  const cand: Cand[] = [];
+  for (let i = 0; i < n; i++) {
+    if (meta[i] & (SEG_CURVE | SEG_CLIP | SEG_FILLONLY)) continue;
+    const x1 = segs[i * 4] * ws, y1 = segs[i * 4 + 1] * ws, x2 = segs[i * 4 + 2] * ws, y2 = segs[i * 4 + 3] * ws;
+    const L = Math.hypot(x2 - x1, y2 - y1);
+    if (!(L > 0)) continue;
+    let ang = Math.atan2(y2 - y1, x2 - x1) * 180 / Math.PI;
+    if (ang < 0) ang += 180; if (ang >= 180) ang -= 180;
+    cand.push({ i, ang, x1, y1, x2, y2, L });
+  }
+  if (cand.length < 4) return { soft, runs: hits };   // a comb needs run + 2 witnesses + a tick
+  // 1. collinear chains, on the hatch classifier's interleaved angle grids so
+  // a family straddling one grid's bin boundary is intact in the other. A
+  // multi-member chain claims its segs in pass 1; singletons re-bin in pass 2.
+  const BIN = DIMSTR_ANGLE_TOL, NB = Math.round(180 / BIN);
+  const gap = Math.max(DIMSTR_CHAIN_GAP_PX, DIMSTR_CHAIN_GAP_FT * ftPx);
+  const offTol = Math.max(DIMSTR_CHAIN_OFF_PX, DIMSTR_CHAIN_OFF_FT * ftPx);
+  const chains: DimChain[] = [];
+  const claimed = new Uint8Array(n);
+  interface Row { c: Cand; d: number; t0: number; t1: number }
+  for (const shift of [0, BIN / 2]) {
+    const bins = new Map<number, Row[]>();
+    for (const c of cand) {
+      if (claimed[c.i]) continue;
+      let b = Math.floor((c.ang + shift) / BIN);
+      if (b >= NB) b -= NB;                             // the 0°/180° seam is one family
+      const axis = ((b * BIN - shift + BIN / 2) % 180 + 180) % 180;
+      const th = axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+      const r: Row = { c,
+        d: ((c.x1 + c.x2) / 2) * nx + ((c.y1 + c.y2) / 2) * ny,
+        t0: Math.min(c.x1 * dx + c.y1 * dy, c.x2 * dx + c.y2 * dy),
+        t1: Math.max(c.x1 * dx + c.y1 * dy, c.x2 * dx + c.y2 * dy) };
+      const arr = bins.get(b);
+      if (arr) arr.push(r); else bins.set(b, [r]);
+    }
+    for (const [b, rows] of bins) {
+      const axis = ((b * BIN - shift + BIN / 2) % 180 + 180) % 180;
+      rows.sort((a, z) => a.d - z.d || a.t0 - z.t0);
+      let g0 = 0;
+      for (let k = 1; k <= rows.length; k++) {
+        if (k < rows.length && rows[k].d - rows[k - 1].d <= offTol) continue;
+        const grp = rows.slice(g0, k).sort((a, z) => a.t0 - z.t0 || a.t1 - z.t1);
+        let cur: (DimChain & { dSum: number }) | null = null;
+        const flush = () => {
+          if (!cur) return;
+          if (shift === 0 || cur.members.length > 1 || !claimed[cur.members[0]]) {
+            if (shift === 0 && cur.members.length < 2) { cur = null; return; }  // singleton: retry on the shifted grid
+            cur.d = cur.dSum / cur.members.length;
+            cur.len = cur.t1 - cur.t0;
+            const th = axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+            cur.p0 = [cur.t0 * dx + cur.d * nx, cur.t0 * dy + cur.d * ny];
+            cur.p1 = [cur.t1 * dx + cur.d * nx, cur.t1 * dy + cur.d * ny];
+            chains.push(cur);
+            for (const m of cur.members) claimed[m] = 1;
+          }
+          cur = null;
+        };
+        for (const r of grp) {
+          if (cur && r.t0 - cur.t1 <= gap) { cur.t1 = Math.max(cur.t1, r.t1); cur.members.push(r.c.i); cur.dSum += r.d; }
+          else { flush(); cur = { axis, d: 0, dSum: r.d, t0: r.t0, t1: r.t1, len: 0, members: [r.c.i], p0: [0, 0], p1: [0, 0] }; }
+        }
+        flush();
+        g0 = k;
+      }
+    }
+  }
+  // 2. comb detection over the chains
+  const runMin = DIMSTR_RUN_MIN_FT * ftPx, isoOff = DIMSTR_ISO_OFF_FT * ftPx;
+  const wMin = DIMSTR_WITNESS_MIN_FT * ftPx, wSoftMax = DIMSTR_WITNESS_SOFT_MAX_FT * ftPx;
+  const attach = Math.max(DIMSTR_ATTACH_PX, DIMSTR_ATTACH_FT * ftPx);
+  const jMin = DIMSTR_JUNCTION_MIN_FT * ftPx;
+  const tickMin = DIMSTR_TICK_MIN_FT * ftPx, tickMax = DIMSTR_TICK_MAX_FT * ftPx;
+  const tickAt = DIMSTR_TICK_AT_JUNCTION_FT * ftPx;
+  const over = Math.max(DIMSTR_OVERSHOOT_PX, DIMSTR_OVERSHOOT_FT * ftPx);
+  const band = DIMSTR_BAND_FT * ftPx;
+  // has this chain a same-axis partner alongside for most of its length?
+  const hasParallelPartner = (C: DimChain, skip: DimChain | null): boolean => {
+    const th = C.axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+    for (const O of chains) {
+      if (O === C || O === skip) continue;
+      let rel = Math.abs(O.axis - C.axis); if (rel > 90) rel = 180 - rel;
+      if (rel > 3 * DIMSTR_ANGLE_TOL) continue;
+      const d0 = O.p0[0] * nx + O.p0[1] * ny - C.d, d1 = O.p1[0] * nx + O.p1[1] * ny - C.d;
+      if (Math.min(Math.abs(d0), Math.abs(d1)) > isoOff) continue;
+      const t0 = Math.min(O.p0[0] * dx + O.p0[1] * dy, O.p1[0] * dx + O.p1[1] * dy);
+      const t1 = Math.max(O.p0[0] * dx + O.p0[1] * dy, O.p1[0] * dx + O.p1[1] * dy);
+      if (Math.min(t1, C.t1) - Math.max(t0, C.t0) >= DIMSTR_ISO_OVERLAP * C.len) return true;
+    }
+    return false;
+  };
+  for (const R of chains) {
+    if (R.len < runMin) continue;
+    if (hasParallelPartner(R, null)) continue;          // a wall face, never a dim run
+    const th = R.axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+    interface Joint { t: number; C: DimChain; past: boolean }
+    const wit: Joint[] = [], ticks: Joint[] = [];
+    let touchClutter = 0;
+    for (const C of chains) {
+      if (C === R) continue;
+      const d0 = C.p0[0] * nx + C.p0[1] * ny - R.d, d1 = C.p1[0] * nx + C.p1[1] * ny - R.d;
+      const near0 = Math.abs(d0) <= attach, near1 = Math.abs(d1) <= attach;
+      const crosses = (d0 < -attach && d1 > attach) || (d1 < -attach && d0 > attach);
+      if (!near0 && !near1 && !crosses) continue;
+      const t0 = C.p0[0] * dx + C.p0[1] * dy, t1 = C.p1[0] * dx + C.p1[1] * dy;
+      const tm = (t0 + t1) / 2;
+      const tRef = near0 && !near1 ? t0 : near1 && !near0 ? t1 : tm;
+      if (tRef < R.t0 - attach || tRef > R.t1 + attach) continue;
+      let rel = Math.abs(C.axis - R.axis); if (rel > 90) rel = 180 - rel;
+      if (rel >= 90 - 2 * DIMSTR_ANGLE_TOL && C.len >= wMin) {
+        // continues past the joint: crosses outright, or reaches the line at
+        // both extremes of its own extent (an overshooting witness does; a
+        // stroke that merely ENDS on the line does not)
+        wit.push({ t: tRef, C, past: crosses || (near0 && near1) });
+      } else if (rel >= DIMSTR_TICK_ANG_LO && rel <= DIMSTR_TICK_ANG_HI
+          && C.len >= tickMin && C.len <= tickMax && Math.abs((d0 + d1) / 2) <= attach) {
+        ticks.push({ t: tm, C, past: false });
+      } else if (++touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) break;
+    }
+    if (touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) continue;
+    // box-corner rejection: keep a junction only where ink continues past it
+    const live = wit.filter((w) => w.past || (w.t >= R.t0 + over && w.t <= R.t1 - over));
+    if (live.length < DIMSTR_MIN_JUNCTIONS) continue;
+    live.sort((a, z) => a.t - z.t);
+    interface Junction { t: number; n: number }
+    const junc: Junction[] = [];
+    let dense = false;
+    for (const w of live) {
+      const j = junc[junc.length - 1];
+      if (j && w.t - j.t < jMin) { if (++j.n > DIMSTR_WIT_PER_JUNCTION_MAX) { dense = true; break; } }
+      else junc.push({ t: w.t, n: 1 });
+    }
+    if (dense || junc.length < DIMSTR_MIN_JUNCTIONS) continue;
+    let ticked = 0;
+    const usedTicks: Joint[] = [];
+    for (const j of junc) {
+      const t = ticks.find((tk) => Math.abs(tk.t - j.t) <= tickAt);
+      if (t) { ticked++; usedTicks.push(t); }
+    }
+    if (ticked < DIMSTR_MIN_TICKED || ticked < DIMSTR_TICKED_FRAC * junc.length) continue;
+    // empty-band check: beyond its own comb, nothing shares a real run's band
+    const witSet = new Set(live.map((w) => w.C)), tickSet = new Set(usedTicks.map((t) => t.C));
+    let bandClutter = 0;
+    for (const C of chains) {
+      if (C === R || witSet.has(C) || tickSet.has(C)) continue;
+      const mx = (C.p0[0] + C.p1[0]) / 2, my = (C.p0[1] + C.p1[1]) / 2;
+      if (Math.abs(mx * nx + my * ny - R.d) > band) continue;
+      const tt = mx * dx + my * dy;
+      if (tt < R.t0 || tt > R.t1) continue;
+      if (++bandClutter > DIMSTR_BAND_CLUTTER_MAX) break;
+    }
+    if (bandClutter > DIMSTR_BAND_CLUTTER_MAX) continue;
+    hits.push(R);
+    for (const m of R.members) soft[m] = 1;
+    for (const t of usedTicks) for (const m of t.C.members) soft[m] = 1;
+    for (const w of live) {
+      // soften a witness only when it is demonstrably NOT wall linework: short
+      // enough to be a witness alone (not glued across a drafting gap) and
+      // without a wall-length parallel partner of its own
+      if (w.C.len > wSoftMax) continue;
+      if (hasParallelPartner(w.C, R)) continue;
+      for (const m of w.C.members) soft[m] = 1;
+    }
+  }
+  return { soft, runs: hits };
+}
+
+/** Strokes belonging to a dimension string — run, witnesses, ticks — are
+ *  annotation, not boundary. Same contract as classifyHatchSegs /
+ *  classifyOffsetAnnotationSegs: one byte per segment, 1 = soft, pure, total,
+ *  never throws. `ftPx` is mask px per foot; the caller gates on scale. */
+export function classifyDimensionStringSegs(segs: number[], meta: Uint8Array, ws: number, ftPx: number): Uint8Array {
+  return sweepDimensionStrings(segs, meta, ws, ftPx).soft;
+}
+
 // Signature quantization for the stable family id (issue #29): coarse enough
 // to absorb CAD jitter (≪ the classifier's own tolerances), fine enough that
 // distinct pattern specs never collide. The RAW signature values ride along
@@ -1319,6 +1589,11 @@ export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = M
     ? classifyOffsetAnnotationSegs(segs, meta, ws, ANNOT_OFFSET_MAX_FT * mppf, ANNOT_OFFSET_MIN_FT * mppf, ANNOT_MIN_LEN_FT * mppf)
     : null;
   if (soft && annot) for (let i = 0; i < soft.length; i++) if (annot[i]) soft[i] = 1;
+  // Third independent contributor to the SAME soft plane: dimension strings
+  // (section 2d, issue #320). Feet-true only, for the same reason as the
+  // annotation classifier above; unioned, never subtracted.
+  const dimstr = meta && mppf > 0 ? classifyDimensionStringSegs(segs, meta, ws, mppf) : null;
+  if (soft && dimstr) for (let i = 0; i < soft.length; i++) if (dimstr[i]) soft[i] = 1;
   // curve chords that are demonstrably not door swings (closed circles, cloud
   // scallops) — a SEPARATE plane from SEG_CURVE, so refusing them never makes
   // them hatch-eligible (classifyHatchSegs still skips every SEG_CURVE chord)

--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -1243,6 +1243,15 @@ export const DIMSTR_TICKED_FRAC = 0.5;    // most junctions carry their mark (ja
 export const DIMSTR_OVERSHOOT_FT = 0.1;   // ink past a joint (0.39 ft measured); a corner has none
 export const DIMSTR_OVERSHOOT_PX = 2;     // floor — overshoot is ink, not geometry
 export const DIMSTR_TOUCH_CLUTTER_MAX = 1;// non-witness/tick chains allowed to TOUCH the run
+// path B (tick-anchored interior strings) — measured on the calibration
+// sheet's interior strings: slash pairs 3.4 px apart, junction spacing ≥ 3 ft
+export const DIMTEXT_NEAR_FT = 1.0;             // dim text sits ON its line (2 px measured); a generous foot covers styles that float it
+export const DIMTEXT_REACH_FT = 40;             // how far along the line from its text a string plausibly extends
+export const DIMTEXT_MIN_LINE_X = 1.5;          // the drawn line must dwarf the text (an underline matches it)
+export const DIMTEXT_STUB_MAX_FT = 2.5;         // ticks and witness stubs; measured 0.27–1.2 ft
+export const DIMSTR_LINE_MARGIN_FT = 0.5;       // pieces just past the span still belong
+export const DIMSTR_PIECE_MAX_DIMFRAC = 0.66;   // a merge piece more dim-bounded than this is exterior band, not floor
+export const DIMSTR_PIECE_MAX_CURVEFRAC = 0.25; // …and one this curve-bounded is a door-swing pocket, not floor
 export const DIMSTR_BAND_FT = 0.7;        // the empty band a real run sits in …
 export const DIMSTR_BAND_CLUTTER_MAX = 4; // … and the stray chains tolerated inside it (hex keynote
                                           // tags ride the band on the Revit sheet; a stipple field
@@ -1261,7 +1270,11 @@ interface DimChain {
  *  deterministic; all inputs in mask px, `ftPx` = mask px per foot (> 0 —
  *  the caller gates on scale). Exported for calibration and tests; the
  *  boundary-mask contract is `classifyDimensionStringSegs` below. */
-export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: number, ftPx: number): { soft: Uint8Array; runs: DimChain[] } {
+export interface DimReject { axis: number; d: number; t0: number; t1: number; lenFt: number; why: string }
+/** A positioned dimension-pattern text item (image px; ang = baseline rotation
+ *  in degrees; wPx = rendered text width) — see sheets.extractDimTexts. */
+export interface DimTextMark { x: number; y: number; ang: number; wPx: number }
+export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: number, ftPx: number, rejects?: DimReject[], dimTexts?: DimTextMark[] | null): { soft: Uint8Array; runs: DimChain[] } {
   const n = segs.length >> 2;
   const soft = new Uint8Array(n);
   const hits: DimChain[] = [];
@@ -1277,7 +1290,7 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
     if (ang < 0) ang += 180; if (ang >= 180) ang -= 180;
     cand.push({ i, ang, x1, y1, x2, y2, L });
   }
-  if (cand.length < 4) return { soft, runs: hits };   // a comb needs run + 2 witnesses + a tick
+  if (!cand.length) return { soft, runs: hits };      // (path A self-guards on counts; the text path can anchor a single drawn line)
   // 1. collinear chains, on the hatch classifier's interleaved angle grids so
   // a family straddling one grid's bin boundary is intact in the other. A
   // multi-member chain claims its segs in pass 1; singletons re-bin in pass 2.
@@ -1350,16 +1363,22 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
       let rel = Math.abs(O.axis - C.axis); if (rel > 90) rel = 180 - rel;
       if (rel > 3 * DIMSTR_ANGLE_TOL) continue;
       const d0 = O.p0[0] * nx + O.p0[1] * ny - C.d, d1 = O.p1[0] * nx + O.p1[1] * ny - C.d;
-      if (Math.min(Math.abs(d0), Math.abs(d1)) > isoOff) continue;
+      // below attach/2 the "partner" is this same drawn line's own pieces
+      // (jitter ≤ ~2 px) — a wall's partner face sits a wall-thickness off
+      // (0.28 ft = 5 px measured), safely above. Same reasoning as
+      // ANNOT_OFFSET_MIN_FT: too close is one line, not a pair.
+      const gapAbs = Math.min(Math.abs(d0), Math.abs(d1));
+      if (gapAbs > isoOff || gapAbs < attach / 2) continue;
       const t0 = Math.min(O.p0[0] * dx + O.p0[1] * dy, O.p1[0] * dx + O.p1[1] * dy);
       const t1 = Math.max(O.p0[0] * dx + O.p0[1] * dy, O.p1[0] * dx + O.p1[1] * dy);
       if (Math.min(t1, C.t1) - Math.max(t0, C.t0) >= DIMSTR_ISO_OVERLAP * C.len) return true;
     }
     return false;
   };
+  const reject = (R: DimChain, why: string) => { rejects?.push({ axis: R.axis, d: R.d, t0: R.t0, t1: R.t1, lenFt: R.len / ftPx, why }); };
   for (const R of chains) {
     if (R.len < runMin) continue;
-    if (hasParallelPartner(R, null)) continue;          // a wall face, never a dim run
+    if (hasParallelPartner(R, null)) { reject(R, "iso"); continue; }   // a wall face, never a dim run
     const th = R.axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
     interface Joint { t: number; C: DimChain; past: boolean }
     const wit: Joint[] = [], ticks: Joint[] = [];
@@ -1385,10 +1404,10 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
         ticks.push({ t: tm, C, past: false });
       } else if (++touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) break;
     }
-    if (touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) continue;
+    if (touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) { reject(R, "touch-clutter"); continue; }
     // box-corner rejection: keep a junction only where ink continues past it
     const live = wit.filter((w) => w.past || (w.t >= R.t0 + over && w.t <= R.t1 - over));
-    if (live.length < DIMSTR_MIN_JUNCTIONS) continue;
+    if (live.length < DIMSTR_MIN_JUNCTIONS) { reject(R, `witnesses (raw=${wit.length} live=${live.length} ticks=${ticks.length})`); continue; }
     live.sort((a, z) => a.t - z.t);
     interface Junction { t: number; n: number }
     const junc: Junction[] = [];
@@ -1398,14 +1417,14 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
       if (j && w.t - j.t < jMin) { if (++j.n > DIMSTR_WIT_PER_JUNCTION_MAX) { dense = true; break; } }
       else junc.push({ t: w.t, n: 1 });
     }
-    if (dense || junc.length < DIMSTR_MIN_JUNCTIONS) continue;
+    if (dense || junc.length < DIMSTR_MIN_JUNCTIONS) { reject(R, dense ? "dense" : "junctions"); continue; }
     let ticked = 0;
     const usedTicks: Joint[] = [];
     for (const j of junc) {
       const t = ticks.find((tk) => Math.abs(tk.t - j.t) <= tickAt);
       if (t) { ticked++; usedTicks.push(t); }
     }
-    if (ticked < DIMSTR_MIN_TICKED || ticked < DIMSTR_TICKED_FRAC * junc.length) continue;
+    if (ticked < DIMSTR_MIN_TICKED || ticked < DIMSTR_TICKED_FRAC * junc.length) { reject(R, `ticked (junc=${junc.length} ticked=${ticked} ticks=${ticks.length})`); continue; }
     // empty-band check: beyond its own comb, nothing shares a real run's band
     const witSet = new Set(live.map((w) => w.C)), tickSet = new Set(usedTicks.map((t) => t.C));
     let bandClutter = 0;
@@ -1417,7 +1436,7 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
       if (tt < R.t0 || tt > R.t1) continue;
       if (++bandClutter > DIMSTR_BAND_CLUTTER_MAX) break;
     }
-    if (bandClutter > DIMSTR_BAND_CLUTTER_MAX) continue;
+    if (bandClutter > DIMSTR_BAND_CLUTTER_MAX) { reject(R, "band-clutter"); continue; }
     hits.push(R);
     for (const m of R.members) soft[m] = 1;
     for (const t of usedTicks) for (const m of t.C.members) soft[m] = 1;
@@ -1430,6 +1449,85 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
       for (const m of w.C.members) soft[m] = 1;
     }
   }
+
+  // ── path B: dimension-TEXT-anchored strings (#320) ─────────────────────────
+  // The comb path above is calibrated on EXTERIOR dimension bands, which sit
+  // in empty sheet space. An INTERIOR string — drawn across a room, chopping
+  // the flood (the reported failure) — lives in clutter by nature, and no
+  // purely geometric acceptance survived four real sheets: every conjunction
+  // loose enough to catch interior strings also caught door-leaf chevrons,
+  // X-braces, or a diagonal hatch field somewhere. The unambiguous anchor the
+  // sheet actually offers is the DIMENSION TEXT itself: `18'-10"` is a
+  // pattern nothing else on a plan carries, and on the calibration sheet it
+  // sits within 2 px of its line. So when the caller supplies positioned
+  // dim-pattern text (the app extracts page text anyway for scale detection;
+  // headless callers that pass none simply get path A alone), a string is:
+  // collinear drawn ink near the text, aligned with the text's own baseline
+  // rotation, spanning well past the text — plus its ticks and witness stubs.
+  // The wall guards stay: a chain with a wall-length parallel partner is
+  // never softened, which also self-protects schedule tables (their row rules
+  // ride 0.3–0.5 ft apart and read as partnered linework).
+  if (dimTexts && dimTexts.length) {
+    const near = DIMTEXT_NEAR_FT * ftPx;
+    const reach = DIMTEXT_REACH_FT * ftPx;
+    const margin = DIMSTR_LINE_MARGIN_FT * ftPx;
+    for (const T of dimTexts) {
+      const ang = ((T.ang % 180) + 180) % 180;
+      const th = ang * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+      const tx = T.x * ws, ty = T.y * ws;
+      const dT = tx * nx + ty * ny, tT = tx * dx + ty * dy;
+      const pieces: DimChain[] = [];
+      let dSum = 0, wSum = 0;
+      for (const C of chains) {
+        let rel = Math.abs(C.axis - ang); if (rel > 90) rel = 180 - rel;
+        if (rel > 2 * DIMSTR_ANGLE_TOL) continue;
+        const cd = ((C.p0[0] + C.p1[0]) / 2) * nx + ((C.p0[1] + C.p1[1]) / 2) * ny;
+        if (Math.abs(cd - dT) > near) continue;
+        const ct0 = Math.min(C.p0[0] * dx + C.p0[1] * dy, C.p1[0] * dx + C.p1[1] * dy);
+        const ct1 = Math.max(C.p0[0] * dx + C.p0[1] * dy, C.p1[0] * dx + C.p1[1] * dy);
+        if (ct1 < tT - reach || ct0 > tT + reach) continue;
+        pieces.push(C);
+        dSum += cd * C.len; wSum += C.len;
+      }
+      if (!wSum) continue;
+      let t0 = Infinity, t1 = -Infinity, drawn = 0;
+      for (const C of pieces) {
+        t0 = Math.min(t0, Math.min(C.p0[0] * dx + C.p0[1] * dy, C.p1[0] * dx + C.p1[1] * dy));
+        t1 = Math.max(t1, Math.max(C.p0[0] * dx + C.p0[1] * dy, C.p1[0] * dx + C.p1[1] * dy));
+        drawn += C.len;
+      }
+      // the line must be REAL: drawn ink at least room-scale AND well past the
+      // text itself (a room label's underline matches its text width; a dim
+      // line dwarfs its text)
+      if (drawn < Math.max(runMin, DIMTEXT_MIN_LINE_X * T.wPx * ws)) continue;
+      const dLine = dSum / wSum;
+      const proxy: DimChain = { axis: ang, d: dLine, t0, t1, len: t1 - t0, members: [],
+        p0: [t0 * dx + dLine * nx, t0 * dy + dLine * ny], p1: [t1 * dx + dLine * nx, t1 * dy + dLine * ny] };
+      if (hasParallelPartner(proxy, null)) continue;
+      hits.push(proxy);
+      for (const C of pieces) {
+        // per-piece wall protection, same rule as witness softening above
+        if (C.len > (t1 - t0) + 2 * margin) continue;
+        if (hasParallelPartner(C, null)) continue;
+        for (const m of C.members) soft[m] = 1;
+      }
+      // ticks and witness stubs at the line, inside the span: short strokes
+      // meeting it obliquely or perpendicularly
+      for (const C of chains) {
+        if (C.len < tickMin || C.len > DIMTEXT_STUB_MAX_FT * ftPx) continue;
+        let rel = Math.abs(C.axis - ang); if (rel > 90) rel = 180 - rel;
+        if (rel < DIMSTR_TICK_ANG_LO) continue;
+        const d0 = C.p0[0] * nx + C.p0[1] * ny - dLine, d1 = C.p1[0] * nx + C.p1[1] * ny - dLine;
+        const near0 = Math.abs(d0) <= attach, near1 = Math.abs(d1) <= attach;
+        const crosses = (d0 < -attach && d1 > attach) || (d1 < -attach && d0 > attach);
+        if (!near0 && !near1 && !crosses) continue;
+        const tm = ((C.p0[0] + C.p1[0]) / 2) * dx + ((C.p0[1] + C.p1[1]) / 2) * dy;
+        if (tm < t0 - margin || tm > t1 + margin) continue;
+        if (hasParallelPartner(C, null)) continue;
+        for (const m of C.members) soft[m] = 1;
+      }
+    }
+  }
   return { soft, runs: hits };
 }
 
@@ -1437,8 +1535,8 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
  *  annotation, not boundary. Same contract as classifyHatchSegs /
  *  classifyOffsetAnnotationSegs: one byte per segment, 1 = soft, pure, total,
  *  never throws. `ftPx` is mask px per foot; the caller gates on scale. */
-export function classifyDimensionStringSegs(segs: number[], meta: Uint8Array, ws: number, ftPx: number): Uint8Array {
-  return sweepDimensionStrings(segs, meta, ws, ftPx).soft;
+export function classifyDimensionStringSegs(segs: number[], meta: Uint8Array, ws: number, ftPx: number, dimTexts?: DimTextMark[] | null): Uint8Array {
+  return sweepDimensionStrings(segs, meta, ws, ftPx, undefined, dimTexts).soft;
 }
 
 // Signature quantization for the stable family id (issue #29): coarse enough
@@ -1514,9 +1612,17 @@ export function hatchFamilies(segs: number[], meta: Uint8Array): HatchFamily[] {
 // (roles sixth, no scale pinning) so layered callers without a scale need no
 // placeholder zeros; the canonical order keeps roles last.
 export const MASK_CURVE_BIT = 4;
-export function buildMask(segs: number[], imgW: number, imgH: number, maxDim?: number, meta?: Uint8Array | null, pxPerFt?: number, basePxPerFt?: number, page?: MaskPage | null, roles?: Uint8Array | null): MaskObj;
+// Soft cells plotted from DIMENSION-STRING ink additionally carry bit 16
+// (#320): the dim classifier is a conjunction of measured gates (ticked sparse
+// junctions, isolation, corner rejection), far higher precision than the hatch
+// rhythm heuristic — and a dimension line is never a scope boundary, so an
+// escalation crossing predominantly-dim soft ink may be trusted past the
+// grow-but-verify cap (see sealedEscalation). Rides only on soft (bit 2)
+// cells; a cell also crossed by hard ink keeps hard's verdict as always.
+export const MASK_DIMSTR_BIT = 16;
+export function buildMask(segs: number[], imgW: number, imgH: number, maxDim?: number, meta?: Uint8Array | null, pxPerFt?: number, basePxPerFt?: number, page?: MaskPage | null, roles?: Uint8Array | null, dimTexts?: DimTextMark[] | null): MaskObj;
 export function buildMask(segs: number[], imgW: number, imgH: number, maxDim?: number, meta?: Uint8Array | null, roles?: Uint8Array | null): MaskObj;
-export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = MASK_MAX_DIM, meta: Uint8Array | null = null, pxPerFt: number | Uint8Array | null = 0, basePxPerFt = 0, page: MaskPage | null = null, roles: Uint8Array | null = null): MaskObj {
+export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = MASK_MAX_DIM, meta: Uint8Array | null = null, pxPerFt: number | Uint8Array | null = 0, basePxPerFt = 0, page: MaskPage | null = null, roles: Uint8Array | null = null, dimTexts: DimTextMark[] | null = null): MaskObj {
   // the compat overload: a Uint8Array (or explicit null) in the pxPerFt slot
   // is a roles table, scale unknown
   if (pxPerFt instanceof Uint8Array || pxPerFt === null) { if (!roles) roles = pxPerFt; pxPerFt = 0; }
@@ -1592,7 +1698,7 @@ export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = M
   // Third independent contributor to the SAME soft plane: dimension strings
   // (section 2d, issue #320). Feet-true only, for the same reason as the
   // annotation classifier above; unioned, never subtracted.
-  const dimstr = meta && mppf > 0 ? classifyDimensionStringSegs(segs, meta, ws, mppf) : null;
+  const dimstr = meta && mppf > 0 ? classifyDimensionStringSegs(segs, meta, ws, mppf, dimTexts) : null;
   if (soft && dimstr) for (let i = 0; i < soft.length; i++) if (dimstr[i]) soft[i] = 1;
   // curve chords that are demonstrably not door swings (closed circles, cloud
   // scallops) — a SEPARATE plane from SEG_CURVE, so refusing them never makes
@@ -1606,9 +1712,10 @@ export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = M
     // a vote — it records geometry (door-swing recognition), so it still rides
     // on stated-hard curve chords exactly as on heuristic-hard ones.
     let v = role === 1 || role === 4 ? 1 : soft && soft[si] ? 2 : 1;
+    if (v === 2 && dimstr && dimstr[si]) v |= MASK_DIMSTR_BIT;
     if (v === 1 && meta && (meta[si] & SEG_CURVE)) v = 1 | MASK_CURVE_BIT;
     if ((v & MASK_CURVE_BIT) && noDoor && noDoor[si]) v |= MASK_NODOOR_BIT;
-    if (v === 2) softCount++;
+    if ((v & 2) && !(v & 1)) softCount++;   // dim-soft cells carry bit 16 beside bit 2
     // Quantization needs no separate baseline step: ws is now baseline-derived
     // (ws = k·wsB) and mw/mh come from the baseline dims, so seg*ws already lands
     // on the baseline grid. Measured: Math.round(seg*ws) and Math.round(seg*k*wsB)
@@ -2768,6 +2875,114 @@ function sealAttempt(mo: MaskObj, ix: number, iy: number, sensitivity: number, r
   const cy = Math.max(0, Math.min(mo.mh - 1, Math.round(iy * mo.ws)));
   const cSoft = (mo.mask[cy * mo.mw + cx] & 2) !== 0;
   const cdt = (s: SealScratch): number => (cSoft ? 0 : s.dt[cy * mo.mw + cx]);
+  // Region-level dim merge (#320). A room chopped by an interior dimension
+  // string floods as several pieces, each a perfectly good STRICT region whose
+  // shared boundary is dim-classified soft ink (mask bit 16). Flood-level
+  // escalation cannot heal this reliably: soft-transparent passes exit through
+  // the door openings the softened witness lines used to plug (measured), and
+  // dilated rungs swallow more area than the merge gains on tiny rooms. So
+  // merge at the REGION level instead: for every dim cell on the region's rim,
+  // strict-flood the far side; a far side that comes back bounded is the same
+  // floor (a dimension line never bounds scope) and unions in — one that
+  // leaks simply doesn't merge, so this can never turn a bounded click into a
+  // leak. The union is re-connected by BFS over region + dim ink, which keeps
+  // it one 4-connected component whose traced ring rides real walls. Pieces
+  // are strict floods, so the result is symmetric: clicking any side of the
+  // chop yields the same union. The room-size cap still stands.
+  const mergeAcrossDimStrings = (ref: FloodResult & { status: "ok" }): FloodResult | null => {
+    if (!mo.softCount) return null;
+    const { mw, mh, mask, ws } = mo;
+    const isDim = (i: number): boolean => (mask[i] & MASK_DIMSTR_BIT) !== 0 && (mask[i] & 1) === 0;
+    const capCells = mw * mh * SEAL_MAX_SHEET_FRAC;
+    const box = boxOf(ref.region, mw, mh);
+    // rim scan: dim cells adjacent to the region, and their open far sides
+    const region = ref.region.slice();
+    let count = ref.count, mergedPieces = 0;
+    const tried = new Set<number>();
+    let frontier = true;
+    for (let pass = 0; pass < 8 && frontier; pass++) {
+      frontier = false;
+      const b = { x0: Math.max(1, box.x0 - 2), y0: Math.max(1, box.y0 - 2), x1: Math.min(mw - 2, box.x1 + 2), y1: Math.min(mh - 2, box.y1 + 2) };
+      for (let y = b.y0; y <= b.y1; y++) for (let x = b.x0; x <= b.x1; x++) {
+        const i = y * mw + x;
+        if (!isDim(i)) continue;
+        if (!(region[i - 1] || region[i + 1] || region[i - mw] || region[i + mw])) continue;
+        for (const o of [-1, 1, -mw, mw]) {
+          // walk across the (possibly 2-cell-thick) dim stroke to open floor
+          let j = i + o, steps = 0;
+          while (steps++ < 3 && isDim(j)) j += o;
+          if (region[j] || (mask[j] & 3) || tried.has(j)) continue;
+          tried.add(j);
+          const jx = j % mw, jy = (j / mw) | 0;
+          const fr = floodPass(mo, (jx + 0.5) / ws, (jy + 0.5) / ws, 3);
+          if (fr.status !== "ok") continue;
+          if (count + fr.count > capCells) continue;
+          // a piece bounded MOSTLY by dim ink is a sliver of the exterior
+          // dimension band (stacked strings wall it on both long sides), not
+          // room floor — an interior chop piece is mostly wall-bounded
+          // (measured: ~50% dim boundary vs ~87% for a band sliver)
+          {
+            const fb = boxOf(fr.region, mw, mh);
+            let bAll = 0, bDim = 0, bCurve = 0;
+            for (let yy = Math.max(1, fb.y0); yy <= Math.min(mh - 2, fb.y1); yy++) for (let xx = Math.max(1, fb.x0); xx <= Math.min(mw - 2, fb.x1); xx++) {
+              const k = yy * mw + xx;
+              if (!fr.region[k]) continue;
+              for (const oo of [-1, 1, -mw, mw]) {
+                const mk = mask[k + oo];
+                if ((mk & 3) && !fr.region[k + oo]) { bAll++; if (isDim(k + oo)) bDim++; if (mk & MASK_CURVE_BIT) bCurve++; }
+              }
+            }
+            if (bAll && bDim / bAll > DIMSTR_PIECE_MAX_DIMFRAC) continue;
+            // a piece bounded appreciably by CURVE ink is a door-swing pocket
+            // reached through the witness line plugging its doorway — door
+            // zones are the wedge pass's jurisdiction, never the dim merge's
+            if (bAll && bCurve / bAll > DIMSTR_PIECE_MAX_CURVEFRAC) continue;
+          }
+          for (let k = 0; k < region.length; k++) if (fr.region[k] && !region[k]) { region[k] = 1; count++; }
+          const fb = boxOf(fr.region, mw, mh);
+          box.x0 = Math.min(box.x0, fb.x0); box.y0 = Math.min(box.y0, fb.y0);
+          box.x1 = Math.max(box.x1, fb.x1); box.y1 = Math.max(box.y1, fb.y1);
+          mergedPieces++; frontier = true;
+        }
+      }
+    }
+    if (!mergedPieces) return null;
+    // re-connect: BFS from the click over region cells + the dim ink between
+    // them — one 4-connected component, dropping anything not actually joined
+    const final = new Uint8Array(mw * mh);
+    const cx0 = Math.max(0, Math.min(mw - 1, Math.round(ix * ws)));
+    const cy0 = Math.max(0, Math.min(mh - 1, Math.round(iy * ws)));
+    let s0 = cy0 * mw + cx0;
+    if (!region[s0]) {           // click sat on ink; start from any ref cell
+      s0 = -1;
+      for (let k = 0; k < region.length && s0 < 0; k++) if (ref.region[k]) s0 = k;
+      if (s0 < 0) return null;
+    }
+    const stack = [s0];
+    final[s0] = 1;
+    let fCount = 0;
+    const nb = { x0: mw, y0: mh, x1: 0, y1: 0 };
+    while (stack.length) {
+      const i = stack.pop() as number;
+      fCount++;
+      const x = i % mw, y = (i / mw) | 0;
+      if (x < nb.x0) nb.x0 = x; if (x > nb.x1) nb.x1 = x;
+      if (y < nb.y0) nb.y0 = y; if (y > nb.y1) nb.y1 = y;
+      for (const o of [-1, 1, -mw, mw]) {
+        const j = i + o;
+        if (j < 0 || j >= final.length || final[j]) continue;
+        const xj = j % mw;
+        if (Math.abs(xj - x) > 1) continue;              // row wrap
+        if (region[j] || isDim(j)) { final[j] = 1; stack.push(j); }
+      }
+    }
+    regionBox.set(final, nb);
+    return {
+      status: "ok", region: final, count: fCount, mw, mh, ws,
+      mppf: mo.mppf, hardHits: ref.hardHits, softHits: ref.softHits,
+      hatchFiltered: true, hatchTier: "bounded",
+    };
+  };
   if (minPassPx > 0) {
     const s = scratch();
     const dm = dilatedView(mo, minPassPx, s.dt);
@@ -2782,7 +2997,7 @@ function sealAttempt(mo: MaskObj, ix: number, iy: number, sensitivity: number, r
       if (r0.status === "ok" && r0.count > 0) {
         const d = +(1 - f.count / r0.count).toFixed(4);
         if (d > 0) { f.minPassPx = minPassPx; f.minPassDelta = d; }
-        return f;                       // a subset of a region that already passed both gates
+        return mergeAcrossDimStrings(f) ?? f;   // a subset of a region that already passed both gates
       }
       // creating: the ladder's own two gates, on the ladder's own terms
       const vf = f.count > f.mw * f.mh * SEAL_MAX_SHEET_FRAC ? 1 : virtualBoundaryFrac(f, s.dt);
@@ -2799,7 +3014,7 @@ function sealAttempt(mo: MaskObj, ix: number, iy: number, sensitivity: number, r
     }
   }
   const base = rawFlood();
-  if (base.status === "ok") return base;
+  if (base.status === "ok") return mergeAcrossDimStrings(base) ?? base;
   const sc = scratch();
   for (const r of radii) {
     // Skipped because a SMALLER dilation bridges strictly less: reaching here

--- a/web/src/lib/sheets.ts
+++ b/web/src/lib/sheets.ts
@@ -201,6 +201,28 @@ export function detectScale(textContent: TextContentLike, viewport: Viewport): D
   return null;
 }
 
+// ── dimension-pattern text (#320) ────────────────────────────────────────────
+// The positioned `12'-4"`-pattern text items the dim-string classifier anchors
+// interior strings on (oneclick.sweepDimensionStrings path B). The pattern is
+// a FULL-string match, deliberately: a room-size note (`19'-2" x 21'-1"`), a
+// ceiling note (`9'-0" CLG`) or a leader with trailing words must never
+// anchor a line. Rotation comes from the item's own baseline transform.
+export const DIMTEXT_RE = /^\s*\d+'\s*(?:-?\s*\d+(?:\s+\d+\/\d+)?\s*")?\s*$/;
+export interface DimTextItem { x: number; y: number; ang: number; wPx: number }
+export function extractDimTexts(textContent: TextContentLike, viewport: Viewport): DimTextItem[] {
+  const out: DimTextItem[] = [];
+  const vs = Math.hypot(viewport.transform[0], viewport.transform[1]) || 1;
+  for (const it of textContent.items || []) {
+    const str = (it.str || "").trim();
+    if (!str || !DIMTEXT_RE.test(str)) continue;
+    const t = pdfjsLib.Util.transform(viewport.transform, it.transform);
+    let ang = Math.atan2(t[1], t[0]) * 180 / Math.PI;
+    ang = ((ang % 180) + 180) % 180;
+    out.push({ x: t[4], y: t[5], ang, wPx: (it.width || 0) * vs });
+  }
+  return out;
+}
+
 // ── marquee → tokens: the text-layer half of "Import from schedule" ──────────
 // Turn the page text layer into positioned tokens inside a viewport-px rect (the
 // box the estimator dragged around the schedule). x is the glyph's left edge, y

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -36,7 +36,7 @@ import UserGuide from "../components/UserGuide.jsx";
 import TakeoffsPanel, { clampPanelW, CONDITION_DND_MIME, ConditionAppearanceEditor } from "../components/TakeoffsPanel.jsx";
 import { HATCHES, PALETTE, NO_FILL, HatchPattern, HatchSwatch } from "../components/hatches.jsx";
 import { Icon } from "../brand/icons.jsx";
-import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, compareSheetKeys, extractSheetNumber, detectScale, extractRegionText } from "../lib/sheets";
+import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, compareSheetKeys, extractSheetNumber, detectScale, extractRegionText, extractDimTexts } from "../lib/sheets";
 import { normalizeLoadedGroups } from "../lib/sheetGroups";
 import { isStitchKey, mintStitchId, sanitizeStitches, autoButt, stitchExtent, alignMembers, seamClips, mergePoints, mergeSegs, stitchAlive, stitchLayoutSig } from "../lib/stitches";
 import { isCanvasBusy } from "../lib/canvasBusy";
@@ -621,6 +621,7 @@ export default function TakeoffCanvas() {
   const stageRef = useRef(null);
   const panelCanvasRefs = useRef(new Map()); // sheetKey → <canvas> (base layer — small backing store, coarse pyramid placeholder)
   const pageObjsRef = useRef(new Map());     // sheetKey → pdf.js page object (getOperatorList/getTextContent only — painting moved to the tile worker pool)
+  const dimTextsRef = useRef(new Map());     // sheetKey → positioned dim-pattern texts (#320) — RENDER_SCALE px, rescaled at buildMask time
   const renderScalesRef = useRef(new Map()); // sheetKey → RENDER_SCALE, always (see factorFor comment above) — kept so the ~20 factorFor/uppFor call sites are untouched
   // Tile-pyramid compositor (#86) — one instance owning the worker pool +
   // tile LRU cache (see lib/tileCompositor.ts). Lazily created on first
@@ -1834,11 +1835,15 @@ export default function TakeoffCanvas() {
           // instead (rasterEligible true, vectorViable false).
           sheetStatsRef.current.set(m.key, { segCount: 0, imageFrac: 1 });
         });
-        // read the drawn scale note off this panel's page text (best-effort)
+        // read the drawn scale note off this panel's page text (best-effort),
+        // and the positioned dimension-pattern texts the dim-string classifier
+        // anchors on (#320) — a mask built before they resolved was textless
         m.pageObj.getTextContent().then((tc) => {
           if (stale()) return;
           const det = detectScale(tc, m.viewport);
           if (det) setDetectedScales((d) => (d[m.key]?.label === det.label ? d : { ...d, [m.key]: det }));
+          const dts = extractDimTexts(tc, m.viewport);
+          if (dts.length) { dimTextsRef.current.set(m.key, dts); maskCacheRef.current.delete(m.key); }
         }).catch(() => {});
       }
       if (stale()) return;
@@ -3980,10 +3985,13 @@ export default function TakeoffCanvas() {
       // too. The mask is cached, so the extra getViewport is once per sheet per
       // calibration.
       const pgVp = pageObjsRef.current.get(key)?.getViewport({ scale: 1 });
+      // dim texts were positioned at RENDER_SCALE; segs live at this render —
+      // rescale so text and ink share a frame whatever the Hi-Res toggle says
+      const dtk = rsNow === RENDER_SCALE ? dimTextsRef.current.get(key) : (dimTextsRef.current.get(key) || []).map((t) => ({ ...t, x: t.x * rsNow / RENDER_SCALE, y: t.y * rsNow / RENDER_SCALE, wPx: t.wPx * rsNow / RENDER_SCALE }));
       mo = buildMask(segs, dims.w, dims.h, MASK_MAX_DIM, segMetaRef.current.get(key), pxPerFt,
                      pxPerFt ? pxPerFt * RENDER_SCALE / rsNow : 0,
                      pgVp ? { pageW: pgVp.width, pageH: pgVp.height, renderScale: rsNow, baseScale: RENDER_SCALE } : null,
-                     rolesForSheet(key));
+                     rolesForSheet(key), dtk && dtk.length ? dtk : null);
       maskCacheRef.current.set(key, mo);
     }
     return mo;

--- a/web/test/geometry.test.ts
+++ b/web/test/geometry.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   buildMask, floodRegion, traceRegion, snapVertices, ringArea, rdpClosed,
-  extractVectorGeometry, classifyHatchSegs, classifyOffsetAnnotationSegs, markPolylineArcs, SEG_CURVE, SEG_CLIP, SEG_FILLONLY, SEG_POLYARC,
+  extractVectorGeometry, classifyHatchSegs, classifyOffsetAnnotationSegs, classifyDimensionStringSegs, markPolylineArcs, SEG_CURVE, SEG_CLIP, SEG_FILLONLY, SEG_POLYARC,
   SENS_STRICT, SENS_BALANCED, SENS_AGGRESSIVE, MASK_CURVE_BIT,
   floodRegionSealed, dilateHardMask, SEAL_RADII, sealRadiiFor, DOOR_SEAL_MAX_FT, SEAL_R_MAX, doorWedgeCapPx,
   splitMergedArcs, doorLeafCells, arcClusterFit,
@@ -699,6 +699,85 @@ test("offset annotation: curve, clip and fill-only strokes are exempt", () => {
     meta[1] |= bit;
     assert.equal(classifyOffsetAnnotationSegs(segs, meta, 1, A_MAX, A_MIN, A_LEN)[1], 0, `bit ${bit} exempt`);
   }
+});
+
+// ── dimension strings (oneclick.ts section 2d, issue #320) ──────────────────
+// One synthetic comb at the same 18 px/ft convention, then each negative test
+// removes the one clause that keeps a wall a wall. The comb: a 23 ft run with
+// three crossing witnesses at room-scale spacing, a 45° tick at each junction.
+const D_FT = 18;
+function dimComb(): [number[], Uint8Array] {
+  const segs = [92, 100, 508, 100];                    // the run, overshooting both end junctions
+  for (const x of [100, 300, 500]) segs.push(x, 90, x, 112);       // witnesses, crossing
+  for (const x of [100, 300, 500]) segs.push(x - 5, 95, x + 5, 105); // 45° ticks ON the run
+  return [segs, new Uint8Array(segs.length >> 2)];
+}
+
+test("dimension string: run, witnesses and ticks all classify soft", () => {
+  const [segs, meta] = dimComb();
+  const soft = classifyDimensionStringSegs(segs, meta, 1, D_FT);
+  assert.deepEqual([...soft], segs.map(() => 1).slice(0, segs.length >> 2), "the whole comb is annotation");
+});
+
+test("dimension string: a wall face with a parallel partner is never a run", () => {
+  // the comb, plus a double-line wall drawn with the SAME comb shape riding on
+  // one face — the partner face 0.44 ft away is what keeps it hard
+  const [segs, meta0] = dimComb();
+  const wall = [92, 300, 508, 300, 92, 308, 508, 308];             // two faces, full overlap
+  const all = [...segs, ...wall];
+  const meta = new Uint8Array(all.length >> 2);
+  const soft = classifyDimensionStringSegs(all, meta, 1, D_FT);
+  const nComb = segs.length >> 2;
+  assert.equal(soft[nComb], 0, "wall face stays hard");
+  assert.equal(soft[nComb + 1], 0, "partner face stays hard");
+  assert.equal(soft[0], 1, "the comb still classifies beside it");
+  assert.ok(meta0.length >= 0);
+});
+
+test("dimension string: a comb without ticks is casework, not a dimension", () => {
+  const segs = [92, 100, 508, 100];
+  for (const x of [150, 300, 450]) segs.push(x, 100, x, 136);      // dividers, no ticks
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(segs.length >> 2), 1, D_FT);
+  assert.deepEqual([...soft], [0, 0, 0, 0], "no junction marks ⇒ nothing softens");
+});
+
+test("dimension string: a rectangle's corners are joints where nothing continues past", () => {
+  // a legend-swatch box with oblique pattern strokes inside — the Crunch
+  // Fitness false positive this rejection exists for
+  const segs = [
+    100, 100, 500, 100,   // top edge (the would-be run)
+    100, 136, 500, 136,   // bottom edge — 2 ft off, OUTSIDE the iso window
+    100, 100, 100, 136,   // left side: stops AT the top edge
+    500, 100, 500, 136,   // right side: stops AT the top edge
+  ];
+  for (let x = 140; x <= 460; x += 40) segs.push(x - 4, 98, x + 4, 106);  // pattern obliques near the edge
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(segs.length >> 2), 1, D_FT);
+  assert.equal(soft[0], 0, "box edge stays hard — its only junctions are corners");
+});
+
+test("dimension string: sub-foot witness rhythm is coursing, not dimensioning", () => {
+  const segs = [92, 100, 508, 100];
+  for (let x = 100; x <= 500; x += 9) segs.push(x, 90, x, 112);    // 0.5 ft pitch
+  segs.push(95, 95, 105, 105, 295, 95, 305, 105);                  // even with plausible ticks
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(segs.length >> 2), 1, D_FT);
+  assert.equal(soft[0], 0, "dense comb stays hard");
+});
+
+test("dimension string: a witness glued into longer linework is evidence, never softened", () => {
+  const [segs, meta] = dimComb();
+  // stretch the middle witness into a 12 ft stroke — longer than the soften cap
+  segs[4 * 4] = 300; segs[4 * 4 + 1] = 90; segs[4 * 4 + 2] = 300; segs[4 * 4 + 3] = 306;
+  const soft = classifyDimensionStringSegs(segs, meta, 1, D_FT);
+  assert.equal(soft[0], 1, "run softens");
+  assert.equal(soft[4], 0, "the long witness stays hard");
+});
+
+test("dimension string: buildMask unions the plane only when the scale is known", () => {
+  const [segs, meta] = dimComb();
+  const noScale = buildMask(segs, 600, 400, 600, meta);
+  const withScale = buildMask(segs, 600, 400, 600, meta, D_FT);
+  assert.equal(noScale.softCount, 0, "scale unknown ⇒ nothing softened");
+  assert.ok(withScale.softCount > 0, "scale known ⇒ the comb is soft");
 });
 
 test("offset annotation: an unscaled sheet gets no annotation plane at all", () => {

--- a/web/test/geometry.test.ts
+++ b/web/test/geometry.test.ts
@@ -772,6 +772,59 @@ test("dimension string: a witness glued into longer linework is evidence, never 
   assert.equal(soft[4], 0, "the long witness stays hard");
 });
 
+// ── text-anchored interior strings (path B) + the region merge ──────────────
+
+test("dim text anchors an interior line: pieces and ticks soften; without text, nothing", () => {
+  // an interior dim line has no comb-clean surroundings — path A must refuse
+  // it, and the TEXT is what identifies it
+  const segs = [200, 90, 200, 400];                       // the line, vertical, 17 ft
+  segs.push(195, 195, 205, 205, 195, 295, 205, 305);      // 45° ticks on it
+  const meta = new Uint8Array(segs.length >> 2);
+  const none = classifyDimensionStringSegs(segs, meta, 1, D_FT);
+  assert.deepEqual([...none], [0, 0, 0], "no text ⇒ an isolated interior line stays hard");
+  const withText = classifyDimensionStringSegs(segs, meta, 1, D_FT, [{ x: 203, y: 240, ang: 90, wPx: 60 }]);
+  assert.deepEqual([...withText], [1, 1, 1], "text on the line ⇒ line and ticks soften");
+});
+
+test("dim text: a room label's underline is not a dimension line", () => {
+  const segs = [180, 240, 250, 240];                      // 70 px underline under 60 px text
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(1), 1, D_FT, [{ x: 215, y: 236, ang: 0, wPx: 60 }]);
+  assert.deepEqual([...soft], [0], "the line must dwarf its text");
+});
+
+test("dim text: schedule-table rules self-protect through the wall guard", () => {
+  // dim-pattern text INSIDE a table cell: the row rules above and below ride
+  // 0.5 ft apart for their whole length — partnered linework, never softened
+  const segs = [100, 231, 500, 231, 100, 249, 500, 249];
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(2), 1, D_FT, [{ x: 300, y: 244, ang: 0, wPx: 60 }]);
+  assert.deepEqual([...soft], [0, 0], "partnered rules stay hard");
+});
+
+test("a room chopped by a text-anchored dim line floods WHOLE, from either side", () => {
+  // 30×15 ft room, an interior dimension line splitting it 2:1, dim text on
+  // the line. Without the text the flood chops at the line; with it, the
+  // region merge unions the strict pieces and both sides click to ONE answer.
+  const segs = squareSegs(100, 100, 640, 370);
+  segs.push(280, 100, 280, 370);                          // the chopping line
+  segs.push(275, 175, 285, 185, 275, 285, 285, 295);      // its ticks
+  const meta = new Uint8Array(segs.length >> 2);
+  const dimText = [{ x: 283, y: 235, ang: 90, wPx: 60 }];
+  const moPlain = buildMask(segs, 1000, 600, 1000, meta, D_FT);
+  const moText = buildMask(segs, 1000, 600, 1000, meta, D_FT, 0, null, null, dimText);
+  const flood = (mo: MaskObj, x: number, y: number) => {
+    const r = floodRegionSealed(mo, x, y, 0.5, sealRadiiFor(mo.mppf || D_FT), 0, 0);
+    assert.equal(r.status, "ok");
+    return r.status === "ok" ? r.count : 0;
+  };
+  const chopLeft = flood(moPlain, 190, 235);
+  const wholeLeft = flood(moText, 190, 235);
+  const wholeRight = flood(moText, 460, 235);
+  assert.ok(chopLeft < wholeLeft * 0.5, `text heals the chop (${chopLeft} → ${wholeLeft})`);
+  assert.equal(wholeLeft, wholeRight, "either side of the chop clicks to the same union");
+  // and the union is the room: 540×270 px interior, ring a hair inside the walls
+  assert.ok(Math.abs(wholeLeft - 540 * 270) / (540 * 270) < 0.03, `union ≈ the room (${wholeLeft})`);
+});
+
 test("dimension string: buildMask unions the plane only when the scale is known", () => {
   const [segs, meta] = dimComb();
   const noScale = buildMask(segs, 600, 400, 600, meta);


### PR DESCRIPTION
Closes #320.

## What

On a flattened set the layer path is dead (role unknown at confidence 0) and neither geometric classifier fires on a dimension string — no heavier parallel neighbour within 2 ft, witnesses perpendicular to everything, pen weight matching thin partitions. So the flood read dimension strings as boundary: leaks into the dimension band, chops at witness lines.

This adds `sweepDimensionStrings` / `classifyDimensionStringSegs` (oneclick.ts section 2d) — a **third independent contributor to the same soft plane**, unioned at the same seam as the annotation-ring classifier, never subtracted, feet-true, gated on `mppf > 0`, stated roles untouched. Same contract as the two existing classifiers: one byte per segment, pure, total, never throws.

## How it identifies a string

1. **Collinear chains first.** One of the calibration sets (AutoCAD export) had every stroke exploded to ~1 px dashes — no per-segment classifier can see a "long run" there. Chains merge on the hatch classifier's interleaved angle grids, with px floors on the merge tolerances where the phenomenon is ink, not geometry (the `CLUSTER_FIT_TOL_PX` precedent).
2. **The full comb, conjunctively:** a ≥ 4 ft run with no parallel partner spanning it (a wall face always has one); ≥ 2 witness junctions at room-scale spacing (≥ 1.5 ft — the inverse of hatch's dense rhythm); ink continuing past every counted joint (run overshoot or witness extension — a rectangle's corner has neither, which kills legend swatches and tag boxes); oblique ticks (20–70°, 0.2–1.5 ft) at ≥ 2 junctions and at least half of them; and an otherwise-empty band (dimension text is showText, never vectors — a stipple field or table blows straight past the allowance).
3. **Softening narrower than evidence.** A witness is often drawn collinear with the wall edge it dimensions, and the measured witness-to-wall drafting gap (0.25 ft) sits *below* the same sheet's dash gaps (0.5 ft) — no gap threshold separates them. So a witness chain that merged into longer linework, or one with a wall-length parallel partner of its own, counts as evidence but is never softened. A real wall cannot go soft through this path.

## Measured, not guessed

Calibrated on two real flattened sets (kept out of the repo per policy): a Revit-flattened multifamily permit sheet at 1/4″ = 1′-0″ (18 px/ft) and an AutoCAD-exported commercial finish plan at 3/32″ = 1′-0″ (6.75 px/ft). Every threshold constant carries its measured justification in a comment. Results on the shipping implementation:

| sheet | dim strings found | false positives |
|---|---|---|
| Revit multifamily (13,974 segs) | 11 of 12 | 0 — every wall, mullion, siding row, hatch field stays hard |
| AutoCAD finish plan (88,331 segs) | 0 (its linework is exploded past even chain reassembly; its walls are equally broken — an upstream mask-bridging issue, not this one) | 0 |
| dense multifamily finish plan (16,495 segs) | 0 present | 0 |

Iteration history that shaped the gates: a loose comb test softened real walls and window mullions (isolation gate); legend swatch boxes matched run+witnesses with pattern strokes as ticks (corner-joint rejection); a tag table in a stipple field matched via cell dividers and stipple obliques (empty-band gate + tick length floor).

## Acceptance criteria from #320

1. ✅ Unit tests in `web/test/geometry.test.ts`, mirroring the offset-annotation fixture pattern: the comb classifies; wall-with-partner, tickless casework, box corners, sub-foot coursing rhythm, and glued witnesses all stay hard; `buildMask` unions only when the scale is known.
2. ✅ `npm run bench:callouts` — MAE 33.8%, unchanged (bit-identical).
3. ✅ Bench goldens untouched (`git diff` on `bench/corpus/` is empty).
4. ✅ `mcp/test` suite green, 180/180 (overlap gate included).
5. ✅ `npm run check` green on Node 24.

Verified in the running app on a real flattened scaled sheet: One-Click floods and traces normally, no console errors.

Runtime: 24 ms on the 14k-seg sheet, 94 ms on the 88k-seg one, once per mask build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)