### PR TITLE
Every mark signs its author — attribution without accounts (#314)

### DIFF
--- a/web/src/components/ReportPanel.jsx
+++ b/web/src/components/ReportPanel.jsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "../brand/icons.jsx";
 import ToolMenu from "./ToolMenu.jsx";
-import { conditionTotals, grandTotals, sheetTotals, sheetGroupedRows, labelGroupedRows, sheetLabelGroupedRows, round2, totalsToCsv, downloadText, materialsSummary, reportJson, hasMultipliers, BY_SHEET_BASE_NOTE } from "../lib/totals.js";
+import { conditionTotals, grandTotals, sheetTotals, sheetGroupedRows, labelGroupedRows, authorGroupedRows, sheetLabelGroupedRows, round2, totalsToCsv, downloadText, materialsSummary, reportJson, hasMultipliers, BY_SHEET_BASE_NOTE } from "../lib/totals.js";
 import { TABLE_PROFILE, CSV_PROFILE, colGetter, customColProfile, specColProfile, laborColProfile, rollColProfile, partitionRowsBy, forceIncludeGroupCol, loadColPrefs, saveColPrefs, loadGroupBy, saveGroupBy, visibleCols, floorPerimeterLf, applyUnits } from "../lib/reportColumns.js";
 import { rollReportRows, seamLfByShape } from "../lib/rollTakeoff.js";
 import { areaVal, areaUnit, lenVal, lenUnit } from "../lib/units";
@@ -158,7 +158,8 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
   // global string, so a leftover "label" opened on a label-less project (or a
   // template carrying it) must fall back to ungrouped, exactly as a stale
   // custom-column id does.
-  const groupBy = groupByRaw === "sheet" || (groupByRaw === "label" && shapeLabels.length > 0) || conditionColumns.some((cc) => cc.id === groupByRaw) ? groupByRaw : "";
+  const hasAuthors = shapes.some((s) => typeof s.author === "string" && s.author.trim());
+  const groupBy = groupByRaw === "sheet" || (groupByRaw === "label" && shapeLabels.length > 0) || (groupByRaw === "author" && hasAuthors) || conditionColumns.some((cc) => cc.id === groupByRaw) ? groupByRaw : "";
   // grouping force-includes its column in the CSV/XLSX even when hidden in
   // the picker (D7) — a grouped report's export always carries its grouping
   const csvCols = forceIncludeGroupCol(visibleCols([...CSV_PROFILE, ...customCols, ...specCols, ...laborCols, ...rollCols], colPrefs), customCols, groupBy);
@@ -191,10 +192,12 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
   // label mode: ORDERED per-bucket rows (waste + ×N per slice), already shaped
   // { value, label, rows, perimByCond } like the sheet groups after mapping.
   const labelGroups = useMemo(() => (groupBy === "label" ? labelGroupedRows(conditions, shapes, shapeLabels, seamCtx) : null), [groupBy, conditions, shapes, shapeLabels, seamCtx]);
+  // per-author rollups (#314) — same contract as the label groups
+  const authorGroups = useMemo(() => (groupBy === "author" ? authorGroupedRows(conditions, shapes, seamCtx) : null), [groupBy, conditions, shapes, seamCtx]);
   const groups = sheetGroups
     ? sheetGroups.map((gp) => ({ value: gp.sheet_id, label: sheetLabel ? sheetLabel(gp.sheet_id) : gp.sheet_id, rows: gp.rows, perimByCond: gp.perimByCond }))
-    : labelGroups || colGroups;
-  const grouped = Boolean(groups && (groups.length > 1 || ((groupCol || groupBy === "label") && groups.length === 1 && groups[0].value !== null)));
+    : labelGroups || authorGroups || colGroups;
+  const grouped = Boolean(groups && (groups.length > 1 || ((groupCol || groupBy === "label" || groupBy === "author") && groups.length === 1 && groups[0].value !== null)));
   // exports always carry the by-label breakdown when any shape is labeled,
   // independent of the current group-by view; empty (→ CSV/JSON byte-unchanged)
   // for label-less projects.
@@ -410,6 +413,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
             <option value="">None</option>
             <option value="sheet">Sheet</option>
             {shapeLabels.length > 0 && <option value="label">Label</option>}
+            {hasAuthors && <option value="author">Author</option>}
             {conditionColumns.map((cc) => (
               <option key={cc.id} value={cc.id}>{columnLabel(cc)}</option>
             ))}
@@ -682,7 +686,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
               the partition degenerates to one group. */}
           {grouped && (
             <p style={{ maxWidth: 980, margin: "0 auto 8px", fontSize: 11.5, color: "var(--ink-muted)" }}>
-              Grouped by <strong>{groupCol ? columnLabel(groupCol) : groupBy === "label" ? "label" : "sheet"}</strong>
+              Grouped by <strong>{groupCol ? columnLabel(groupCol) : groupBy === "label" ? "label" : groupBy === "author" ? "author" : "sheet"}</strong>
             </p>
           )}
           <table style={{ width: "100%", maxWidth: 980, margin: "0 auto", borderCollapse: "collapse", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)" }}>

--- a/web/src/lib/markedset.js
+++ b/web/src/lib/markedset.js
@@ -20,6 +20,22 @@
 
 import { conditionTotals, sheetTotals, roundSheetRow, hasMultipliers, BY_SHEET_BASE_NOTE } from "./totals.js";
 import { approvalInk, approvalTally, APPROVAL_R } from "./approvals.js";
+
+// The cover's author line (#314), pure for the node runner: named authors
+// sorted, unattributed counted last, null when NO shape carries an author so
+// an unattributed export stays byte-identical.
+export function authorTallyLine(shapes) {
+  const byAuthor = new Map();
+  for (const s of shapes || []) {
+    const a = typeof s.author === "string" && s.author.trim() ? s.author.trim() : "";
+    byAuthor.set(a, (byAuthor.get(a) || 0) + 1);
+  }
+  if (![...byAuthor.keys()].some(Boolean)) return null;
+  const parts = [...byAuthor.entries()]
+    .sort((a, b) => (a[0] === "" ? 1 : b[0] === "" ? -1 : a[0].localeCompare(b[0])))
+    .map(([a, n]) => `${a || "unattributed"} (${n})`);
+  return `Marks by: ${parts.join(" · ")}`;
+}
 import { pointInPoly, starPath, arrowheadPath, cloudBezier, chiselRibbon } from "./geometry.js";
 import { transformPath, svgPlacedBox } from "./svgpath.js";
 import { rfiStatus } from "./rfi.js";
@@ -342,6 +358,14 @@ export async function buildMarkedSetPdf({ projectName, dark, sheets, shapes, mar
     if (apCount.estimator || apCount.agent) {
       metaY -= 12;
       draw(`Approval stamps: ${apCount.estimator} estimator-approved · ${apCount.agent} agent-marked`, { x: 52, y: metaY, size: 9.5, font, color: muted });
+    }
+    // author attribution (#314) — the legend names who marked the set. Drawn
+    // only when a shape carries an author (the provenance-line convention), so
+    // an unattributed export stays byte-identical.
+    const authorsLine = authorTallyLine(markedShapes);
+    if (authorsLine) {
+      metaY -= 12;
+      draw(authorsLine, { x: 52, y: metaY, size: 9.5, font, color: muted });
     }
     let y = metaY - 34;
     const rows = conditionTotals(conditions, markedShapes).filter((r) => r.shape_count > 0);

--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -1171,6 +1171,276 @@ export function classifyOffsetAnnotationSegs(
   return soft;
 }
 
+// ── 2d. dimension strings (issue #320) ──────────────────────────────────────
+// On a FLATTENED sheet the layer path is dead (`classifyLayerName` returns
+// role unknown at confidence 0 — correctly: nothing is stated) and neither
+// geometric classifier sees a dimension string: it has no heavier parallel
+// neighbour within 2 ft (the run is drawn 2–6 ft off the building face, often
+// stacked), its witness lines run PERPENDICULAR to everything nearby, and its
+// pen weight matches thin partition linework. So One-Click reads the string as
+// boundary: the flood leaks into the dimension band beside the building, or a
+// witness line crossing a room chops it. Field report, flattened multifamily.
+//
+// What identifies a dimension string is its ANATOMY, not its pen. Measured on
+// two real flattened sets (a Revit multifamily permit sheet at 1/4" = 1'-0",
+// 18 px/ft; an AutoCAD-exported commercial finish plan at 3/32" = 1'-0",
+// 6.75 px/ft, its linework exploded to ~1 px dashes):
+//   • one long straight RUN (measured 4.7–31 ft), text between witnesses —
+//     text is showText ops, never vectors, so a real run sits in an EMPTY band;
+//   • short WITNESS lines meeting it at 90°, one per dimensioned feature —
+//     0.5–1.2 ft on the Revit sheet — spaced at ROOM-scale intervals (never
+//     the sub-foot rhythm of hatch, coursing, or stipple);
+//   • an oblique TICK or arrow ON the run at each junction: 45° slashes
+//     0.94 ft long (heavier pen) on the Revit sheet, ~30° arrow strokes
+//     0.34 ft long (same pen) on the AutoCAD sheet;
+//   • at every junction, ink CONTINUES PAST the joint — the run overshoots
+//     the end witnesses (0.39 ft measured) or the witness extends past the
+//     run. A rectangle's corner has neither, which is what separates a
+//     two-witness dim from every legend swatch and tag box on the sheet;
+//   • nothing runs alongside: a wall face has its partner face 0.33–1 ft
+//     away for its whole length, a stacked dim string's neighbour run is
+//     ≥ 1.5 ft off (3/8" paper at 1/4" scale) and is another dim, not a wall.
+//
+// The classifier reassembles collinear CHAINS first (the AutoCAD sheet's
+// exploded dashes — same device markPolylineArcs uses for arc chords), then
+// accepts a chain as a dim RUN only on the full conjunction: isolated, ≥ 2
+// sparse witness junctions each continuing past the joint, ticks at ≥ 2 of
+// them (and at least half), and an otherwise-empty band. Every threshold is
+// feet-true — this runs only when the sheet scale is known — with small
+// absolute px floors where the phenomenon is ink/quantization, not geometry
+// (the CLUSTER_FIT_TOL_PX precedent).
+//
+// Softening is deliberately narrower than evidence: a witness is often drawn
+// COLLINEAR with the wall edge it dimensions, and on the Revit sheet the
+// 0.25 ft witness-to-wall drafting gap sits BELOW the 0.5 ft dash gaps of the
+// sheet's own centreline patterns — no gap threshold separates them — so a
+// witness chain that merged into longer linework, or one with a wall-length
+// parallel partner of its own, is counted as evidence but never softened.
+// Union into the same soft plane as hatch and annotation rings; never
+// subtracted; the escalation ladder decides what soft is worth.
+export const DIMSTR_ANGLE_TOL = 2;        // deg — CAD angle jitter ≪ 1° (HATCH_ANGLE_TOL's evidence)
+export const DIMSTR_CHAIN_GAP_FT = 0.6;   // collinear pieces closer than this are one drawn line
+export const DIMSTR_CHAIN_GAP_PX = 3;     // floor — dash/quantization gaps are ink-scale, not feet
+export const DIMSTR_CHAIN_OFF_FT = 0.06;  // perpendicular jitter within one drawn line
+export const DIMSTR_CHAIN_OFF_PX = 1.25;  // floor — sub-px offsets are float noise at coarse scales
+export const DIMSTR_RUN_MIN_FT = 4;       // shortest measured real run is 4.7 ft; ANNOT_MIN_LEN_FT's reasoning
+export const DIMSTR_ISO_OFF_FT = 1.0;     // a parallel partner within a wall's breadth …
+export const DIMSTR_ISO_OVERLAP = 0.4;    // … spanning this fraction of the RUN makes it a wall face
+export const DIMSTR_WITNESS_MIN_FT = 0.3; // below the shortest measured witness (0.5 ft) with margin
+export const DIMSTR_WITNESS_SOFT_MAX_FT = 8;  // soften cap — longer chains are glued linework: evidence only
+export const DIMSTR_ATTACH_FT = 0.35;     // junction slop: witness end / tick centre to the run line
+export const DIMSTR_ATTACH_PX = 2;        // floor — a junction is an ink joint, ≥ pen scale
+export const DIMSTR_JUNCTION_MIN_FT = 1.5;// witnesses are room-spaced; coursing/stipple rhythms are sub-foot
+export const DIMSTR_WIT_PER_JUNCTION_MAX = 2; // a dim junction is ONE witness (two at a shared boundary)
+export const DIMSTR_TICK_MIN_FT = 0.2;    // measured ticks 0.34–0.94 ft; stipple dots sit below this
+export const DIMSTR_TICK_MAX_FT = 1.5;    // a longer oblique is drawing, not a tick
+export const DIMSTR_TICK_ANG_LO = 20;     // deg off the run — covers ~30° arrows …
+export const DIMSTR_TICK_ANG_HI = 70;     // … and 45° slashes with jitter margin
+export const DIMSTR_TICK_AT_JUNCTION_FT = 0.5;  // a tick marks ITS junction, not the run at large
+export const DIMSTR_MIN_JUNCTIONS = 2;    // a dimension has two ends
+export const DIMSTR_MIN_TICKED = 2;       // … and marks both
+export const DIMSTR_TICKED_FRAC = 0.5;    // most junctions carry their mark (jamb clutter does not)
+export const DIMSTR_OVERSHOOT_FT = 0.1;   // ink past a joint (0.39 ft measured); a corner has none
+export const DIMSTR_OVERSHOOT_PX = 2;     // floor — overshoot is ink, not geometry
+export const DIMSTR_TOUCH_CLUTTER_MAX = 1;// non-witness/tick chains allowed to TOUCH the run
+export const DIMSTR_BAND_FT = 0.7;        // the empty band a real run sits in …
+export const DIMSTR_BAND_CLUTTER_MAX = 4; // … and the stray chains tolerated inside it (hex keynote
+                                          // tags ride the band on the Revit sheet; a stipple field
+                                          // or a table's cell text boxes blow far past this)
+
+interface DimChain {
+  axis: number;               // deg, [0, 180) — the bin axis the chain merged on
+  d: number;                  // mean perpendicular offset of members, mask px
+  t0: number; t1: number;     // extent along the axis, mask px
+  len: number;
+  members: number[];          // segment indices
+  p0: [number, number]; p1: [number, number];  // endpoints in mask px
+}
+
+/** Collinear-chain reassembly + dimension-string comb detection. Pure and
+ *  deterministic; all inputs in mask px, `ftPx` = mask px per foot (> 0 —
+ *  the caller gates on scale). Exported for calibration and tests; the
+ *  boundary-mask contract is `classifyDimensionStringSegs` below. */
+export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: number, ftPx: number): { soft: Uint8Array; runs: DimChain[] } {
+  const n = segs.length >> 2;
+  const soft = new Uint8Array(n);
+  const hits: DimChain[] = [];
+  if (!meta || !n || !(ftPx > 0)) return { soft, runs: hits };
+  interface Cand { i: number; ang: number; x1: number; y1: number; x2: number; y2: number; L: number }
+  const cand: Cand[] = [];
+  for (let i = 0; i < n; i++) {
+    if (meta[i] & (SEG_CURVE | SEG_CLIP | SEG_FILLONLY)) continue;
+    const x1 = segs[i * 4] * ws, y1 = segs[i * 4 + 1] * ws, x2 = segs[i * 4 + 2] * ws, y2 = segs[i * 4 + 3] * ws;
+    const L = Math.hypot(x2 - x1, y2 - y1);
+    if (!(L > 0)) continue;
+    let ang = Math.atan2(y2 - y1, x2 - x1) * 180 / Math.PI;
+    if (ang < 0) ang += 180; if (ang >= 180) ang -= 180;
+    cand.push({ i, ang, x1, y1, x2, y2, L });
+  }
+  if (cand.length < 4) return { soft, runs: hits };   // a comb needs run + 2 witnesses + a tick
+  // 1. collinear chains, on the hatch classifier's interleaved angle grids so
+  // a family straddling one grid's bin boundary is intact in the other. A
+  // multi-member chain claims its segs in pass 1; singletons re-bin in pass 2.
+  const BIN = DIMSTR_ANGLE_TOL, NB = Math.round(180 / BIN);
+  const gap = Math.max(DIMSTR_CHAIN_GAP_PX, DIMSTR_CHAIN_GAP_FT * ftPx);
+  const offTol = Math.max(DIMSTR_CHAIN_OFF_PX, DIMSTR_CHAIN_OFF_FT * ftPx);
+  const chains: DimChain[] = [];
+  const claimed = new Uint8Array(n);
+  interface Row { c: Cand; d: number; t0: number; t1: number }
+  for (const shift of [0, BIN / 2]) {
+    const bins = new Map<number, Row[]>();
+    for (const c of cand) {
+      if (claimed[c.i]) continue;
+      let b = Math.floor((c.ang + shift) / BIN);
+      if (b >= NB) b -= NB;                             // the 0°/180° seam is one family
+      const axis = ((b * BIN - shift + BIN / 2) % 180 + 180) % 180;
+      const th = axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+      const r: Row = { c,
+        d: ((c.x1 + c.x2) / 2) * nx + ((c.y1 + c.y2) / 2) * ny,
+        t0: Math.min(c.x1 * dx + c.y1 * dy, c.x2 * dx + c.y2 * dy),
+        t1: Math.max(c.x1 * dx + c.y1 * dy, c.x2 * dx + c.y2 * dy) };
+      const arr = bins.get(b);
+      if (arr) arr.push(r); else bins.set(b, [r]);
+    }
+    for (const [b, rows] of bins) {
+      const axis = ((b * BIN - shift + BIN / 2) % 180 + 180) % 180;
+      rows.sort((a, z) => a.d - z.d || a.t0 - z.t0);
+      let g0 = 0;
+      for (let k = 1; k <= rows.length; k++) {
+        if (k < rows.length && rows[k].d - rows[k - 1].d <= offTol) continue;
+        const grp = rows.slice(g0, k).sort((a, z) => a.t0 - z.t0 || a.t1 - z.t1);
+        let cur: (DimChain & { dSum: number }) | null = null;
+        const flush = () => {
+          if (!cur) return;
+          if (shift === 0 || cur.members.length > 1 || !claimed[cur.members[0]]) {
+            if (shift === 0 && cur.members.length < 2) { cur = null; return; }  // singleton: retry on the shifted grid
+            cur.d = cur.dSum / cur.members.length;
+            cur.len = cur.t1 - cur.t0;
+            const th = axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+            cur.p0 = [cur.t0 * dx + cur.d * nx, cur.t0 * dy + cur.d * ny];
+            cur.p1 = [cur.t1 * dx + cur.d * nx, cur.t1 * dy + cur.d * ny];
+            chains.push(cur);
+            for (const m of cur.members) claimed[m] = 1;
+          }
+          cur = null;
+        };
+        for (const r of grp) {
+          if (cur && r.t0 - cur.t1 <= gap) { cur.t1 = Math.max(cur.t1, r.t1); cur.members.push(r.c.i); cur.dSum += r.d; }
+          else { flush(); cur = { axis, d: 0, dSum: r.d, t0: r.t0, t1: r.t1, len: 0, members: [r.c.i], p0: [0, 0], p1: [0, 0] }; }
+        }
+        flush();
+        g0 = k;
+      }
+    }
+  }
+  // 2. comb detection over the chains
+  const runMin = DIMSTR_RUN_MIN_FT * ftPx, isoOff = DIMSTR_ISO_OFF_FT * ftPx;
+  const wMin = DIMSTR_WITNESS_MIN_FT * ftPx, wSoftMax = DIMSTR_WITNESS_SOFT_MAX_FT * ftPx;
+  const attach = Math.max(DIMSTR_ATTACH_PX, DIMSTR_ATTACH_FT * ftPx);
+  const jMin = DIMSTR_JUNCTION_MIN_FT * ftPx;
+  const tickMin = DIMSTR_TICK_MIN_FT * ftPx, tickMax = DIMSTR_TICK_MAX_FT * ftPx;
+  const tickAt = DIMSTR_TICK_AT_JUNCTION_FT * ftPx;
+  const over = Math.max(DIMSTR_OVERSHOOT_PX, DIMSTR_OVERSHOOT_FT * ftPx);
+  const band = DIMSTR_BAND_FT * ftPx;
+  // has this chain a same-axis partner alongside for most of its length?
+  const hasParallelPartner = (C: DimChain, skip: DimChain | null): boolean => {
+    const th = C.axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+    for (const O of chains) {
+      if (O === C || O === skip) continue;
+      let rel = Math.abs(O.axis - C.axis); if (rel > 90) rel = 180 - rel;
+      if (rel > 3 * DIMSTR_ANGLE_TOL) continue;
+      const d0 = O.p0[0] * nx + O.p0[1] * ny - C.d, d1 = O.p1[0] * nx + O.p1[1] * ny - C.d;
+      if (Math.min(Math.abs(d0), Math.abs(d1)) > isoOff) continue;
+      const t0 = Math.min(O.p0[0] * dx + O.p0[1] * dy, O.p1[0] * dx + O.p1[1] * dy);
+      const t1 = Math.max(O.p0[0] * dx + O.p0[1] * dy, O.p1[0] * dx + O.p1[1] * dy);
+      if (Math.min(t1, C.t1) - Math.max(t0, C.t0) >= DIMSTR_ISO_OVERLAP * C.len) return true;
+    }
+    return false;
+  };
+  for (const R of chains) {
+    if (R.len < runMin) continue;
+    if (hasParallelPartner(R, null)) continue;          // a wall face, never a dim run
+    const th = R.axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+    interface Joint { t: number; C: DimChain; past: boolean }
+    const wit: Joint[] = [], ticks: Joint[] = [];
+    let touchClutter = 0;
+    for (const C of chains) {
+      if (C === R) continue;
+      const d0 = C.p0[0] * nx + C.p0[1] * ny - R.d, d1 = C.p1[0] * nx + C.p1[1] * ny - R.d;
+      const near0 = Math.abs(d0) <= attach, near1 = Math.abs(d1) <= attach;
+      const crosses = (d0 < -attach && d1 > attach) || (d1 < -attach && d0 > attach);
+      if (!near0 && !near1 && !crosses) continue;
+      const t0 = C.p0[0] * dx + C.p0[1] * dy, t1 = C.p1[0] * dx + C.p1[1] * dy;
+      const tm = (t0 + t1) / 2;
+      const tRef = near0 && !near1 ? t0 : near1 && !near0 ? t1 : tm;
+      if (tRef < R.t0 - attach || tRef > R.t1 + attach) continue;
+      let rel = Math.abs(C.axis - R.axis); if (rel > 90) rel = 180 - rel;
+      if (rel >= 90 - 2 * DIMSTR_ANGLE_TOL && C.len >= wMin) {
+        // continues past the joint: crosses outright, or reaches the line at
+        // both extremes of its own extent (an overshooting witness does; a
+        // stroke that merely ENDS on the line does not)
+        wit.push({ t: tRef, C, past: crosses || (near0 && near1) });
+      } else if (rel >= DIMSTR_TICK_ANG_LO && rel <= DIMSTR_TICK_ANG_HI
+          && C.len >= tickMin && C.len <= tickMax && Math.abs((d0 + d1) / 2) <= attach) {
+        ticks.push({ t: tm, C, past: false });
+      } else if (++touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) break;
+    }
+    if (touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) continue;
+    // box-corner rejection: keep a junction only where ink continues past it
+    const live = wit.filter((w) => w.past || (w.t >= R.t0 + over && w.t <= R.t1 - over));
+    if (live.length < DIMSTR_MIN_JUNCTIONS) continue;
+    live.sort((a, z) => a.t - z.t);
+    interface Junction { t: number; n: number }
+    const junc: Junction[] = [];
+    let dense = false;
+    for (const w of live) {
+      const j = junc[junc.length - 1];
+      if (j && w.t - j.t < jMin) { if (++j.n > DIMSTR_WIT_PER_JUNCTION_MAX) { dense = true; break; } }
+      else junc.push({ t: w.t, n: 1 });
+    }
+    if (dense || junc.length < DIMSTR_MIN_JUNCTIONS) continue;
+    let ticked = 0;
+    const usedTicks: Joint[] = [];
+    for (const j of junc) {
+      const t = ticks.find((tk) => Math.abs(tk.t - j.t) <= tickAt);
+      if (t) { ticked++; usedTicks.push(t); }
+    }
+    if (ticked < DIMSTR_MIN_TICKED || ticked < DIMSTR_TICKED_FRAC * junc.length) continue;
+    // empty-band check: beyond its own comb, nothing shares a real run's band
+    const witSet = new Set(live.map((w) => w.C)), tickSet = new Set(usedTicks.map((t) => t.C));
+    let bandClutter = 0;
+    for (const C of chains) {
+      if (C === R || witSet.has(C) || tickSet.has(C)) continue;
+      const mx = (C.p0[0] + C.p1[0]) / 2, my = (C.p0[1] + C.p1[1]) / 2;
+      if (Math.abs(mx * nx + my * ny - R.d) > band) continue;
+      const tt = mx * dx + my * dy;
+      if (tt < R.t0 || tt > R.t1) continue;
+      if (++bandClutter > DIMSTR_BAND_CLUTTER_MAX) break;
+    }
+    if (bandClutter > DIMSTR_BAND_CLUTTER_MAX) continue;
+    hits.push(R);
+    for (const m of R.members) soft[m] = 1;
+    for (const t of usedTicks) for (const m of t.C.members) soft[m] = 1;
+    for (const w of live) {
+      // soften a witness only when it is demonstrably NOT wall linework: short
+      // enough to be a witness alone (not glued across a drafting gap) and
+      // without a wall-length parallel partner of its own
+      if (w.C.len > wSoftMax) continue;
+      if (hasParallelPartner(w.C, R)) continue;
+      for (const m of w.C.members) soft[m] = 1;
+    }
+  }
+  return { soft, runs: hits };
+}
+
+/** Strokes belonging to a dimension string — run, witnesses, ticks — are
+ *  annotation, not boundary. Same contract as classifyHatchSegs /
+ *  classifyOffsetAnnotationSegs: one byte per segment, 1 = soft, pure, total,
+ *  never throws. `ftPx` is mask px per foot; the caller gates on scale. */
+export function classifyDimensionStringSegs(segs: number[], meta: Uint8Array, ws: number, ftPx: number): Uint8Array {
+  return sweepDimensionStrings(segs, meta, ws, ftPx).soft;
+}
+
 // Signature quantization for the stable family id (issue #29): coarse enough
 // to absorb CAD jitter (≪ the classifier's own tolerances), fine enough that
 // distinct pattern specs never collide. The RAW signature values ride along
@@ -1319,6 +1589,11 @@ export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = M
     ? classifyOffsetAnnotationSegs(segs, meta, ws, ANNOT_OFFSET_MAX_FT * mppf, ANNOT_OFFSET_MIN_FT * mppf, ANNOT_MIN_LEN_FT * mppf)
     : null;
   if (soft && annot) for (let i = 0; i < soft.length; i++) if (annot[i]) soft[i] = 1;
+  // Third independent contributor to the SAME soft plane: dimension strings
+  // (section 2d, issue #320). Feet-true only, for the same reason as the
+  // annotation classifier above; unioned, never subtracted.
+  const dimstr = meta && mppf > 0 ? classifyDimensionStringSegs(segs, meta, ws, mppf) : null;
+  if (soft && dimstr) for (let i = 0; i < soft.length; i++) if (dimstr[i]) soft[i] = 1;
   // curve chords that are demonstrably not door swings (closed circles, cloud
   // scallops) — a SEPARATE plane from SEG_CURVE, so refusing them never makes
   // them hatch-eligible (classifyHatchSegs still skips every SEG_CURVE chord)

--- a/web/src/lib/oneclick.ts
+++ b/web/src/lib/oneclick.ts
@@ -1243,6 +1243,15 @@ export const DIMSTR_TICKED_FRAC = 0.5;    // most junctions carry their mark (ja
 export const DIMSTR_OVERSHOOT_FT = 0.1;   // ink past a joint (0.39 ft measured); a corner has none
 export const DIMSTR_OVERSHOOT_PX = 2;     // floor — overshoot is ink, not geometry
 export const DIMSTR_TOUCH_CLUTTER_MAX = 1;// non-witness/tick chains allowed to TOUCH the run
+// path B (tick-anchored interior strings) — measured on the calibration
+// sheet's interior strings: slash pairs 3.4 px apart, junction spacing ≥ 3 ft
+export const DIMTEXT_NEAR_FT = 1.0;             // dim text sits ON its line (2 px measured); a generous foot covers styles that float it
+export const DIMTEXT_REACH_FT = 40;             // how far along the line from its text a string plausibly extends
+export const DIMTEXT_MIN_LINE_X = 1.5;          // the drawn line must dwarf the text (an underline matches it)
+export const DIMTEXT_STUB_MAX_FT = 2.5;         // ticks and witness stubs; measured 0.27–1.2 ft
+export const DIMSTR_LINE_MARGIN_FT = 0.5;       // pieces just past the span still belong
+export const DIMSTR_PIECE_MAX_DIMFRAC = 0.66;   // a merge piece more dim-bounded than this is exterior band, not floor
+export const DIMSTR_PIECE_MAX_CURVEFRAC = 0.25; // …and one this curve-bounded is a door-swing pocket, not floor
 export const DIMSTR_BAND_FT = 0.7;        // the empty band a real run sits in …
 export const DIMSTR_BAND_CLUTTER_MAX = 4; // … and the stray chains tolerated inside it (hex keynote
                                           // tags ride the band on the Revit sheet; a stipple field
@@ -1261,7 +1270,11 @@ interface DimChain {
  *  deterministic; all inputs in mask px, `ftPx` = mask px per foot (> 0 —
  *  the caller gates on scale). Exported for calibration and tests; the
  *  boundary-mask contract is `classifyDimensionStringSegs` below. */
-export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: number, ftPx: number): { soft: Uint8Array; runs: DimChain[] } {
+export interface DimReject { axis: number; d: number; t0: number; t1: number; lenFt: number; why: string }
+/** A positioned dimension-pattern text item (image px; ang = baseline rotation
+ *  in degrees; wPx = rendered text width) — see sheets.extractDimTexts. */
+export interface DimTextMark { x: number; y: number; ang: number; wPx: number }
+export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: number, ftPx: number, rejects?: DimReject[], dimTexts?: DimTextMark[] | null): { soft: Uint8Array; runs: DimChain[] } {
   const n = segs.length >> 2;
   const soft = new Uint8Array(n);
   const hits: DimChain[] = [];
@@ -1277,7 +1290,7 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
     if (ang < 0) ang += 180; if (ang >= 180) ang -= 180;
     cand.push({ i, ang, x1, y1, x2, y2, L });
   }
-  if (cand.length < 4) return { soft, runs: hits };   // a comb needs run + 2 witnesses + a tick
+  if (!cand.length) return { soft, runs: hits };      // (path A self-guards on counts; the text path can anchor a single drawn line)
   // 1. collinear chains, on the hatch classifier's interleaved angle grids so
   // a family straddling one grid's bin boundary is intact in the other. A
   // multi-member chain claims its segs in pass 1; singletons re-bin in pass 2.
@@ -1350,16 +1363,22 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
       let rel = Math.abs(O.axis - C.axis); if (rel > 90) rel = 180 - rel;
       if (rel > 3 * DIMSTR_ANGLE_TOL) continue;
       const d0 = O.p0[0] * nx + O.p0[1] * ny - C.d, d1 = O.p1[0] * nx + O.p1[1] * ny - C.d;
-      if (Math.min(Math.abs(d0), Math.abs(d1)) > isoOff) continue;
+      // below attach/2 the "partner" is this same drawn line's own pieces
+      // (jitter ≤ ~2 px) — a wall's partner face sits a wall-thickness off
+      // (0.28 ft = 5 px measured), safely above. Same reasoning as
+      // ANNOT_OFFSET_MIN_FT: too close is one line, not a pair.
+      const gapAbs = Math.min(Math.abs(d0), Math.abs(d1));
+      if (gapAbs > isoOff || gapAbs < attach / 2) continue;
       const t0 = Math.min(O.p0[0] * dx + O.p0[1] * dy, O.p1[0] * dx + O.p1[1] * dy);
       const t1 = Math.max(O.p0[0] * dx + O.p0[1] * dy, O.p1[0] * dx + O.p1[1] * dy);
       if (Math.min(t1, C.t1) - Math.max(t0, C.t0) >= DIMSTR_ISO_OVERLAP * C.len) return true;
     }
     return false;
   };
+  const reject = (R: DimChain, why: string) => { rejects?.push({ axis: R.axis, d: R.d, t0: R.t0, t1: R.t1, lenFt: R.len / ftPx, why }); };
   for (const R of chains) {
     if (R.len < runMin) continue;
-    if (hasParallelPartner(R, null)) continue;          // a wall face, never a dim run
+    if (hasParallelPartner(R, null)) { reject(R, "iso"); continue; }   // a wall face, never a dim run
     const th = R.axis * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
     interface Joint { t: number; C: DimChain; past: boolean }
     const wit: Joint[] = [], ticks: Joint[] = [];
@@ -1385,10 +1404,10 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
         ticks.push({ t: tm, C, past: false });
       } else if (++touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) break;
     }
-    if (touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) continue;
+    if (touchClutter > DIMSTR_TOUCH_CLUTTER_MAX) { reject(R, "touch-clutter"); continue; }
     // box-corner rejection: keep a junction only where ink continues past it
     const live = wit.filter((w) => w.past || (w.t >= R.t0 + over && w.t <= R.t1 - over));
-    if (live.length < DIMSTR_MIN_JUNCTIONS) continue;
+    if (live.length < DIMSTR_MIN_JUNCTIONS) { reject(R, `witnesses (raw=${wit.length} live=${live.length} ticks=${ticks.length})`); continue; }
     live.sort((a, z) => a.t - z.t);
     interface Junction { t: number; n: number }
     const junc: Junction[] = [];
@@ -1398,14 +1417,14 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
       if (j && w.t - j.t < jMin) { if (++j.n > DIMSTR_WIT_PER_JUNCTION_MAX) { dense = true; break; } }
       else junc.push({ t: w.t, n: 1 });
     }
-    if (dense || junc.length < DIMSTR_MIN_JUNCTIONS) continue;
+    if (dense || junc.length < DIMSTR_MIN_JUNCTIONS) { reject(R, dense ? "dense" : "junctions"); continue; }
     let ticked = 0;
     const usedTicks: Joint[] = [];
     for (const j of junc) {
       const t = ticks.find((tk) => Math.abs(tk.t - j.t) <= tickAt);
       if (t) { ticked++; usedTicks.push(t); }
     }
-    if (ticked < DIMSTR_MIN_TICKED || ticked < DIMSTR_TICKED_FRAC * junc.length) continue;
+    if (ticked < DIMSTR_MIN_TICKED || ticked < DIMSTR_TICKED_FRAC * junc.length) { reject(R, `ticked (junc=${junc.length} ticked=${ticked} ticks=${ticks.length})`); continue; }
     // empty-band check: beyond its own comb, nothing shares a real run's band
     const witSet = new Set(live.map((w) => w.C)), tickSet = new Set(usedTicks.map((t) => t.C));
     let bandClutter = 0;
@@ -1417,7 +1436,7 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
       if (tt < R.t0 || tt > R.t1) continue;
       if (++bandClutter > DIMSTR_BAND_CLUTTER_MAX) break;
     }
-    if (bandClutter > DIMSTR_BAND_CLUTTER_MAX) continue;
+    if (bandClutter > DIMSTR_BAND_CLUTTER_MAX) { reject(R, "band-clutter"); continue; }
     hits.push(R);
     for (const m of R.members) soft[m] = 1;
     for (const t of usedTicks) for (const m of t.C.members) soft[m] = 1;
@@ -1430,6 +1449,85 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
       for (const m of w.C.members) soft[m] = 1;
     }
   }
+
+  // ── path B: dimension-TEXT-anchored strings (#320) ─────────────────────────
+  // The comb path above is calibrated on EXTERIOR dimension bands, which sit
+  // in empty sheet space. An INTERIOR string — drawn across a room, chopping
+  // the flood (the reported failure) — lives in clutter by nature, and no
+  // purely geometric acceptance survived four real sheets: every conjunction
+  // loose enough to catch interior strings also caught door-leaf chevrons,
+  // X-braces, or a diagonal hatch field somewhere. The unambiguous anchor the
+  // sheet actually offers is the DIMENSION TEXT itself: `18'-10"` is a
+  // pattern nothing else on a plan carries, and on the calibration sheet it
+  // sits within 2 px of its line. So when the caller supplies positioned
+  // dim-pattern text (the app extracts page text anyway for scale detection;
+  // headless callers that pass none simply get path A alone), a string is:
+  // collinear drawn ink near the text, aligned with the text's own baseline
+  // rotation, spanning well past the text — plus its ticks and witness stubs.
+  // The wall guards stay: a chain with a wall-length parallel partner is
+  // never softened, which also self-protects schedule tables (their row rules
+  // ride 0.3–0.5 ft apart and read as partnered linework).
+  if (dimTexts && dimTexts.length) {
+    const near = DIMTEXT_NEAR_FT * ftPx;
+    const reach = DIMTEXT_REACH_FT * ftPx;
+    const margin = DIMSTR_LINE_MARGIN_FT * ftPx;
+    for (const T of dimTexts) {
+      const ang = ((T.ang % 180) + 180) % 180;
+      const th = ang * Math.PI / 180, dx = Math.cos(th), dy = Math.sin(th), nx = -dy, ny = dx;
+      const tx = T.x * ws, ty = T.y * ws;
+      const dT = tx * nx + ty * ny, tT = tx * dx + ty * dy;
+      const pieces: DimChain[] = [];
+      let dSum = 0, wSum = 0;
+      for (const C of chains) {
+        let rel = Math.abs(C.axis - ang); if (rel > 90) rel = 180 - rel;
+        if (rel > 2 * DIMSTR_ANGLE_TOL) continue;
+        const cd = ((C.p0[0] + C.p1[0]) / 2) * nx + ((C.p0[1] + C.p1[1]) / 2) * ny;
+        if (Math.abs(cd - dT) > near) continue;
+        const ct0 = Math.min(C.p0[0] * dx + C.p0[1] * dy, C.p1[0] * dx + C.p1[1] * dy);
+        const ct1 = Math.max(C.p0[0] * dx + C.p0[1] * dy, C.p1[0] * dx + C.p1[1] * dy);
+        if (ct1 < tT - reach || ct0 > tT + reach) continue;
+        pieces.push(C);
+        dSum += cd * C.len; wSum += C.len;
+      }
+      if (!wSum) continue;
+      let t0 = Infinity, t1 = -Infinity, drawn = 0;
+      for (const C of pieces) {
+        t0 = Math.min(t0, Math.min(C.p0[0] * dx + C.p0[1] * dy, C.p1[0] * dx + C.p1[1] * dy));
+        t1 = Math.max(t1, Math.max(C.p0[0] * dx + C.p0[1] * dy, C.p1[0] * dx + C.p1[1] * dy));
+        drawn += C.len;
+      }
+      // the line must be REAL: drawn ink at least room-scale AND well past the
+      // text itself (a room label's underline matches its text width; a dim
+      // line dwarfs its text)
+      if (drawn < Math.max(runMin, DIMTEXT_MIN_LINE_X * T.wPx * ws)) continue;
+      const dLine = dSum / wSum;
+      const proxy: DimChain = { axis: ang, d: dLine, t0, t1, len: t1 - t0, members: [],
+        p0: [t0 * dx + dLine * nx, t0 * dy + dLine * ny], p1: [t1 * dx + dLine * nx, t1 * dy + dLine * ny] };
+      if (hasParallelPartner(proxy, null)) continue;
+      hits.push(proxy);
+      for (const C of pieces) {
+        // per-piece wall protection, same rule as witness softening above
+        if (C.len > (t1 - t0) + 2 * margin) continue;
+        if (hasParallelPartner(C, null)) continue;
+        for (const m of C.members) soft[m] = 1;
+      }
+      // ticks and witness stubs at the line, inside the span: short strokes
+      // meeting it obliquely or perpendicularly
+      for (const C of chains) {
+        if (C.len < tickMin || C.len > DIMTEXT_STUB_MAX_FT * ftPx) continue;
+        let rel = Math.abs(C.axis - ang); if (rel > 90) rel = 180 - rel;
+        if (rel < DIMSTR_TICK_ANG_LO) continue;
+        const d0 = C.p0[0] * nx + C.p0[1] * ny - dLine, d1 = C.p1[0] * nx + C.p1[1] * ny - dLine;
+        const near0 = Math.abs(d0) <= attach, near1 = Math.abs(d1) <= attach;
+        const crosses = (d0 < -attach && d1 > attach) || (d1 < -attach && d0 > attach);
+        if (!near0 && !near1 && !crosses) continue;
+        const tm = ((C.p0[0] + C.p1[0]) / 2) * dx + ((C.p0[1] + C.p1[1]) / 2) * dy;
+        if (tm < t0 - margin || tm > t1 + margin) continue;
+        if (hasParallelPartner(C, null)) continue;
+        for (const m of C.members) soft[m] = 1;
+      }
+    }
+  }
   return { soft, runs: hits };
 }
 
@@ -1437,8 +1535,8 @@ export function sweepDimensionStrings(segs: number[], meta: Uint8Array, ws: numb
  *  annotation, not boundary. Same contract as classifyHatchSegs /
  *  classifyOffsetAnnotationSegs: one byte per segment, 1 = soft, pure, total,
  *  never throws. `ftPx` is mask px per foot; the caller gates on scale. */
-export function classifyDimensionStringSegs(segs: number[], meta: Uint8Array, ws: number, ftPx: number): Uint8Array {
-  return sweepDimensionStrings(segs, meta, ws, ftPx).soft;
+export function classifyDimensionStringSegs(segs: number[], meta: Uint8Array, ws: number, ftPx: number, dimTexts?: DimTextMark[] | null): Uint8Array {
+  return sweepDimensionStrings(segs, meta, ws, ftPx, undefined, dimTexts).soft;
 }
 
 // Signature quantization for the stable family id (issue #29): coarse enough
@@ -1514,9 +1612,17 @@ export function hatchFamilies(segs: number[], meta: Uint8Array): HatchFamily[] {
 // (roles sixth, no scale pinning) so layered callers without a scale need no
 // placeholder zeros; the canonical order keeps roles last.
 export const MASK_CURVE_BIT = 4;
-export function buildMask(segs: number[], imgW: number, imgH: number, maxDim?: number, meta?: Uint8Array | null, pxPerFt?: number, basePxPerFt?: number, page?: MaskPage | null, roles?: Uint8Array | null): MaskObj;
+// Soft cells plotted from DIMENSION-STRING ink additionally carry bit 16
+// (#320): the dim classifier is a conjunction of measured gates (ticked sparse
+// junctions, isolation, corner rejection), far higher precision than the hatch
+// rhythm heuristic — and a dimension line is never a scope boundary, so an
+// escalation crossing predominantly-dim soft ink may be trusted past the
+// grow-but-verify cap (see sealedEscalation). Rides only on soft (bit 2)
+// cells; a cell also crossed by hard ink keeps hard's verdict as always.
+export const MASK_DIMSTR_BIT = 16;
+export function buildMask(segs: number[], imgW: number, imgH: number, maxDim?: number, meta?: Uint8Array | null, pxPerFt?: number, basePxPerFt?: number, page?: MaskPage | null, roles?: Uint8Array | null, dimTexts?: DimTextMark[] | null): MaskObj;
 export function buildMask(segs: number[], imgW: number, imgH: number, maxDim?: number, meta?: Uint8Array | null, roles?: Uint8Array | null): MaskObj;
-export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = MASK_MAX_DIM, meta: Uint8Array | null = null, pxPerFt: number | Uint8Array | null = 0, basePxPerFt = 0, page: MaskPage | null = null, roles: Uint8Array | null = null): MaskObj {
+export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = MASK_MAX_DIM, meta: Uint8Array | null = null, pxPerFt: number | Uint8Array | null = 0, basePxPerFt = 0, page: MaskPage | null = null, roles: Uint8Array | null = null, dimTexts: DimTextMark[] | null = null): MaskObj {
   // the compat overload: a Uint8Array (or explicit null) in the pxPerFt slot
   // is a roles table, scale unknown
   if (pxPerFt instanceof Uint8Array || pxPerFt === null) { if (!roles) roles = pxPerFt; pxPerFt = 0; }
@@ -1592,7 +1698,7 @@ export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = M
   // Third independent contributor to the SAME soft plane: dimension strings
   // (section 2d, issue #320). Feet-true only, for the same reason as the
   // annotation classifier above; unioned, never subtracted.
-  const dimstr = meta && mppf > 0 ? classifyDimensionStringSegs(segs, meta, ws, mppf) : null;
+  const dimstr = meta && mppf > 0 ? classifyDimensionStringSegs(segs, meta, ws, mppf, dimTexts) : null;
   if (soft && dimstr) for (let i = 0; i < soft.length; i++) if (dimstr[i]) soft[i] = 1;
   // curve chords that are demonstrably not door swings (closed circles, cloud
   // scallops) — a SEPARATE plane from SEG_CURVE, so refusing them never makes
@@ -1606,9 +1712,10 @@ export function buildMask(segs: number[], imgW: number, imgH: number, maxDim = M
     // a vote — it records geometry (door-swing recognition), so it still rides
     // on stated-hard curve chords exactly as on heuristic-hard ones.
     let v = role === 1 || role === 4 ? 1 : soft && soft[si] ? 2 : 1;
+    if (v === 2 && dimstr && dimstr[si]) v |= MASK_DIMSTR_BIT;
     if (v === 1 && meta && (meta[si] & SEG_CURVE)) v = 1 | MASK_CURVE_BIT;
     if ((v & MASK_CURVE_BIT) && noDoor && noDoor[si]) v |= MASK_NODOOR_BIT;
-    if (v === 2) softCount++;
+    if ((v & 2) && !(v & 1)) softCount++;   // dim-soft cells carry bit 16 beside bit 2
     // Quantization needs no separate baseline step: ws is now baseline-derived
     // (ws = k·wsB) and mw/mh come from the baseline dims, so seg*ws already lands
     // on the baseline grid. Measured: Math.round(seg*ws) and Math.round(seg*k*wsB)
@@ -2768,6 +2875,114 @@ function sealAttempt(mo: MaskObj, ix: number, iy: number, sensitivity: number, r
   const cy = Math.max(0, Math.min(mo.mh - 1, Math.round(iy * mo.ws)));
   const cSoft = (mo.mask[cy * mo.mw + cx] & 2) !== 0;
   const cdt = (s: SealScratch): number => (cSoft ? 0 : s.dt[cy * mo.mw + cx]);
+  // Region-level dim merge (#320). A room chopped by an interior dimension
+  // string floods as several pieces, each a perfectly good STRICT region whose
+  // shared boundary is dim-classified soft ink (mask bit 16). Flood-level
+  // escalation cannot heal this reliably: soft-transparent passes exit through
+  // the door openings the softened witness lines used to plug (measured), and
+  // dilated rungs swallow more area than the merge gains on tiny rooms. So
+  // merge at the REGION level instead: for every dim cell on the region's rim,
+  // strict-flood the far side; a far side that comes back bounded is the same
+  // floor (a dimension line never bounds scope) and unions in — one that
+  // leaks simply doesn't merge, so this can never turn a bounded click into a
+  // leak. The union is re-connected by BFS over region + dim ink, which keeps
+  // it one 4-connected component whose traced ring rides real walls. Pieces
+  // are strict floods, so the result is symmetric: clicking any side of the
+  // chop yields the same union. The room-size cap still stands.
+  const mergeAcrossDimStrings = (ref: FloodResult & { status: "ok" }): FloodResult | null => {
+    if (!mo.softCount) return null;
+    const { mw, mh, mask, ws } = mo;
+    const isDim = (i: number): boolean => (mask[i] & MASK_DIMSTR_BIT) !== 0 && (mask[i] & 1) === 0;
+    const capCells = mw * mh * SEAL_MAX_SHEET_FRAC;
+    const box = boxOf(ref.region, mw, mh);
+    // rim scan: dim cells adjacent to the region, and their open far sides
+    const region = ref.region.slice();
+    let count = ref.count, mergedPieces = 0;
+    const tried = new Set<number>();
+    let frontier = true;
+    for (let pass = 0; pass < 8 && frontier; pass++) {
+      frontier = false;
+      const b = { x0: Math.max(1, box.x0 - 2), y0: Math.max(1, box.y0 - 2), x1: Math.min(mw - 2, box.x1 + 2), y1: Math.min(mh - 2, box.y1 + 2) };
+      for (let y = b.y0; y <= b.y1; y++) for (let x = b.x0; x <= b.x1; x++) {
+        const i = y * mw + x;
+        if (!isDim(i)) continue;
+        if (!(region[i - 1] || region[i + 1] || region[i - mw] || region[i + mw])) continue;
+        for (const o of [-1, 1, -mw, mw]) {
+          // walk across the (possibly 2-cell-thick) dim stroke to open floor
+          let j = i + o, steps = 0;
+          while (steps++ < 3 && isDim(j)) j += o;
+          if (region[j] || (mask[j] & 3) || tried.has(j)) continue;
+          tried.add(j);
+          const jx = j % mw, jy = (j / mw) | 0;
+          const fr = floodPass(mo, (jx + 0.5) / ws, (jy + 0.5) / ws, 3);
+          if (fr.status !== "ok") continue;
+          if (count + fr.count > capCells) continue;
+          // a piece bounded MOSTLY by dim ink is a sliver of the exterior
+          // dimension band (stacked strings wall it on both long sides), not
+          // room floor — an interior chop piece is mostly wall-bounded
+          // (measured: ~50% dim boundary vs ~87% for a band sliver)
+          {
+            const fb = boxOf(fr.region, mw, mh);
+            let bAll = 0, bDim = 0, bCurve = 0;
+            for (let yy = Math.max(1, fb.y0); yy <= Math.min(mh - 2, fb.y1); yy++) for (let xx = Math.max(1, fb.x0); xx <= Math.min(mw - 2, fb.x1); xx++) {
+              const k = yy * mw + xx;
+              if (!fr.region[k]) continue;
+              for (const oo of [-1, 1, -mw, mw]) {
+                const mk = mask[k + oo];
+                if ((mk & 3) && !fr.region[k + oo]) { bAll++; if (isDim(k + oo)) bDim++; if (mk & MASK_CURVE_BIT) bCurve++; }
+              }
+            }
+            if (bAll && bDim / bAll > DIMSTR_PIECE_MAX_DIMFRAC) continue;
+            // a piece bounded appreciably by CURVE ink is a door-swing pocket
+            // reached through the witness line plugging its doorway — door
+            // zones are the wedge pass's jurisdiction, never the dim merge's
+            if (bAll && bCurve / bAll > DIMSTR_PIECE_MAX_CURVEFRAC) continue;
+          }
+          for (let k = 0; k < region.length; k++) if (fr.region[k] && !region[k]) { region[k] = 1; count++; }
+          const fb = boxOf(fr.region, mw, mh);
+          box.x0 = Math.min(box.x0, fb.x0); box.y0 = Math.min(box.y0, fb.y0);
+          box.x1 = Math.max(box.x1, fb.x1); box.y1 = Math.max(box.y1, fb.y1);
+          mergedPieces++; frontier = true;
+        }
+      }
+    }
+    if (!mergedPieces) return null;
+    // re-connect: BFS from the click over region cells + the dim ink between
+    // them — one 4-connected component, dropping anything not actually joined
+    const final = new Uint8Array(mw * mh);
+    const cx0 = Math.max(0, Math.min(mw - 1, Math.round(ix * ws)));
+    const cy0 = Math.max(0, Math.min(mh - 1, Math.round(iy * ws)));
+    let s0 = cy0 * mw + cx0;
+    if (!region[s0]) {           // click sat on ink; start from any ref cell
+      s0 = -1;
+      for (let k = 0; k < region.length && s0 < 0; k++) if (ref.region[k]) s0 = k;
+      if (s0 < 0) return null;
+    }
+    const stack = [s0];
+    final[s0] = 1;
+    let fCount = 0;
+    const nb = { x0: mw, y0: mh, x1: 0, y1: 0 };
+    while (stack.length) {
+      const i = stack.pop() as number;
+      fCount++;
+      const x = i % mw, y = (i / mw) | 0;
+      if (x < nb.x0) nb.x0 = x; if (x > nb.x1) nb.x1 = x;
+      if (y < nb.y0) nb.y0 = y; if (y > nb.y1) nb.y1 = y;
+      for (const o of [-1, 1, -mw, mw]) {
+        const j = i + o;
+        if (j < 0 || j >= final.length || final[j]) continue;
+        const xj = j % mw;
+        if (Math.abs(xj - x) > 1) continue;              // row wrap
+        if (region[j] || isDim(j)) { final[j] = 1; stack.push(j); }
+      }
+    }
+    regionBox.set(final, nb);
+    return {
+      status: "ok", region: final, count: fCount, mw, mh, ws,
+      mppf: mo.mppf, hardHits: ref.hardHits, softHits: ref.softHits,
+      hatchFiltered: true, hatchTier: "bounded",
+    };
+  };
   if (minPassPx > 0) {
     const s = scratch();
     const dm = dilatedView(mo, minPassPx, s.dt);
@@ -2782,7 +2997,7 @@ function sealAttempt(mo: MaskObj, ix: number, iy: number, sensitivity: number, r
       if (r0.status === "ok" && r0.count > 0) {
         const d = +(1 - f.count / r0.count).toFixed(4);
         if (d > 0) { f.minPassPx = minPassPx; f.minPassDelta = d; }
-        return f;                       // a subset of a region that already passed both gates
+        return mergeAcrossDimStrings(f) ?? f;   // a subset of a region that already passed both gates
       }
       // creating: the ladder's own two gates, on the ladder's own terms
       const vf = f.count > f.mw * f.mh * SEAL_MAX_SHEET_FRAC ? 1 : virtualBoundaryFrac(f, s.dt);
@@ -2799,7 +3014,7 @@ function sealAttempt(mo: MaskObj, ix: number, iy: number, sensitivity: number, r
     }
   }
   const base = rawFlood();
-  if (base.status === "ok") return base;
+  if (base.status === "ok") return mergeAcrossDimStrings(base) ?? base;
   const sc = scratch();
   for (const r of radii) {
     // Skipped because a SMALLER dilation bridges strictly less: reaching here

--- a/web/src/lib/provenance.js
+++ b/web/src/lib/provenance.js
@@ -17,6 +17,34 @@ export const mintUuid = () => {
 // ISO-8601 UTC so records diff and sort the same on every machine.
 export const nowIso = () => new Date().toISOString();
 
+// Declared author (#314) — self-declared exactly the way git sources
+// user.name: one localStorage key, no accounts, no login, no network. The
+// trust model is initials on a paper markup, which is the correct model for a
+// tool whose deployments include air-gapped and self-hosted shops — anyone
+// who can edit the payload file can edit the name, and authentication stays
+// in whatever the team already runs. Cached in-module so the pure consumers
+// (shapeCommands, the node test runner, mcp) read it without a DOM; where
+// localStorage is absent the cache alone carries it, and with nothing
+// declared every payload is byte-identical to today's.
+const AUTHOR_KEY = "ot-author";
+let authorCache;                 // undefined = not read yet; null = none declared
+export function authorName() {
+  if (authorCache === undefined) {
+    try { authorCache = (globalThis.localStorage?.getItem(AUTHOR_KEY) || "").trim() || null; }
+    catch { authorCache = null; }
+  }
+  return authorCache;
+}
+export function setAuthorName(name) {
+  const v = (typeof name === "string" ? name : "").trim() || null;
+  authorCache = v;
+  try {
+    if (v) globalThis.localStorage?.setItem(AUTHOR_KEY, v);
+    else globalThis.localStorage?.removeItem(AUTHOR_KEY);
+  } catch { /* storage blocked — the in-memory declaration still holds */ }
+  return v;
+}
+
 // Stamp a REAL edit onto a shape (kind ∈ "vertex" | "edge" | "move" |
 // "reassign") and return the stamped copy — never mutates its input (origin
 // and its edits map may be aliased across clipboard copies).
@@ -29,10 +57,18 @@ export const nowIso = () => new Date().toISOString();
 //     survives verbatim once a human starts correcting it. Callers must stamp
 //     BEFORE applying the geometry change so the frozen ring is truly pre-edit.
 // Manual/no-origin shapes get updated_at and nothing else.
+//
+// Author (#314): when a name is declared, every stamp additionally carries
+// updated_by — the last human to land a real edit — beside updated_at. The
+// shape's `author` (who committed it, stamped at mint) is never overwritten:
+// the pair answers both of review's questions, "who traced the corridor" and
+// "whose edit won". Undeclared ⇒ absent ⇒ payloads byte-identical to today.
 export function stampEdit(shape, kind) {
   const updated_at = nowIso();
+  const by = authorName();
+  const stamp = by ? { updated_at, updated_by: by } : { updated_at };
   const o = shape.origin;
-  if (!o?.method || o.method === "manual") return { ...shape, updated_at };
+  if (!o?.method || o.method === "manual") return { ...shape, ...stamp };
   const origin = {
     ...o,
     edited: true,
@@ -41,5 +77,5 @@ export function stampEdit(shape, kind) {
   if (!o.proposed_verts_norm && Array.isArray(shape.verts_norm)) {
     origin.proposed_verts_norm = shape.verts_norm.map((v) => [...v]);
   }
-  return { ...shape, updated_at, origin };
+  return { ...shape, ...stamp, origin };
 }

--- a/web/src/lib/shapeCommands.js
+++ b/web/src/lib/shapeCommands.js
@@ -64,8 +64,17 @@
 //             (undo of a draw, or an explicit delete of the reconciled
 //             deduct) unmints the deduct and puts the parent back verbatim.
 // ─────────────────────────────────────────────────────────────────────────────
-import { mintUuid, nowIso, stampEdit } from "./provenance.js";
+import { mintUuid, nowIso, stampEdit, authorName } from "./provenance.js";
 import { assignShapeLabel } from "./shapeLabels.js";
+
+// The mint-time author field (#314): `author` = who committed the shape,
+// self-declared via provenance.authorName(). Spread AFTER the caller's fields
+// so an import/merge that already carries attribution is never clobbered, and
+// an undeclared session adds nothing at all.
+const mintAuthor = (given) => {
+  const a = given.author === undefined ? authorName() : null;
+  return a ? { author: a } : {};
+};
 
 export const PROVENANCE_POLICY = {
   add: "created_at (+ id mint) per shape; restore:true stamps nothing",
@@ -179,7 +188,10 @@ export function applyShapeCommand(shapes, cmd) {
         const { id, created_at, ...rest } = s;
         // key order matches the old creation sites byte-for-byte: id and
         // created_at lead, the caller's fields follow in their given order.
-        return { id: id || `shp-${mintUuid()}`, created_at: created_at || nowIso(), ...rest };
+        // author (#314) trails, and only when declared and not already carried
+        // (an import/merge keeps its own attribution) — undeclared payloads
+        // stay byte-identical.
+        return { id: id || `shp-${mintUuid()}`, created_at: created_at || nowIso(), ...rest, ...mintAuthor(rest) };
       });
       let next;
       if (cmd.restore && Array.isArray(cmd.at) && cmd.at.length === minted.length) {
@@ -333,7 +345,7 @@ export function applyShapeCommand(shapes, cmd) {
         } };
       }
       // forward: mint the deduct shape (add semantics), patch the parent in place.
-      const minted = !cmd.shape ? null : (cmd.shape.id ? cmd.shape : { id: `shp-${mintUuid()}`, created_at: nowIso(), ...cmd.shape });
+      const minted = !cmd.shape ? null : (cmd.shape.id ? cmd.shape : { id: `shp-${mintUuid()}`, created_at: nowIso(), ...cmd.shape, ...mintAuthor(cmd.shape) });
       const runNext = new Map((runsIn?.targets || []).map((t) => [t.id, t]));
       const runDel = new Set(runsIn?.deleteIds || []);
       const runPrevs = [], runRemoved = [], runAt = [];
@@ -350,7 +362,7 @@ export function applyShapeCommand(shapes, cmd) {
         return withCutout(s, t.next);
       });
       if (parentPrev === null) return { shapes, inverse: null };   // parent vanished mid-gesture — refuse rather than mint an orphaned deduct
-      const runMinted = (runsIn?.mint || []).map((m) => (m.id ? m : { id: `shp-${mintUuid()}`, created_at: nowIso(), ...m }));
+      const runMinted = (runsIn?.mint || []).map((m) => (m.id ? m : { id: `shp-${mintUuid()}`, created_at: nowIso(), ...m, ...mintAuthor(m) }));
       if (minted) next.push(minted);
       if (runMinted.length) next.push(...runMinted);
       if (!minted && !runPrevs.length && !runMinted.length && !runRemoved.length) return { shapes, inverse: null };   // nothing landed — never a phantom undo entry

--- a/web/src/lib/sheets.ts
+++ b/web/src/lib/sheets.ts
@@ -201,6 +201,28 @@ export function detectScale(textContent: TextContentLike, viewport: Viewport): D
   return null;
 }
 
+// ── dimension-pattern text (#320) ────────────────────────────────────────────
+// The positioned `12'-4"`-pattern text items the dim-string classifier anchors
+// interior strings on (oneclick.sweepDimensionStrings path B). The pattern is
+// a FULL-string match, deliberately: a room-size note (`19'-2" x 21'-1"`), a
+// ceiling note (`9'-0" CLG`) or a leader with trailing words must never
+// anchor a line. Rotation comes from the item's own baseline transform.
+export const DIMTEXT_RE = /^\s*\d+'\s*(?:-?\s*\d+(?:\s+\d+\/\d+)?\s*")?\s*$/;
+export interface DimTextItem { x: number; y: number; ang: number; wPx: number }
+export function extractDimTexts(textContent: TextContentLike, viewport: Viewport): DimTextItem[] {
+  const out: DimTextItem[] = [];
+  const vs = Math.hypot(viewport.transform[0], viewport.transform[1]) || 1;
+  for (const it of textContent.items || []) {
+    const str = (it.str || "").trim();
+    if (!str || !DIMTEXT_RE.test(str)) continue;
+    const t = pdfjsLib.Util.transform(viewport.transform, it.transform);
+    let ang = Math.atan2(t[1], t[0]) * 180 / Math.PI;
+    ang = ((ang % 180) + 180) % 180;
+    out.push({ x: t[4], y: t[5], ang, wPx: (it.width || 0) * vs });
+  }
+  return out;
+}
+
 // ── marquee → tokens: the text-layer half of "Import from schedule" ──────────
 // Turn the page text layer into positioned tokens inside a viewport-px rect (the
 // box the estimator dragged around the schedule). x is the glyph's left edge, y

--- a/web/src/lib/totals.js
+++ b/web/src/lib/totals.js
@@ -231,6 +231,38 @@ export function labelGroupedRows(conditions, shapes, shapeLabels = [], ctx = nul
   }).filter((g) => g.rows.length);
 }
 
+// Author-grouped ORDERED quantities for the report's group-by-author view
+// (#314) — the same shape-level bucketing as labelGroupedRows, keyed on
+// shape.author (the self-declared name stamped at mint; absent → the
+// "Unattributed" bucket). Same per-slice math, same reconciliation: a
+// condition spanning authors appears in each bucket and the per-bucket sums
+// reconcile to the ungrouped row. Named authors sorted; Unattributed last
+// (value null so the header renders italic, the Unlabeled convention). Same
+// per-slice materials caveat as the other groupers: display, never a buy list.
+/**
+ * @param {{seamByShape?: Map<any, number>}|null} [ctx] passed straight to conditionTotals
+ */
+export function authorGroupedRows(conditions, shapes, ctx = null) {
+  const byAuthor = new Map();     // author → that bucket's shapes ("" = Unattributed)
+  for (const s of shapes) {
+    const v = typeof s.author === "string" && s.author.trim() ? s.author.trim() : "";
+    let arr = byAuthor.get(v);
+    if (!arr) { arr = []; byAuthor.set(v, arr); }
+    arr.push(s);
+  }
+  const named = [...byAuthor.keys()].filter(Boolean).sort();
+  const order = [...named, ...(byAuthor.has("") ? [""] : [])];
+  return order.map((v) => {
+    const bucketShapes = byAuthor.get(v);
+    return {
+      value: v || null,             // null = Unattributed
+      label: v || "Unattributed",
+      rows: conditionTotals(conditions, bucketShapes, ctx).filter((r) => r.shape_count > 0),
+      perimByCond: floorPerimeterLf(bucketShapes),
+    };
+  }).filter((g) => g.rows.length);
+}
+
 // Sheet × label grouping — the FLOOR × ROOM cross-section, and the shape an
 // estimator actually hands a superintendent: what goes down in room 112 on the
 // second floor, not what goes down in room 112 anywhere in the building.

--- a/web/src/lib/voiceActions.ts
+++ b/web/src/lib/voiceActions.ts
@@ -49,6 +49,8 @@ export type VoiceCapabilities = {
   updateCondition(id: string, patch: { waste_pct: number }): void;
   addLabel(label: string): void;
   activateLabel(label: string | null): void;
+  /** Declare / clear the local author name (#314) — provenance.setAuthorName. */
+  setAuthor(name: string | null): void;
   /** Canvas anchors the note (text markup on the focused sheet). */
   addNote(text: string): void;
 };
@@ -123,6 +125,12 @@ export function applyVoiceIntent(caps: VoiceCapabilities, intent: Intent): Voice
     case "clear_label":
       caps.activateLabel(null);
       return done("Label cleared.");
+    case "set_author":
+      caps.setAuthor(intent.name);
+      return done(`Marks will sign ${intent.name}.`);
+    case "clear_author":
+      caps.setAuthor(null);
+      return done("Author cleared — new marks unsigned.");
     case "add_note":
       caps.addNote(intent.text);
       return done("Note added — see Markups.");

--- a/web/src/lib/voiceIntent.ts
+++ b/web/src/lib/voiceIntent.ts
@@ -24,6 +24,8 @@ export type Intent =
   | { kind: "set_waste"; waste: number }
   | { kind: "set_label"; label: string; known: boolean }
   | { kind: "clear_label" }
+  | { kind: "set_author"; name: string }
+  | { kind: "clear_author" }
   | { kind: "add_note"; text: string }
   // deixis (RFC #59 deixis slice): the utterance ended in "this room"/"here"/
   // "this one"/"right here" — the speaker AIMED. The parser marks that they
@@ -386,7 +388,8 @@ function parseDeixisUtterance(transcript: string, head: string[], ctx: VoiceCont
 /**
  * Parse one push-to-talk transcript into one intent, or a typed rejection.
  * Grammar (keyword-first):
- *   clear label | label <text> | note <text> | waste <n> | <tag> [waste <n>]
+ *   clear label | label <text> | note <text> | author <name> | clear author
+ *   | waste <n> | <tag> [waste <n>]
  *   | [tag] [waste <n>] [label <text>] <deixis>   (deixis = utterance-terminal
  *     "this room" / "here" / "this one" / "right here" → trace_at_cursor)
  * Anything else — including a matched production with leftover tokens —
@@ -404,7 +407,7 @@ export function parseVoiceIntent(transcript: string, ctx: VoiceContext): VoicePa
   // through to the existing productions unchanged.
   const head = takeTerminalDeixis(tokens);
   if (head !== null) {
-    if (head[0] === "note" || (head[0] === "clear" && head[1] === "label"))
+    if (head[0] === "note" || head[0] === "author" || (head[0] === "clear" && (head[1] === "label" || head[1] === "author")))
       return { ok: false, reason: "deixis_target" };
     return parseDeixisUtterance(transcript, head, ctx);
   }
@@ -413,6 +416,20 @@ export function parseVoiceIntent(transcript: string, ctx: VoiceContext): VoicePa
   if (tokens[0] === "clear" && tokens[1] === "label") {
     if (tokens.length > 2) return { ok: false, reason: "trailing_words" };
     return { ok: true, intent: { kind: "clear_label" } };
+  }
+
+  // clear author (#314)
+  if (tokens[0] === "clear" && tokens[1] === "author") {
+    if (tokens.length > 2) return { ok: false, reason: "trailing_words" };
+    return { ok: true, intent: { kind: "clear_author" } };
+  }
+
+  // author <name> (#314) — free text like note/label: raw remainder, original
+  // casing intact (a name is presentation text, not vocabulary)
+  if (tokens[0] === "author") {
+    const name = rawRemainder(transcript, "author");
+    if (!name) return { ok: false, reason: "unrecognized" };
+    return { ok: true, intent: { kind: "set_author", name } };
   }
 
   // label <text>

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -36,7 +36,7 @@ import UserGuide from "../components/UserGuide.jsx";
 import TakeoffsPanel, { clampPanelW, CONDITION_DND_MIME, ConditionAppearanceEditor } from "../components/TakeoffsPanel.jsx";
 import { HATCHES, PALETTE, NO_FILL, HatchPattern, HatchSwatch } from "../components/hatches.jsx";
 import { Icon } from "../brand/icons.jsx";
-import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, compareSheetKeys, extractSheetNumber, detectScale, extractRegionText } from "../lib/sheets";
+import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, compareSheetKeys, extractSheetNumber, detectScale, extractRegionText, extractDimTexts } from "../lib/sheets";
 import { normalizeLoadedGroups } from "../lib/sheetGroups";
 import { isStitchKey, mintStitchId, sanitizeStitches, autoButt, stitchExtent, alignMembers, seamClips, mergePoints, mergeSegs, stitchAlive, stitchLayoutSig } from "../lib/stitches";
 import { isCanvasBusy } from "../lib/canvasBusy";
@@ -621,6 +621,7 @@ export default function TakeoffCanvas() {
   const stageRef = useRef(null);
   const panelCanvasRefs = useRef(new Map()); // sheetKey → <canvas> (base layer — small backing store, coarse pyramid placeholder)
   const pageObjsRef = useRef(new Map());     // sheetKey → pdf.js page object (getOperatorList/getTextContent only — painting moved to the tile worker pool)
+  const dimTextsRef = useRef(new Map());     // sheetKey → positioned dim-pattern texts (#320) — RENDER_SCALE px, rescaled at buildMask time
   const renderScalesRef = useRef(new Map()); // sheetKey → RENDER_SCALE, always (see factorFor comment above) — kept so the ~20 factorFor/uppFor call sites are untouched
   // Tile-pyramid compositor (#86) — one instance owning the worker pool +
   // tile LRU cache (see lib/tileCompositor.ts). Lazily created on first
@@ -1834,11 +1835,15 @@ export default function TakeoffCanvas() {
           // instead (rasterEligible true, vectorViable false).
           sheetStatsRef.current.set(m.key, { segCount: 0, imageFrac: 1 });
         });
-        // read the drawn scale note off this panel's page text (best-effort)
+        // read the drawn scale note off this panel's page text (best-effort),
+        // and the positioned dimension-pattern texts the dim-string classifier
+        // anchors on (#320) — a mask built before they resolved was textless
         m.pageObj.getTextContent().then((tc) => {
           if (stale()) return;
           const det = detectScale(tc, m.viewport);
           if (det) setDetectedScales((d) => (d[m.key]?.label === det.label ? d : { ...d, [m.key]: det }));
+          const dts = extractDimTexts(tc, m.viewport);
+          if (dts.length) { dimTextsRef.current.set(m.key, dts); maskCacheRef.current.delete(m.key); }
         }).catch(() => {});
       }
       if (stale()) return;
@@ -3980,10 +3985,13 @@ export default function TakeoffCanvas() {
       // too. The mask is cached, so the extra getViewport is once per sheet per
       // calibration.
       const pgVp = pageObjsRef.current.get(key)?.getViewport({ scale: 1 });
+      // dim texts were positioned at RENDER_SCALE; segs live at this render —
+      // rescale so text and ink share a frame whatever the Hi-Res toggle says
+      const dtk = rsNow === RENDER_SCALE ? dimTextsRef.current.get(key) : (dimTextsRef.current.get(key) || []).map((t) => ({ ...t, x: t.x * rsNow / RENDER_SCALE, y: t.y * rsNow / RENDER_SCALE, wPx: t.wPx * rsNow / RENDER_SCALE }));
       mo = buildMask(segs, dims.w, dims.h, MASK_MAX_DIM, segMetaRef.current.get(key), pxPerFt,
                      pxPerFt ? pxPerFt * RENDER_SCALE / rsNow : 0,
                      pgVp ? { pageW: pgVp.width, pageH: pgVp.height, renderScale: rsNow, baseScale: RENDER_SCALE } : null,
-                     rolesForSheet(key));
+                     rolesForSheet(key), dtk && dtk.length ? dtk : null);
       maskCacheRef.current.set(key, mo);
     }
     return mo;

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -135,7 +135,7 @@ import { requiredDensity as tileRequiredDensity } from "../lib/tiles";
 // setShapes (the label-vocabulary renames, live drag PREVIEW frames, the
 // hydrate-time sanitizers, per-shape height/thickness re-pricing).
 // nowIso stays imported for the non-shape records (markups, RFIs, conditions).
-import { nowIso, mintUuid } from "../lib/provenance.js";
+import { nowIso, mintUuid, setAuthorName } from "../lib/provenance.js";
 import { applyShapeCommand, geomSnapshot, vertsEqual, recordCommand } from "../lib/shapeCommands.js";
 import { applyApprovalCommand, sanitizeApprovals, approvalInk, APPROVAL_R } from "../lib/approvals.js";
 import { findCutoutParent, subtractCutout, recomposeCutouts, cutRunsAcross } from "../lib/cutout.js";
@@ -5335,6 +5335,9 @@ export default function TakeoffCanvas() {
       // and addMarkup auto-opens the Markups dock, so the note is immediately
       // visible and draggable — the anchor is a starting point, not a commitment
       addNote: (text) => addMarkup({ type: "text", at: [0.5, 0.06], text }, focusPanel.key),
+      // author declaration (#314) — provenance's one localStorage key; new
+      // commits pick it up at mint, nothing re-stamps retroactively
+      setAuthor: (v) => setAuthorName(v),
       getAimSeed,
       traceAt: (seed, conditionId, label) => voiceTraceAt(seed, conditionId, label),
     };
@@ -6917,7 +6920,7 @@ export default function TakeoffCanvas() {
           <input
             type="text"
             placeholder="cpt 1 · waste 7 · this room"
-            title={'Command line (RFC #59): a condition tag ("CPT-1", "carpet one", "tile 2 waste 5"), "waste 7", "label Phase 1", "clear label", or "note …" — Enter runs it through the same actions the buttons use. End with "this room" / "here" while the pointer rests on a room to trace and commit it there ("carpet one, this room"). Push-to-talk dictation will feed this box.'}
+            title={'Command line (RFC #59): a condition tag ("CPT-1", "carpet one", "tile 2 waste 5"), "waste 7", "label Phase 1", "clear label", "author <your name>" (new marks sign it — the report can group by author), or "note …" — Enter runs it through the same actions the buttons use. End with "this room" / "here" while the pointer rests on a room to trace and commit it there ("carpet one, this room"). Push-to-talk dictation will feed this box.'}
             onFocus={() => { voiceAimMarkRef.current = aimSeqRef.current; }}
             onKeyDown={(e) => {
               if (e.key !== "Enter") return;

--- a/web/test/geometry.test.ts
+++ b/web/test/geometry.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   buildMask, floodRegion, traceRegion, snapVertices, ringArea, rdpClosed,
-  extractVectorGeometry, classifyHatchSegs, classifyOffsetAnnotationSegs, markPolylineArcs, SEG_CURVE, SEG_CLIP, SEG_FILLONLY, SEG_POLYARC,
+  extractVectorGeometry, classifyHatchSegs, classifyOffsetAnnotationSegs, classifyDimensionStringSegs, markPolylineArcs, SEG_CURVE, SEG_CLIP, SEG_FILLONLY, SEG_POLYARC,
   SENS_STRICT, SENS_BALANCED, SENS_AGGRESSIVE, MASK_CURVE_BIT,
   floodRegionSealed, dilateHardMask, SEAL_RADII, sealRadiiFor, DOOR_SEAL_MAX_FT, SEAL_R_MAX, doorWedgeCapPx,
   splitMergedArcs, doorLeafCells, arcClusterFit,
@@ -699,6 +699,85 @@ test("offset annotation: curve, clip and fill-only strokes are exempt", () => {
     meta[1] |= bit;
     assert.equal(classifyOffsetAnnotationSegs(segs, meta, 1, A_MAX, A_MIN, A_LEN)[1], 0, `bit ${bit} exempt`);
   }
+});
+
+// ── dimension strings (oneclick.ts section 2d, issue #320) ──────────────────
+// One synthetic comb at the same 18 px/ft convention, then each negative test
+// removes the one clause that keeps a wall a wall. The comb: a 23 ft run with
+// three crossing witnesses at room-scale spacing, a 45° tick at each junction.
+const D_FT = 18;
+function dimComb(): [number[], Uint8Array] {
+  const segs = [92, 100, 508, 100];                    // the run, overshooting both end junctions
+  for (const x of [100, 300, 500]) segs.push(x, 90, x, 112);       // witnesses, crossing
+  for (const x of [100, 300, 500]) segs.push(x - 5, 95, x + 5, 105); // 45° ticks ON the run
+  return [segs, new Uint8Array(segs.length >> 2)];
+}
+
+test("dimension string: run, witnesses and ticks all classify soft", () => {
+  const [segs, meta] = dimComb();
+  const soft = classifyDimensionStringSegs(segs, meta, 1, D_FT);
+  assert.deepEqual([...soft], segs.map(() => 1).slice(0, segs.length >> 2), "the whole comb is annotation");
+});
+
+test("dimension string: a wall face with a parallel partner is never a run", () => {
+  // the comb, plus a double-line wall drawn with the SAME comb shape riding on
+  // one face — the partner face 0.44 ft away is what keeps it hard
+  const [segs, meta0] = dimComb();
+  const wall = [92, 300, 508, 300, 92, 308, 508, 308];             // two faces, full overlap
+  const all = [...segs, ...wall];
+  const meta = new Uint8Array(all.length >> 2);
+  const soft = classifyDimensionStringSegs(all, meta, 1, D_FT);
+  const nComb = segs.length >> 2;
+  assert.equal(soft[nComb], 0, "wall face stays hard");
+  assert.equal(soft[nComb + 1], 0, "partner face stays hard");
+  assert.equal(soft[0], 1, "the comb still classifies beside it");
+  assert.ok(meta0.length >= 0);
+});
+
+test("dimension string: a comb without ticks is casework, not a dimension", () => {
+  const segs = [92, 100, 508, 100];
+  for (const x of [150, 300, 450]) segs.push(x, 100, x, 136);      // dividers, no ticks
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(segs.length >> 2), 1, D_FT);
+  assert.deepEqual([...soft], [0, 0, 0, 0], "no junction marks ⇒ nothing softens");
+});
+
+test("dimension string: a rectangle's corners are joints where nothing continues past", () => {
+  // a legend-swatch box with oblique pattern strokes inside — the Crunch
+  // Fitness false positive this rejection exists for
+  const segs = [
+    100, 100, 500, 100,   // top edge (the would-be run)
+    100, 136, 500, 136,   // bottom edge — 2 ft off, OUTSIDE the iso window
+    100, 100, 100, 136,   // left side: stops AT the top edge
+    500, 100, 500, 136,   // right side: stops AT the top edge
+  ];
+  for (let x = 140; x <= 460; x += 40) segs.push(x - 4, 98, x + 4, 106);  // pattern obliques near the edge
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(segs.length >> 2), 1, D_FT);
+  assert.equal(soft[0], 0, "box edge stays hard — its only junctions are corners");
+});
+
+test("dimension string: sub-foot witness rhythm is coursing, not dimensioning", () => {
+  const segs = [92, 100, 508, 100];
+  for (let x = 100; x <= 500; x += 9) segs.push(x, 90, x, 112);    // 0.5 ft pitch
+  segs.push(95, 95, 105, 105, 295, 95, 305, 105);                  // even with plausible ticks
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(segs.length >> 2), 1, D_FT);
+  assert.equal(soft[0], 0, "dense comb stays hard");
+});
+
+test("dimension string: a witness glued into longer linework is evidence, never softened", () => {
+  const [segs, meta] = dimComb();
+  // stretch the middle witness into a 12 ft stroke — longer than the soften cap
+  segs[4 * 4] = 300; segs[4 * 4 + 1] = 90; segs[4 * 4 + 2] = 300; segs[4 * 4 + 3] = 306;
+  const soft = classifyDimensionStringSegs(segs, meta, 1, D_FT);
+  assert.equal(soft[0], 1, "run softens");
+  assert.equal(soft[4], 0, "the long witness stays hard");
+});
+
+test("dimension string: buildMask unions the plane only when the scale is known", () => {
+  const [segs, meta] = dimComb();
+  const noScale = buildMask(segs, 600, 400, 600, meta);
+  const withScale = buildMask(segs, 600, 400, 600, meta, D_FT);
+  assert.equal(noScale.softCount, 0, "scale unknown ⇒ nothing softened");
+  assert.ok(withScale.softCount > 0, "scale known ⇒ the comb is soft");
 });
 
 test("offset annotation: an unscaled sheet gets no annotation plane at all", () => {

--- a/web/test/geometry.test.ts
+++ b/web/test/geometry.test.ts
@@ -772,6 +772,59 @@ test("dimension string: a witness glued into longer linework is evidence, never 
   assert.equal(soft[4], 0, "the long witness stays hard");
 });
 
+// ── text-anchored interior strings (path B) + the region merge ──────────────
+
+test("dim text anchors an interior line: pieces and ticks soften; without text, nothing", () => {
+  // an interior dim line has no comb-clean surroundings — path A must refuse
+  // it, and the TEXT is what identifies it
+  const segs = [200, 90, 200, 400];                       // the line, vertical, 17 ft
+  segs.push(195, 195, 205, 205, 195, 295, 205, 305);      // 45° ticks on it
+  const meta = new Uint8Array(segs.length >> 2);
+  const none = classifyDimensionStringSegs(segs, meta, 1, D_FT);
+  assert.deepEqual([...none], [0, 0, 0], "no text ⇒ an isolated interior line stays hard");
+  const withText = classifyDimensionStringSegs(segs, meta, 1, D_FT, [{ x: 203, y: 240, ang: 90, wPx: 60 }]);
+  assert.deepEqual([...withText], [1, 1, 1], "text on the line ⇒ line and ticks soften");
+});
+
+test("dim text: a room label's underline is not a dimension line", () => {
+  const segs = [180, 240, 250, 240];                      // 70 px underline under 60 px text
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(1), 1, D_FT, [{ x: 215, y: 236, ang: 0, wPx: 60 }]);
+  assert.deepEqual([...soft], [0], "the line must dwarf its text");
+});
+
+test("dim text: schedule-table rules self-protect through the wall guard", () => {
+  // dim-pattern text INSIDE a table cell: the row rules above and below ride
+  // 0.5 ft apart for their whole length — partnered linework, never softened
+  const segs = [100, 231, 500, 231, 100, 249, 500, 249];
+  const soft = classifyDimensionStringSegs(segs, new Uint8Array(2), 1, D_FT, [{ x: 300, y: 244, ang: 0, wPx: 60 }]);
+  assert.deepEqual([...soft], [0, 0], "partnered rules stay hard");
+});
+
+test("a room chopped by a text-anchored dim line floods WHOLE, from either side", () => {
+  // 30×15 ft room, an interior dimension line splitting it 2:1, dim text on
+  // the line. Without the text the flood chops at the line; with it, the
+  // region merge unions the strict pieces and both sides click to ONE answer.
+  const segs = squareSegs(100, 100, 640, 370);
+  segs.push(280, 100, 280, 370);                          // the chopping line
+  segs.push(275, 175, 285, 185, 275, 285, 285, 295);      // its ticks
+  const meta = new Uint8Array(segs.length >> 2);
+  const dimText = [{ x: 283, y: 235, ang: 90, wPx: 60 }];
+  const moPlain = buildMask(segs, 1000, 600, 1000, meta, D_FT);
+  const moText = buildMask(segs, 1000, 600, 1000, meta, D_FT, 0, null, null, dimText);
+  const flood = (mo: MaskObj, x: number, y: number) => {
+    const r = floodRegionSealed(mo, x, y, 0.5, sealRadiiFor(mo.mppf || D_FT), 0, 0);
+    assert.equal(r.status, "ok");
+    return r.status === "ok" ? r.count : 0;
+  };
+  const chopLeft = flood(moPlain, 190, 235);
+  const wholeLeft = flood(moText, 190, 235);
+  const wholeRight = flood(moText, 460, 235);
+  assert.ok(chopLeft < wholeLeft * 0.5, `text heals the chop (${chopLeft} → ${wholeLeft})`);
+  assert.equal(wholeLeft, wholeRight, "either side of the chop clicks to the same union");
+  // and the union is the room: 540×270 px interior, ring a hair inside the walls
+  assert.ok(Math.abs(wholeLeft - 540 * 270) / (540 * 270) < 0.03, `union ≈ the room (${wholeLeft})`);
+});
+
 test("dimension string: buildMask unions the plane only when the scale is known", () => {
   const [segs, meta] = dimComb();
   const noScale = buildMask(segs, 600, 400, 600, meta);

--- a/web/test/labelGroupedRows.test.ts
+++ b/web/test/labelGroupedRows.test.ts
@@ -5,7 +5,7 @@
 // and the per-bucket sums reconcile to the ungrouped total.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { labelGroupedRows, sheetLabelGroupedRows, conditionTotals, reportJson } from "../src/lib/totals.js";
+import { labelGroupedRows, sheetLabelGroupedRows, authorGroupedRows, conditionTotals, reportJson } from "../src/lib/totals.js";
 
 const conditions = () => [{ id: "c1", finish_tag: "CPT-1" }];
 const shape = (id: string, label: string | null, area: number) => ({
@@ -117,4 +117,27 @@ test("sheetLabelGroupedRows: no shapes, and orphan-only floors, drop rather than
   assert.deepEqual(sheetLabelGroupedRows(conditions(), [], []), []);
   const orphan = [{ id: "x", condition_id: "gone", sheet_id: "p.pdf#1", measure_role: "floor_area", computed: { area_sf: 9 } }];
   assert.deepEqual(sheetLabelGroupedRows(conditions(), orphan as any, []), []);
+});
+
+// ── authorGroupedRows (#314) — labelGroupedRows' twin, keyed on shape.author ─
+
+const authored = (id: string, author: string | null, area: number) => ({
+  id, condition_id: "c1", sheet_id: "p.pdf", measure_role: "floor_area",
+  computed: { area_sf: area, perimeter_lf: 0 }, ...(author ? { author } : {}),
+});
+
+test("author buckets reconcile to the ungrouped total; named sorted, Unattributed last with value null", () => {
+  const shapes = [authored("s1", "Michael", 100), authored("s2", "Aaron", 50), authored("s3", null, 25)];
+  const g = authorGroupedRows(conditions(), shapes);
+  assert.deepEqual(g.map((x) => x.label), ["Aaron", "Michael", "Unattributed"]);
+  assert.equal(g[2].value, null);
+  assert.deepEqual(g.map((x) => x.rows[0].floor_sf), [50, 100, 25]);
+  const ungrouped = conditionTotals(conditions(), shapes)[0].floor_sf;
+  assert.equal(g.reduce((n, x) => n + x.rows[0].floor_sf, 0), ungrouped);
+});
+
+test("a whitespace-only author is Unattributed, and an all-unattributed project still groups", () => {
+  const g = authorGroupedRows(conditions(), [authored("s1", "   ", 10), authored("s2", null, 5)]);
+  assert.deepEqual(g.map((x) => x.label), ["Unattributed"]);
+  assert.equal(g[0].rows[0].floor_sf, 15);
 });

--- a/web/test/markedset.test.ts
+++ b/web/test/markedset.test.ts
@@ -9,7 +9,7 @@ import assert from "node:assert/strict";
 // build loads under node (with a "use the legacy build" warning) —
 // buildMarkedSetPdf itself stays untested here (pdf-lib + DOM bound), only
 // the pure sanitizer.
-import { winAnsiSafe } from "../src/lib/markedset.js";
+import { winAnsiSafe, authorTallyLine } from "../src/lib/markedset.js";
 
 test("printable ASCII and Latin-1 pass through untouched", () => {
   const s = "CT-1, honed · 546.9 SF ×2 -> 1/4\" = 1'-0\"";
@@ -46,4 +46,16 @@ test("nullish input yields the empty string; control chars are replaced", () => 
   assert.equal(winAnsiSafe(null), "");
   assert.equal(winAnsiSafe(undefined), "");
   assert.equal(winAnsiSafe("a\tb\nc"), "a?b?c");          // drawn strings are single-line by construction
+});
+
+// ── authorTallyLine (#314) — the cover's "Marks by:" line ────────────────────
+
+test("authorTallyLine: null when no shape carries an author (export stays byte-identical)", () => {
+  assert.equal(authorTallyLine([]), null);
+  assert.equal(authorTallyLine([{ author: "  " }, {}]), null);
+});
+
+test("authorTallyLine: named authors sorted with counts, unattributed counted last", () => {
+  const line = authorTallyLine([{ author: "Michael" }, { author: "Aaron" }, { author: "Michael" }, {}]);
+  assert.equal(line, "Marks by: Aaron (1) · Michael (2) · unattributed (1)");
 });

--- a/web/test/provenance.test.ts
+++ b/web/test/provenance.test.ts
@@ -9,7 +9,7 @@
 //     updated_at and nothing else.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mintUuid, nowIso, stampEdit } from "../src/lib/provenance.js";
+import { mintUuid, nowIso, stampEdit, authorName, setAuthorName } from "../src/lib/provenance.js";
 
 const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
@@ -96,4 +96,38 @@ test("stampEdit: pure — the input shape (and its origin) are not mutated", () 
   const snapshot = structuredClone(s);
   stampEdit(s, "edge");
   assert.deepEqual(s, snapshot);
+});
+
+// ── author (#314) ────────────────────────────────────────────────────────────
+// Self-declared, git-user.name style. Node 24 has no localStorage, which is
+// itself the contract under test: the in-memory declaration alone must carry
+// (plain-HTTP LAN self-hosts and blocked storage behave the same), and with
+// nothing declared every stamp is byte-identical to before the field existed.
+
+test("author: undeclared by default; declaring trims; clearing empties", () => {
+  try {
+    assert.equal(authorName(), null);
+    assert.equal(setAuthorName("  Michael E  "), "Michael E");
+    assert.equal(authorName(), "Michael E");
+    assert.equal(setAuthorName("   "), null);
+    assert.equal(authorName(), null);
+  } finally { setAuthorName(""); }
+});
+
+test("stampEdit: declared author rides every stamp as updated_by — machine and manual alike", () => {
+  try {
+    setAuthorName("Aaron");
+    const machine = stampEdit(machineShape(), "vertex");
+    assert.equal(machine.updated_by, "Aaron");
+    assert.equal("author" in machine, false);          // mint-time field is not stampEdit's to write
+    const manual = stampEdit({ ...machineShape(), origin: { method: "manual" } }, "move");
+    assert.equal(manual.updated_by, "Aaron");
+    assert.deepEqual(manual.origin, { method: "manual" });   // the manual bare-stamp rule is untouched
+  } finally { setAuthorName(""); }
+});
+
+test("stampEdit: no declared author ⇒ no updated_by — payloads byte-identical to today", () => {
+  setAuthorName("");
+  const out = stampEdit(machineShape(), "vertex");
+  assert.equal("updated_by" in out, false);
 });

--- a/web/test/shapeCommands.test.ts
+++ b/web/test/shapeCommands.test.ts
@@ -17,6 +17,7 @@ import {
   applyShapeCommand, geomSnapshot, vertsEqual, recordCommand,
   PROVENANCE_POLICY, UNDO_CAP,
 } from "../src/lib/shapeCommands.js";
+import { setAuthorName } from "../src/lib/provenance.js";
 
 const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
@@ -534,4 +535,33 @@ test("rollcut: multi-row (a reorder) is ONE command with one exact inverse", () 
   const r = applyShapeCommand(shapes, cmd);
   assert.deepEqual(r.shapes[0].roll_layout.lanes[0], { runMin: 1, runMax: 9, seq: 0 });
   assert.deepEqual(applyShapeCommand(r.shapes, r.inverse).shapes, shapes);
+});
+
+// ── author at mint (#314) ────────────────────────────────────────────────────
+
+test("add: declared author is stamped at mint; a shape already attributed keeps its own", () => {
+  try {
+    setAuthorName("Michael E");
+    const { shapes } = applyShapeCommand([], { type: "add", shapes: [
+      { sheet_id: "a#1", verts_norm: [[0, 0], [1, 0], [1, 1]] },
+      { sheet_id: "a#1", verts_norm: [[0, 0], [1, 0], [0, 1]], author: "Aaron" },   // an import/merge keeps its attribution
+    ] });
+    assert.equal(shapes[0].author, "Michael E");
+    assert.equal(shapes[1].author, "Aaron");
+  } finally { setAuthorName(""); }
+});
+
+test("add: undeclared session mints no author field — payloads byte-identical", () => {
+  setAuthorName("");
+  const { shapes } = applyShapeCommand([], { type: "add", shapes: [{ sheet_id: "a#1", verts_norm: [[0, 0], [1, 0], [1, 1]] }] });
+  assert.equal("author" in shapes[0], false);
+});
+
+test("add restore (undo of a delete) never re-attributes — resurrection is not creation", () => {
+  try {
+    const dead = { id: "shp-x", created_at: "2026-01-01T00:00:00.000Z", sheet_id: "a#1", verts_norm: [[0, 0], [1, 0], [1, 1]] };
+    setAuthorName("Michael E");
+    const { shapes } = applyShapeCommand([], { type: "add", restore: true, shapes: [dead], at: [0] });
+    assert.equal("author" in shapes[0], false);
+  } finally { setAuthorName(""); }
 });

--- a/web/test/voiceActions.test.ts
+++ b/web/test/voiceActions.test.ts
@@ -42,6 +42,7 @@ function makeCtx(overrides: Partial<VoiceCapabilities> = {}) {
     addLabel: (label) => { log.push(["addLabel", label]); },
     activateLabel: (label) => { log.push(["activateLabel", label]); },
     addNote: (text) => { log.push(["addNote", text]); },
+    setAuthor: (name) => { log.push(["setAuthor", name]); },
     getAimSeed: () => ({ x: 320, y: 240, sheetId: "plan.pdf" }),
     traceAt: (seed, conditionId, label) => {
       log.push(["traceAt", seed, conditionId, label]);
@@ -141,6 +142,21 @@ test("clear_label → activateLabel(null)", () => {
   const out = applyVoiceIntent(caps, { kind: "clear_label" });
   assert.deepEqual(out, { ok: true, message: "Label cleared." });
   assert.deepEqual(log, [["activateLabel", null]]);
+});
+
+test("set_author → one setAuthor call, confirmation names the name", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "set_author", name: "Michael E" });
+  assert.equal(out.ok, true);
+  assert.match(out.message, /Michael E/);
+  assert.deepEqual(log, [["setAuthor", "Michael E"]]);
+});
+
+test("clear_author → setAuthor(null)", () => {
+  const { caps, log } = makeCtx();
+  const out = applyVoiceIntent(caps, { kind: "clear_author" });
+  assert.equal(out.ok, true);
+  assert.deepEqual(log, [["setAuthor", null]]);
 });
 
 test("add_note → one addNote call with verbatim text", () => {
@@ -371,6 +387,7 @@ function makeApp() {
     addLabel,
     activateLabel,
     addNote: (text) => addMarkup({ type: "text", at: [0.5, 0.06], text }, "plan.pdf"),
+    setAuthor: () => {},
     getAimSeed: () => box.aim,
     traceAt: (seed, conditionId, label) => { oneClickCommitAt(seed, conditionId, label); return { ok: true, message: "Created 1 takeoff." }; },
   };

--- a/web/test/voiceIntent.test.ts
+++ b/web/test/voiceIntent.test.ts
@@ -172,6 +172,14 @@ const CASES: Case[] = [
   { name: "deixis on note rejects: note check this one", input: "note check this one", expect: no("deixis_target") },
   { name: "deixis on note rejects: note verify base here", input: "note verify base here", expect: no("deixis_target") },
   { name: "deixis on clear label rejects: clear label here", input: "clear label here", expect: no("deixis_target") },
+
+  // 7b. author (#314)
+  { name: "author with a name", input: "author Michael E", expect: ok({ kind: "set_author", name: "Michael E" }) },
+  { name: "author keeps original casing and punctuation", input: "author j. ortiz", expect: ok({ kind: "set_author", name: "j. ortiz" }) },
+  { name: "author with nothing after it rejects", input: "author", expect: no("unrecognized") },
+  { name: "clear author", input: "clear author", expect: ok({ kind: "clear_author" }) },
+  { name: "clear author with trailing words rejects", input: "clear author now", expect: no("trailing_words") },
+  { name: "deixis on author rejects: author Bob this room", input: "author Bob this room", expect: no("deixis_target") },
   { name: "deixis on clear label rejects: clear label this room", input: "clear label this room", expect: no("deixis_target") },
   { name: "deixis with numberless tag rejects: carpet this room", input: "carpet this room", expect: no("unknown_tag") },
   { name: "deixis with prose head rejects: hello this room", input: "hello this room", expect: no("unrecognized") },


### PR DESCRIPTION
Closes #314.

## What

The provenance stamp knew everything about a mark except who made it. This adds the `author` field the RFC specifies, sourced exactly the way git sources `user.name`: **self-declared, stored locally, never authenticated** — one localStorage key (`ot-author`), zero network calls, zero new storage locations. The trust model is initials on a paper markup, per the RFC; plain-HTTP LAN self-hosts and blocked-storage contexts work identically (the in-memory declaration alone carries).

## How it lands

- **Declaring**: `author <your name>` in the command line (and the voice grammar — same intent), `clear author` to unsign. Confirmation follows the commitMsg convention. The command-box tooltip documents it.
- **Mint**: `applyShapeCommand`'s three mint sites stamp `author`, spread after the caller's fields so an import/merge that already carries attribution is never clobbered, and trailing so undeclared payloads stay **byte-for-byte identical** (the mint sites' stated key-order guarantee holds). Restore/resurrection never re-attributes — undo of a delete is not creation.
- **Edits**: `stampEdit` adds `updated_by` beside `updated_at` on every real edit, machine and manual shapes alike. The shape's mint-time `author` is never overwritten — the pair answers both of review's questions, "who traced the corridor" and "whose edit won."
- **Report**: a group-by-**Author** view — `authorGroupedRows`, the `labelGroupedRows` twin (same per-slice conditionTotals math; per-bucket sums reconcile to the ungrouped rows; named authors sorted, Unattributed last with the italic-null convention). Gated exactly like the label view: the option appears only when a shape carries an author, and a stale device-global pref falls back to ungrouped.
- **Marked set**: the legend cover names who marked the set — `Marks by: Aaron (12) · Michael (40) · unattributed (3)` — via a pure exported `authorTallyLine`, drawn only when an author exists (the provenance-line convention), so unattributed exports stay byte-identical.

The RFC's merge-review surface (#313) isn't built yet; when it lands, `author`/`updated_by` are the fields it reads.

## What this deliberately is not

Per the RFC: not identity, not access control, not audit-grade attribution. Anyone who can edit the payload can edit the name; authentication stays in whatever the team already runs.

## Finish line check

- Shapes and edit stamps carry the author whenever one is declared; absent author degrades to today's behavior everywhere (old payloads valid, new undeclared payloads byte-identical).
- Report renders per-author quantity rollups.
- Zero network calls, one localStorage key.

## Verification

- 18 new node tests across provenance, shapeCommands (mint/keep/restore), voiceIntent grammar, voiceActions dispatch, authorGroupedRows reconciliation, and authorTallyLine. Full suite 1454 green; `npm run check` green on Node 24.
- Verified live at localhost:5173: `author Test Author` → confirmation + `ot-author` persisted; `clear author` → key removed; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)