### PR TITLE
Drive presence rides the non-creating read path too

### DIFF
--- a/web/src/lib/sync/composite.js
+++ b/web/src/lib/sync/composite.js
@@ -66,6 +66,8 @@ export function buildLocalFirstStore(projectId, drive, cloud) {
     const presence = createPresence({
       provider: driveSnapshotProvider(drive),
       ensureSidecarId: cloud.ensureSidecarId,   // shared resolver (F4 — one `.opentakeoff`)
+      findSidecarId: cloud.findSidecarFolder,   // non-creating read path — an anonymous
+                                                // presence pass never litters a fresh project
       deviceId,
       getAuthor: authorName,
       getSheet: () => bridge.getSheet?.() ?? null,


### PR DESCRIPTION
Completes the no-litter discipline from #326: presence on the DRIVE composite now gets `cloud.findSidecarFolder` — the same non-creating resolver its annotation provider already uses — so an anonymous presence pass on a fresh project reads an empty room instead of creating an empty `.opentakeoff`. The folder and 365 composites already had this; Drive was the one seam missed.

One-line wiring change; `npm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)