### PR TITLE
One list of tools: TOOL_NAMES is the single source every pin reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
         working-directory: mcp
       - run: npm test
         working-directory: mcp
+      - run: npm run check:tool-count
+        working-directory: mcp
       - run: npm run build
         working-directory: mcp
       - run: npm run smoke:dist

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ otherwise, and nothing an autonomous agent could call.
 
 OpenTakeoff is that engine, with two front ends over identical geometry:
 
-- **A stdio MCP server**—`npx -y opentakeoff-mcp`, 40 tools, on the
+- **A stdio MCP server**—`npx -y opentakeoff-mcp`, <!--tool-count-->42<!--/tool-count--> tools, on the
   [official MCP registry](https://registry.modelcontextprotocol.io). An agent opens a plan,
   reads the title block, sets the scale, floods the rooms, checks its own work on a rendered
   overlay, and hands back a marked-up planset PDF.
@@ -161,7 +161,7 @@ exporting after each commit. Every shape lands in the app as a dashed **pencil p
 becomes ink only when the operator clicks Accept.* The full run, live and uncut, is
 [on YouTube (2:47)](https://youtu.be/e--kXxSGv7Y).
 
-### The 40 tools
+### The tools
 
 | Group | Tools |
 |---|---|
@@ -472,7 +472,7 @@ plus a vision-capable model id.
 | **Voice** | Push-to-talk takeoff commands, recognized on-device in WebAssembly; audio never leaves the browser |
 | **View** | Light or **dark (negative print)**—sheet pixels inverted at draw time, exports follow |
 | **Storage** | IndexedDB + localStorage—client-only, nothing uploaded |
-| **MCP server** | 40 tools + browsable sheet resources on stdio, multi-document sessions ([`mcp/`](mcp/README.md)) |
+| **MCP server** | <!--tool-count-->42<!--/tool-count--> tools + browsable sheet resources on stdio, multi-document sessions ([`mcp/`](mcp/README.md)) |
 | **Provenance** | Every shape records its scale, its method, its confidence, and whether a person or an agent made it |
 | **Capture (opt-in)** | Bundled [capture server](capture/README.md) banks each contributed takeoff as (geometry → label) training rows |
 | **Deploy** | One static build—Netlify, Vercel, GitHub Pages, Cloudflare Pages, S3, any static host |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -785,7 +785,7 @@ What's sent, and only when you run an AI feature: the sheet region in question a
 
 The same engine speaks [MCP](https://modelcontextprotocol.io), one command away:
 `npx -y opentakeoff-mcp` (or the one-click `opentakeoff-mcp.mcpb` bundle for Claude Desktop). An
-MCP client gets **40 tools** plus browsable sheet resources, over the very same measuring engine,
+MCP client gets **<!--tool-count-->42<!--/tool-count--> tools** plus browsable sheet resources, over the very same measuring engine,
 with the same scale gate and the same provenance receipts:
 
 | Group | Tools |

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.64",
+  "version": "0.9.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.64",
+      "version": "0.9.65",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.64",
+  "version": "0.9.65",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -16,6 +16,7 @@
     "mcpb": "npm run build && node scripts/build-mcpb.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run build",
     "typecheck": "tsc --noEmit",
+    "check:tool-count": "node scripts/check-tool-count.mjs",
     "test": "node --import tsx --test test/conformance.test.ts test/context.test.ts test/dxf.test.ts test/e2e.test.ts test/labels.test.ts test/overlap.test.ts test/parity.test.ts test/raster.test.ts test/resources.test.ts test/safewrite.test.ts test/scalewarn.test.ts test/session.test.ts test/staging.test.ts test/tools.test.ts test/transitions.test.ts test/twins.test.ts test/view.test.ts"
   },
   "dependencies": {

--- a/mcp/scripts/check-tool-count.mjs
+++ b/mcp/scripts/check-tool-count.mjs
@@ -1,0 +1,27 @@
+// The README's tool count is generated, not typed (issue: it rotted at "40"
+// while the server registered 42). Every `<!--tool-count-->N<!--/tool-count-->`
+// marker in the docs below must equal TOOL_NAMES.length — the same constant
+// tools.test, staging.test and smoke-dist read. `--write` rewrites them;
+// without it, a stale number fails (CI runs the check form).
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { TOOL_NAMES } from "../src/staging.ts";
+
+const DOCS = ["../../README.md", "../../docs/USER_GUIDE.md"].map((p) => fileURLToPath(new URL(p, import.meta.url)));
+const RE = /<!--tool-count-->(\d+)<!--\/tool-count-->/g;
+const want = String(TOOL_NAMES.length);
+const write = process.argv.includes("--write");
+let stale = 0, seen = 0;
+for (const file of DOCS) {
+  const text = readFileSync(file, "utf8");
+  const hits = [...text.matchAll(RE)];
+  if (!hits.length) { console.error(`${file}: no tool-count marker — the count is not generated there`); process.exitCode = 1; continue; }
+  seen += hits.length;
+  const wrong = hits.filter((m) => m[1] !== want);
+  if (!wrong.length) continue;
+  stale += wrong.length;
+  if (write) writeFileSync(file, text.replace(RE, `<!--tool-count-->${want}<!--/tool-count-->`));
+  else console.error(`${file}: says ${[...new Set(wrong.map((m) => m[1]))].join("/")} tools, the server registers ${want} — run \`npm run check:tool-count -- --write\``);
+}
+if (stale && !write) process.exitCode = 1;
+console.log(`${seen} marker(s), ${stale} ${write ? "rewritten" : "stale"}, TOOL_NAMES.length = ${want}`);

--- a/mcp/scripts/smoke-dist.mjs
+++ b/mcp/scripts/smoke-dist.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { fileURLToPath } from "node:url";
+import { TOOL_NAMES } from "../src/staging.ts";
 
 const child = spawn(process.execPath, ["dist/server.js"], {
   cwd: fileURLToPath(new URL("..", import.meta.url)),
@@ -92,49 +93,9 @@ send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
 
 const listed = await responseFor(2);
 const names = listed.tools.map((tool) => tool.name).sort();
-assert.deepEqual(names, [
-  "annotate",
-  "apply_rules",
-  "count_marks",
-  "cut_out",
-  "delete_shape",
-  "delete_verdict",
-  "derive_base",
-  "derive_transitions",
-  "detect_rooms",
-  "duplicate_condition",
-  "edit_condition",
-  "edit_materials",
-  "edit_shape", "export_dxf",
-  "export_marked_pdf",
-  "export_report",
-  "export_takeoff",
-  "find_schedule",
-  "find_text",
-  "import_takeoff",
-  "link_annotation",
-  "list_annotations",
-  "list_shapes",
-  "load_plan",
-  "mark_verdict",
-  "measure_line",
-  "measure_polygon",
-  "measure_surface",
-  "one_click",
-  "place_count",
-  "read_sheet_text",
-  "resolve_tag",
-  "set_scale",
-  "sheet_context",
-  "sheet_graph",
-  "sheet_info",
-  "split_condition",
-  "sweep_schedule_row",
-  "symbol_sweep",
-  "takeoff_summary",
-  "undo_last",
-  "view_sheet",
-]);
+// The expected surface is the ONE list every other check reads (src/staging.ts);
+// node 24 strips the types on import, so this needs no build of its own.
+assert.deepEqual(names, [...TOOL_NAMES]);
 
 child.stdin.end();
 await once(child, "close");

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.64",
+  "version": "0.9.65",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.64",
+      "version": "0.9.65",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/staging.ts
+++ b/mcp/src/staging.ts
@@ -1,5 +1,5 @@
 // Staged tool exposure (#230) — opt-in via OPENTAKEOFF_MCP_STAGED_TOOLS=1.
-// The flat forty-two stay the default for every published client; behind the flag
+// The flat set (TOOL_NAMES) stays the default for every published client; behind the flag
 // only the setup stage starts enabled and `open_tool_stage` grows the surface
 // on demand, so an agent session pays for the tool descriptions it actually
 // uses. The stage map is the same phase structure the initialize instructions
@@ -32,6 +32,14 @@ export const TOOL_STAGES: Record<string, readonly string[]> = {
     "apply_rules", "export_marked_pdf", "export_dxf",
   ],
 };
+
+/** The full tool surface, sorted — THE single source of truth. Every other
+ * statement of "which tools exist" (tools.test, staging.test, the dist smoke
+ * harness, the README's tool count) derives from this, so registering a tool
+ * means adding it to TOOL_STAGES above and nowhere else. */
+export const TOOL_NAMES: readonly string[] = Object.freeze(
+  Object.values(TOOL_STAGES).flat().sort(),
+);
 
 const OPENABLE = ["measure", "revise", "handoff"] as const;
 

--- a/mcp/test/staging.test.ts
+++ b/mcp/test/staging.test.ts
@@ -9,7 +9,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { buildServer } from "../server.ts";
 import { Session } from "../src/session.ts";
-import { TOOL_STAGES } from "../src/staging.ts";
+import { TOOL_STAGES, TOOL_NAMES } from "../src/staging.ts";
 
 const PLAN = fileURLToPath(new URL("../../demo/sample-plan.pdf", import.meta.url));
 const KEY = "sample-plan.pdf";
@@ -25,9 +25,9 @@ const connect = async (staged: boolean) => {
 const toolNames = async (client: Client) =>
   new Set((await client.listTools()).tools.map((t) => t.name));
 
-test("staging: default build is the flat forty-two — no opener, nothing disabled", async () => {
+test("staging: default build is the flat TOOL_NAMES — no opener, nothing disabled", async () => {
   const names = await toolNames(await connect(false));
-  assert.equal(names.size, 42);
+  assert.equal(names.size, TOOL_NAMES.length);
   assert.ok(!names.has("open_tool_stage"));
   for (const stage of Object.values(TOOL_STAGES)) for (const n of stage) assert.ok(names.has(n), n);
 });
@@ -68,11 +68,11 @@ test("staging: setup-only at start, open_tool_stage grows the surface, idempoten
   assert.ok(!again.isError);
   assert.deepEqual(JSON.parse(again.content[0].text).enabled, []);
 
-  // open the rest: the full forty-two, nothing ever closes
+  // open the rest: the full TOOL_NAMES, nothing ever closes
   await client.callTool({ name: "open_tool_stage", arguments: { stage: "revise" } });
   await client.callTool({ name: "open_tool_stage", arguments: { stage: "handoff" } });
   const all = await toolNames(client);
-  assert.equal(all.size, 43);
+  assert.equal(all.size, TOOL_NAMES.length + 1);
 
   // an unknown stage is a validation refusal, not a crash
   const bad: any = await client.callTool({ name: "open_tool_stage", arguments: { stage: "cleanup" } });

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -1,5 +1,6 @@
 // Tool-layer tests over a real client/server pair on an in-memory transport —
 // schemas, error surfaces, and the scale gate as an MCP client sees them.
+import { TOOL_NAMES } from "../src/staging.ts";
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
@@ -67,15 +68,10 @@ async function captureStderr(fn: () => Promise<void>): Promise<string> {
 // delete_verdict takes a record id — same reasoning.
 const NO_COORDS = new Set(["undo_last", "edit_materials", "edit_condition", "export_report", "export_marked_pdf", "export_dxf", "link_annotation", "list_shapes", "derive_base", "import_takeoff", "delete_verdict", "duplicate_condition", "split_condition", "apply_rules"]);
 
-test("tools/list: all forty-two tools, each described with the coordinate contract", async () => {
+test("tools/list: exactly TOOL_NAMES, each described with the coordinate contract", async () => {
   const client = await pair();
   const { tools } = await client.listTools();
-  assert.deepEqual(tools.map((t) => t.name).sort(), [
-    "annotate", "apply_rules", "count_marks", "cut_out", "delete_shape", "delete_verdict", "derive_base", "derive_transitions", "detect_rooms", "duplicate_condition", "edit_condition", "edit_materials", "edit_shape", "export_dxf", "export_marked_pdf", "export_report",
-    "export_takeoff", "find_schedule", "find_text", "import_takeoff",
-    "link_annotation", "list_annotations", "list_shapes", "load_plan", "mark_verdict", "measure_line", "measure_polygon", "measure_surface", "one_click", "place_count",
-    "read_sheet_text", "resolve_tag", "set_scale", "sheet_context", "sheet_graph", "sheet_info", "split_condition", "sweep_schedule_row", "symbol_sweep", "takeoff_summary", "undo_last", "view_sheet",
-  ]);
+  assert.deepEqual(tools.map((t) => t.name).sort(), [...TOOL_NAMES]);
   for (const t of tools) {
     if (NO_COORDS.has(t.name)) continue;
     assert.match(t.description || "", /image px at render scale 2\.0/, `${t.name} carries the coordinate contract`);

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.64",
+  "version": "0.9.65",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.64",
+      "version": "0.9.65",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Re-opened #332 against `main` (its base `feat/dxf-export` was deleted when #331 landed, which closes rather than retargets a stacked PR via the API). Same two commits, rebased cleanly onto `fb9b1db`.

## What & why

Adding a tool to the MCP server meant restating the surface **four times by hand**: the stage table (`staging.ts`), `staging.test.ts`'s two counts, `tools.test.ts`'s sorted list, and `scripts/smoke-dist.mjs`'s list — the last one CI-only, so a locally-green PR still went red (#331 did, once). And the README's tool count was prose nobody checked: it said **40** while the server registered **42**.

Now:
- `TOOL_NAMES` (sorted, derived from `TOOL_STAGES`) is exported from `staging.ts` and is what `tools.test.ts`, `staging.test.ts`, and `smoke-dist.mjs` all read. Node 24 strips the types on import, so the smoke harness needs no build of its own to read it.
- The README and USER_GUIDE counts sit behind `<!--tool-count-->N<!--/tool-count-->` markers. `npm run check:tool-count` (new CI step in the `mcp` job after `npm test`) fails when a marker disagrees with `TOOL_NAMES.length`; `-- --write` rewrites them. The markers say 42.
- "### The 40 tools" → "### The tools", so the count lives in one kind of place.
- MCP `0.9.64 → 0.9.65`: the version guard fires on anything under `mcp/`, and `staging.ts` does feed the bundle.

**Register a tool in `TOOL_STAGES` and nowhere else.** Skip the table → partition test fails; stale README count → CI fails.

## How it was verified

- [x] `npm run typecheck`, `npm test` (182/182), `npm run build`, `npm run smoke:dist` green on Node 24
- [x] `check:tool-count` proved both ways: fails on the stale 40s naming the file and the fix, `--write` rewrites, then passes
- [x] `node scripts/check-doc-links.mjs` — every relative path and anchor still resolves after the heading change
- [x] Docs updated where behavior changed

## Notes for the reviewer

- `NO_COORDS` in `tools.test.ts` stays a hand list on purpose — a per-tool *description* exemption, not the surface.
- No CHANGELOG entry: nothing user-facing changed except the README saying the true number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)