### PR TITLE
The net engine is One-Click: no switch, no slider; the flood is the scan path only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
 ### Added
 - **DXF export — the takeoff as a drawing, not a picture.** Every committed shape leaves as native CAD geometry: floor rings as closed `LWPOLYLINE`s, walls and linear runs open, count marks as circles, room labels as `TEXT`, each on a layer named for its finish (`OT-<TAG>`, with `-DEDUCT` / `-HOLE` / `-WALL` / `-LINEAR` / `-COUNT` suffix layers so a CAD user isolates any bucket with one layer filter). Coordinates are real units in the sheet's own frame — origin at the sheet's bottom-left, Y up, feet by default or metres in a metric report — so a ring's area in AutoCAD equals its area in the Report to rounding: the drawing is the audit. One sheet per file, like a DWG; the Report's **Export ▸ DXF (CAD)** writes the `.dxf` for a single sheet or a zip of per-sheet drawings, and the MCP server's new `export_dxf` writes one sheet to `path` (refusing without a scale, and naming the candidates when several sheets carry shapes). The file is DXF R2000 with handles, a root dictionary and a plot-style placeholder, so it passes a strict audit (`ezdxf`: 0 errors, 0 fixes) rather than merely surviving AutoCAD's lenient loader. Nothing is dropped silently — every shape left out is named with its reason, and a deduct already reconciled into its parent ships once, as that ring's `-HOLE`. Overwrite guard recognizes our own DXF by its first-line stamp, exactly as it does JSON and PDF exports. MCP `0.9.64`.
+## 2026-08-25 — the net engine is One-Click
+
+### Changed
+- **The net engine is One-Click on vector sheets — no switch, no slider.** The owner's call after a day of driving both: the flood has no purpose where there is linework to read. The **NET/FILL** toggle and the **Fill sensitivity** slider are gone; a click is a room from the wall network, ⇧-click is a finish field, and the agent's `one_click` probe runs the same engine as the estimator's click (the who-aimed-it rule). The flood survives only as the **scan** path — a scan has no linework to network — and is never reached on a vector sheet. Shapes no longer carry `fill_sensitivity`; they carry `net_v1` provenance.
+
 ## 2026-08-24 — One-Click reads the walls: the net engine (test build)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -200,11 +200,11 @@ are the rules that make this one safe to hand a model, and why each one exists:
    refuses. Pixels × a wrong scale² is every number wrong at once, so the engine would rather
    stop than guess. Disagreeing scale notes inside a measured region raise a warning rather
    than a silent pick.
-3. **The engine traces; the model doesn't invent.** `one_click` returns the ring the flood fill
-   produced from a seed point you name. A model cannot hand back a polygon it imagined and have
+3. **The engine traces; the model doesn't invent.** `one_click` returns the ring the wall
+   network produced from a seed point you name. A model cannot hand back a polygon it imagined and have
    it counted.
 4. **Every record carries how it was made.** Method, seed point, whether hatch filtering
-   engaged, whether it came off scan pixels, non-default fill sensitivity, confidence factors,
+   engaged, whether it came off scan pixels, confidence factors,
    and the machine's original ring if a human later moves it.
 5. **Agent work is pencil until a person inks it.** Exports land in the canvas as dashed
    proposals. `mark_verdict` lets an agent sign its own work as a graphite `AGENT` diamond; the

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -498,32 +498,19 @@ When One-Click refuses, it says why, and the answer is always actionable:
 - *"That space isn't enclosed on the plan linework — the fill spilled."*—there's a genuine gap (an open doorway, a break in the wall). Click a more enclosed spot, or trace it with Area (`A`). A hatched room with a real door gap **refuses rather than guessing**—that's deliberate.
 - *"Landed in dense linework (hatching/text)."*—the click landed on a text block, or on hatching too dense to read as a room. Zoom in and click an open spot, or use Area.
 
-### Fill sensitivity
+### What bounds a room
 
-The **Fill** slider lives in the **Render & fill settings** menu (sliders icon), with three notches:
+On a vector sheet One-Click reads the linework as a **wall network**: walls the drafter drew (poché, double lines, single partitions), the doors that hang in them (swings, panels, open leaves), and the finish transitions marked across wide openings. The room is the enclosed space around your click, its ring on the wall faces — not a pixel fill. There is nothing to tune: if a ring is wrong, drag its handles; the machine's ring is kept beside yours.
 
-- **Strict**—stop at the linework, no hatch crossing (the original behavior).
-- **Balanced** (default)—recover hatch-lined rooms to the walls.
-- **Aggressive**—cross more pattern and tolerate more growth.
-
-Lower it if fills spill; raise it if hatched rooms come up short. The setting is per browser, and a non-default sensitivity is recorded on the shapes it produced.
-
-**When the slider can't help, it says so.** Sensitivity tunes exactly one thing—how eagerly a
-fill escalates past ink the classifier called hatch—so a fill whose boundary is *entirely* hard
-ink comes back identical at every notch. Rather than let you crank Strict → Aggressive and
-conclude the control is broken, the menu adds the reason for the last fill: *"Nothing on this
-fill's boundary classified as a hatch or tile pattern, so every setting returns the same region.
-It is stopping on ink the engine still reads as a wall."* That's a different problem—trace it
-with Area (`A`), or check the sheet's **Layers** panel ([§2](#2-opening-plans-and-moving-around)) if
-it's a CAD export whose ink is mislabeled.
+**⇧-click an open floor** to select a whole finish **field** — the tile or plank pattern itself, grown across matching floor through doorways and stopped where the pattern stops. Teller lines, lobbies, open plans.
 
 ### Scanned plans
 
-A scanned sheet has no vector linework, so the engine reads the rendered pixels instead: adaptive thresholding (shaded rooms and uneven scans read correctly), polarity detection (blueprint negatives invert), and a gap-bridging pass for faded ink—then the same flood-and-trace machinery runs on the scan ink. Raster results skip corner snapping (a scan has no true endpoints) and the readout badges them plainly: ***Traced from scan pixels — verify edges before Create.*** Nudge the grips where the scan is soft, then create. The sensitivity slider doesn't apply on scans, and the refusal messages name the scan honestly (*"the fill escaped through a gap — faded line or open doorway"*).
+A scanned sheet has no vector linework, so the engine reads the rendered pixels instead: adaptive thresholding (shaded rooms and uneven scans read correctly), polarity detection (blueprint negatives invert), and a gap-bridging pass for faded ink—then the same flood-and-trace machinery runs on the scan ink. Raster results skip corner snapping (a scan has no true endpoints) and the readout badges them plainly: ***Traced from scan pixels — verify edges before Create.*** Nudge the grips where the scan is soft, then create. The refusal messages name the scan honestly (*"the fill escaped through a gap — faded line or open doorway"*).
 
 ### The provenance receipt
 
-Every shape One-Click creates records how it was made: the method, the seed point you clicked, whether hatch filtering engaged, whether it was traced from scan pixels, any non-default fill sensitivity, and—if you adjusted the proposal—the machine's original ring frozen next to your final one. You'll never need to think about this while measuring; it's what makes the takeoff auditable later, and it's the backbone of the optional Contribute flow (§12).
+Every shape One-Click creates records how it was made: the method, the seed point you clicked, whether hatch filtering engaged, whether it was traced from scan pixels, and—if you adjusted the proposal—the machine's original ring frozen next to your final one. You'll never need to think about this while measuring; it's what makes the takeoff auditable later, and it's the backbone of the optional Contribute flow (§12).
 
 ---
 
@@ -1025,7 +1012,7 @@ those are the ones worth pinning down before you rely on a number.
 | **Unconfirmed scale** | A scale an agent set, which no person has verified. Quantities compute, but the chip, the gallery badge, and the report all say so until you confirm it ([§3](#3-scale--set-it-first)). |
 | **Calibrate versus Check** | Calibrate sets the scale from a dimension you type. Check (`K`) is its read-only twin—it grades the scale you already have ([§3](#3-scale--set-it-first)). |
 | **Hatch / poché** | The pattern fill inside a room or wall on the drawing. One-Click classifies it as pattern rather than boundary, so a hatched room still traces to the real walls ([§6](#6-one-click-area)). |
-| **Fill sensitivity** | How eagerly a fill escalates past ink the engine called hatch—Strict, Balanced, Aggressive. It cannot help when the boundary is all hard ink, and it says so ([§6](#6-one-click-area)). |
+| **Finish field** | ⇧-click on a vector sheet: the whole tile or plank pattern under the click, grown through doorways and stopped where the pattern stops ([§6](#6-one-click-area)). |
 | **Zone check** | A reading, not a takeoff: trace a wing and see what's inside it, with materials scaled to the zone. Nothing is saved ([§5](#5-the-measuring-tools)). |
 | **Marked set** | The distribution-ready PDF—your work burned into the drawings behind a legend cover, with a tally of how much of it a person has approved. The deliverable a GC can check ([§10](#10-the-report-and-exports)). |
 | **Revision** | A named snapshot of the whole takeoff. Compare two and you get quantity deltas per condition, per sheet, and on the buy list ([§11](#11-revisions)). |

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -583,19 +583,18 @@ export default function TakeoffCanvas() {
   const [angleOn, setAngleOn] = useState(true);  // 45°/90° angle guides (polar tracking) — on by default; ⇧ = hard lock
   // One-Click fill sensitivity (0..1) — how eagerly a fill crosses a room's hatch;
   // per-user pref, defaults to the calibrated Balanced preset.
-  const [fillSens, setFillSens] = useState(() => {
-    try { const v = parseFloat(localStorage.getItem("opentakeoff_fill_sens")); return Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : SENS_BALANCED; } catch { return SENS_BALANCED; }
-  });
-  useEffect(() => { try { localStorage.setItem("opentakeoff_fill_sens", String(fillSens)); } catch { /* private mode */ } }, [fillSens]);
+  // scan-path flood sensitivity — fixed; the knob is gone with the fill UI
+  const fillSens = SENS_BALANCED;
   // NET ENGINE (test drive, 2026-08-24): route One-Click through the wall-
   // network room detector (lib/netroom) instead of the raster flood. Off by
   // default; persisted so a test session survives a reload. The net for a
   // sheet is built once per (sheet, scale) and cached — seconds on a dense
   // sheet, instant after.
-  const [netEngine, setNetEngine] = useState(() => {
-    try { return localStorage.getItem("opentakeoff_net_engine") === "1"; } catch { return false; }
-  });
-  useEffect(() => { try { localStorage.setItem("opentakeoff_net_engine", netEngine ? "1" : "0"); } catch { /* private mode */ } }, [netEngine]);
+  // The net engine IS One-Click on vector sheets (owner's call, 2026-08-25:
+  // the flood has no purpose there). The flood survives only as the SCAN
+  // path — a scan has no linework to network — and is never user-visible on
+  // a vector sheet.
+  const netEngine = true;
   const netCacheRef = useRef(new Map());   // `${sheetKey}:${upp}` → built net
   const netTickRef = useRef(null);          // ticking "reading the walls… N s" timer
   // No mode dial (his call, 2026-08-24: "too technical for users"). A click
@@ -4289,7 +4288,7 @@ export default function TakeoffCanvas() {
       const segs = vectorSegsRef.current.get(tp.key);
       const meta = segMetaRef.current.get(tp.key);
       if (!segs || !meta) return say("Still reading this sheet's linework — One-Click arms as soon as that finishes (a dense sheet can take a few seconds). Try again in a moment.");
-      if (!netWorker) return say("Net engine needs Web Workers — switch it off to use the fill.");
+      if (!netWorker) return say("One-Click needs Web Workers in this browser — trace it with Area (A).");
       // FRAMES: the vector segments live at the BASELINE render scale; a hi-res
       // sheet's click and its upp are in the hi-res frame (uppFor divides by
       // factorFor). Convert into the segments' frame for the engine and back
@@ -4317,7 +4316,7 @@ export default function TakeoffCanvas() {
       }
       let info;
       try { info = await built; }
-      catch (err) { console.error("net engine build failed", err); return say("Net engine couldn't read this sheet — switch it off to use the fill."); }
+      catch (err) { console.error("net engine build failed", err); return say("One-Click couldn't read this sheet's linework — trace it with Area (A)."); }
       finally { if (netTickRef.current) { clearInterval(netTickRef.current); netTickRef.current = null; } }
       if (toolRef.current !== "oneclick" || (proposalRef.current && proposalRef.current.key !== tp.key)) { setCommitMsg(""); return { ok: false, message: "" }; }
       const field = !!fieldClick;
@@ -4325,7 +4324,7 @@ export default function TakeoffCanvas() {
       const r = rm.room;
       if (!r) return say(field
         ? "No finish pattern under that ⇧-click — ⇧-click inside the tile or plank pattern to select the whole field."
-        : "Net engine: that click isn't inside an enclosed space — click an open spot, ⇧-click an open finish field, or trace it with Area (A).");
+        : "That click isn't inside an enclosed space — click an open spot, ⇧-click an open finish field, or trace it with Area (A).");
       const ring = r.ring.map(([x, y]) => [x / kF, y / kF]);      // back to the panel's frame
       try { Object.assign(window.__netLast, { lastClick: [local[0], local[1]], lastRing: ring.map(([x, y]) => [+x.toFixed(1), +y.toFixed(1)]), lastFaces: r.faces }); } catch { /* diagnostics only */ }
       const area_sf = +(r.areaPx / (ftPx * ftPx)).toFixed(2);
@@ -5318,21 +5317,39 @@ export default function TakeoffCanvas() {
     if (upp == null) return { error: agentScaleGate(key, agentStateRef.current.detectedScales[key]?.label || "") };
     const local = [xn * p.img.w, yn * p.img.h];
     const stats = sheetStatsRef.current.get(key);
-    const rasterEligible = !!stats && stats.imageFrac >= RASTER_MIN_IMG_FRAC;
     const vectorViable = !!stats && stats.segCount >= RASTER_MIN_SEGS;
     let f = null, raster = false;
-    if (!rasterEligible || vectorViable) {
-      const mo = ensureMask(key);
-      if (!mo && !rasterEligible) return { error: "Still reading this sheet's linework — try again in a second." };
-      if (mo) {
-        const r = floodRegionSealed(mo, local[0], local[1], fillSens, sealRadiiFor(mo.ws / upp), doorWedgeCapPx(mo.ws / upp), minPassRadiusFor(mo.ws / upp));
-        if (r.status === "ok") f = r;
-        else if (!rasterEligible) {
-          return { error: r.status === "leak"
-            ? "That space isn't enclosed on the plan linework — the fill spilled. Seed a more enclosed spot."
-            : "Landed in dense linework (hatching/text). Seed an open spot inside the room." };
-        }
+    // Vector sheet: the SAME net engine a human click runs — an agent and an
+    // estimator must never trace differently (the who-aimed-it rule).
+    if (vectorViable) {
+      const segs = vectorSegsRef.current.get(key);
+      const meta = segMetaRef.current.get(key);
+      if (!segs || !meta) return { error: "Still reading this sheet's linework — try again in a moment." };
+      if (!netWorker) return { error: "One-Click needs Web Workers in this browser." };
+      const kF = RENDER_SCALE / (renderScalesRef.current.get(key) || RENDER_SCALE);
+      const ftPx = kF / upp;
+      const ck = `${key}:${ftPx.toFixed(4)}`;
+      let built = netCacheRef.current.get(ck);
+      if (!built) {
+        built = netCall({ type: "build", key: ck, segs, meta, subpaths: subpathsRef.current.get(key) || null, ftPx, texts: textMarksRef.current.get(key) || [], opts: {} })
+          .then((m) => { if (m.error) { netCacheRef.current.delete(ck); throw new Error(m.error); } return m; });
+        netCacheRef.current.set(ck, built);
       }
+      try { await built; } catch { return { error: "One-Click couldn't read this sheet's linework — the estimator will have to trace it." }; }
+      const rm = await netCall({ type: "room", key: ck, x: local[0] * kF, y: local[1] * kF, ftPx, mode: "room" });
+      const r = rm.room;
+      if (!r) return { error: "That seed isn't inside an enclosed space on the plan linework. Seed an open spot inside the room." };
+      const ring = r.ring.map(([x, y]) => [x / kF, y / kF]);
+      if (ring.length < 3) return { error: "Couldn't trace that space into a polygon." };
+      const area_sf = +(r.areaPx / (ftPx * ftPx)).toFixed(2);
+      return {
+        verts_norm: ring.map(([x, y]) => [+(x / p.img.w).toFixed(5), +(y / p.img.h).toFixed(5)]),
+        area_sf,
+        perimeter_lf: +(closedMetrics(ring).perim * upp).toFixed(2),
+        seed_norm: [+xn.toFixed(5), +yn.toFixed(5)],
+        confidence: 1,
+        net_faces: r.faces,
+      };
     }
     if (!f) {
       const rmo = await ensureRasterMask(key);
@@ -6860,52 +6877,6 @@ export default function TakeoffCanvas() {
   // Aggressive; the slider still tunes 0–100% freely, snapping to a notch when
   // released near one. Detents come from oneclick's canonical presets so UI
   // and flood math can't drift if a preset is ever retuned.
-  const fillRow = (() => {
-    const NOTCHES = [SENS_STRICT, SENS_BALANCED, SENS_AGGRESSIVE];
-    const label = fillSens === SENS_STRICT ? "Strict" : fillSens === SENS_BALANCED ? "Balanced" : fillSens === SENS_AGGRESSIVE ? "Aggressive" : `${Math.round(fillSens * 100)}%`;
-    const snap = (v) => { for (const n of NOTCHES) if (Math.abs(v - n) <= 0.06) return n; return v; };
-    // A knob that cannot move must SAY so. Sensitivity tunes one thing — how
-    // eagerly a fill escalates past ink the classifier called hatch — so a
-    // fill whose boundary is entirely hard ink returns a bit-identical region
-    // at every notch, and the estimator watching it stop short reaches for
-    // this slider and gets nothing (measured on the VA finish plan: Strict,
-    // Balanced and Aggressive agree to the square foot on every room).
-    //
-    // The claim is made from the LAST FILL's own softHits, not the sheet's
-    // softCount. Sheet level cannot answer it: AF101 classifies thousands of
-    // poché strokes in its toilet rooms — nonzero softCount all day — while
-    // the patient rooms that stop short touch none of them. Undefined means
-    // no fill yet, and discloses nothing.
-    const inert = proposal?.regions?.length
-      ? proposal.regions.every((r) => r.shs === 0)
-      : false;
-    return (
-      <div title={"One-Click fill sensitivity — how far a fill reaches past a room's hatch pattern.\nStrict: stop at the linework (original behavior).\nBalanced: recover hatch-lined rooms to the walls (default).\nAggressive: cross more pattern and tolerate more growth.\nLower it if fills spill; raise it if hatched rooms come up short.\nScanned sheets trace from pixels — sensitivity doesn't apply there."
-        + (inert ? "\n\nNothing on this fill's boundary classified as a hatch or tile pattern, so every setting returns the same region. It is stopping on ink the engine still reads as a wall." : "")}
-        style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 12px", flexWrap: "wrap" }}>
-        <button type="button" onClick={() => { setNetEngine((v) => !v); setProposal(null); }}
-          title={netEngine
-            ? "NET ENGINE ON — One-Click runs the wall-network room detector (test build). Click a room to select it; ⇧-click an open floor to select the whole finish field (tile, plank). Click to switch back to the fill."
-            : "One-Click runs the fill. Click to try the NET ENGINE (wall-network room detector, test build)."}
-          style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: 0.3, padding: "3px 8px", borderRadius: 6, cursor: "pointer",
-                   border: `1px solid ${netEngine ? "var(--cobalt)" : "var(--line)"}`,
-                   background: netEngine ? "var(--cobalt)" : "transparent", color: netEngine ? "#fff" : "var(--ink-soft)" }}>
-          {netEngine ? "NET" : "FILL"}
-        </button>
-        <span style={{ fontSize: 11.5, fontWeight: 600, color: "var(--ink-soft)", opacity: netEngine ? 0.45 : 1 }}>Fill</span>
-        <input name="fill-sensitivity" type="range" min={SENS_STRICT} max={SENS_AGGRESSIVE} step={0.01} value={fillSens} list="fill-sens-notches"
-          onChange={(e) => setFillSens(snap(parseFloat(e.target.value)))}
-          style={{ flex: 1, accentColor: "var(--cobalt)", cursor: "pointer", opacity: inert ? 0.45 : 1 }} />
-        <datalist id="fill-sens-notches"><option value={SENS_STRICT} /><option value={SENS_BALANCED} /><option value={SENS_AGGRESSIVE} /></datalist>
-        <span style={{ fontFamily: "var(--f-mono)", fontSize: 10.5, fontWeight: 600, color: inert ? "var(--ink-faint)" : "var(--cobalt)", minWidth: 58 }}>{label}</span>
-        {inert && (
-          <span style={{ flexBasis: "100%", fontSize: 10.5, lineHeight: 1.35, color: "var(--ink-soft)" }}>
-            This fill is bounded entirely by hard ink — every setting returns the same region.
-          </span>
-        )}
-      </div>
-    );
-  })();
 
   // ?hatchqa — density-tuning wall: every pattern at three scales in two palette
   // colors, real components, dark-aware. Unreachable from the UI; kept for retunes.
@@ -7040,15 +7011,6 @@ export default function TakeoffCanvas() {
             style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "6px 10px", border: `1px solid ${angleOn ? "var(--cobalt)" : "var(--ink-faint)"}`, background: angleOn ? "var(--cobalt)" : "transparent", color: angleOn ? "var(--paper-bright)" : "var(--ink)", cursor: "pointer", fontWeight: 600, fontSize: 12.5, lineHeight: 1 }}>
             <Icon name="angle" size={15} />45°
           </button>
-          <ToolMenu
-            title="Render & fill settings — One-Click fill sensitivity"
-            onOpenChange={onMenuDepth}
-            face={<Icon name="sliders" size={15} />}
-            menuStyle={{ minWidth: 252 }}
-            items={[
-              { id: "fill", custom: fillRow },
-            ]}
-          />
         </>)}
         {/* The caption always shows the ACTIVE label (+ the cobalt highlight keyed
             on it) so what a new trace will get is never hidden — even in Select


### PR DESCRIPTION
## What & why

The net engine is One-Click on vector sheets. The owner's call after a day driving both engines side by side: the flood has no purpose where there is linework to read.

- **NET/FILL toggle and the Fill sensitivity slider removed.** A click is a room from the wall network; ⇧-click is a finish field.
- **The agent's `one_click` probe runs the same engine** as the estimator's click — the who-aimed-it rule, an agent and a person never trace differently.
- **The flood survives only as the scan path** (a scan has no linework to network), at a fixed sensitivity, never reached on a vector sheet.
- Shapes no longer carry `fill_sensitivity`; they carry `net_v1` provenance.

Follows #330 (the engine behind a switch). Serves #60 and #320.

## How it was verified

- [x] `npm run check` green — typecheck, lint (one pre-existing warning), 1543/1543 web tests, bench, build; `mcp` 182/182
- [x] Exercised in the running app on a real finish plan: One-Click with no switch → 201 SF room on the walls, net from cache in 0.3 s, zero console errors
- [x] `docs/USER_GUIDE.md` (§6 rewritten: "What bounds a room", finish field, glossary), `README.md`, `CHANGELOG.md` updated

## Notes for the reviewer

- `fillSens` is now a constant (`SENS_BALANCED`) feeding only the scan-path flood; `netEngine` is a constant `true`. The dead UI (`fillRow`, its `ToolMenu`, the localStorage keys) is gone.
- `agentOneClickProbe` gained the same frame conversion (`kF`) and per-(sheet, scale) build cache the interactive path uses; scan sheets fall through to the existing raster branch unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
