### PR TITLE
Faster, crisper plan preview: big-tile base layer + persisted 2× gallery thumbnails

### DIFF
--- a/web/src/components/PlanNavigator.jsx
+++ b/web/src/components/PlanNavigator.jsx
@@ -30,8 +30,12 @@ import { listConflictCopies } from "../lib/fs/fsProvider.js";
 import { m365Config, M365_ENABLED_KEY } from "../lib/msgraph/config.js";
 import { metaGet, metaPut, metaDelete } from "../lib/store.js";
 import { groupSheetsByLevel, sortGalleryGroups } from "../lib/sheetLevels.js";
+import { renderThumb, loadThumb, saveThumb, thumbPixelWidth } from "../lib/thumbs.js";
 
-const THUMB_W = 380;
+// Thumbnails in flight at once. The canvas rasters in its worker pool now, so
+// the main thread's pdf.js is mostly idle while the gallery is up; two keeps
+// a 3-core laptop responsive while halving the wave on a big set.
+const THUMB_PAR = 2;
 const ROOT = { id: undefined, name: "Project" };   // id undefined → cloudStore's default (project folder)
 
 function fmtSize(s) {
@@ -229,7 +233,6 @@ export default function PlanNavigator({
   const [, bump] = useState(0);
   const seqRef = useRef(0);
   const queueRef = useRef([]);
-  const pumpingRef = useRef(false);
   const obsRef = useRef(null);
 
   const loadSample = async () => {
@@ -303,38 +306,66 @@ export default function PlanNavigator({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pages, knownPages, mode]);
 
-  const pump = async () => {
-    if (pumpingRef.current) return;
-    pumpingRef.current = true;
-    const seq = seqRef.current;
-    while (queueRef.current.length) {
-      if (seq !== seqRef.current) break;
-      if (busyRef.current === "rendering") { await new Promise((r) => setTimeout(r, 150)); continue; }
-      const key = queueRef.current.shift();
-      if (thumbCacheRef.current.has(key)) continue;
-      try {
-        const { file, page } = parseSheetKey(key);
-        const pdf = await getDoc(file);
-        const pg = await pdf.getPage(page);
-        if (seq !== seqRef.current) break;
-        const vp1 = pg.getViewport({ scale: 1 });
-        const vp = pg.getViewport({ scale: THUMB_W / vp1.width });
-        const c = document.createElement("canvas");
-        c.width = Math.ceil(vp.width); c.height = Math.ceil(vp.height);
-        await pg.render({ canvasContext: c.getContext("2d"), viewport: vp }).promise;
-        thumbCacheRef.current.set(key, c.toDataURL("image/jpeg", 0.72));
-        bump((n) => n + 1);
-        if (!labels[key] || !detectedScales[key]) {
+  // One card's thumbnail: persisted record first (no pdf.js doc, no raster —
+  // the whole reason a known set's gallery opens instantly), else raster at
+  // this screen's density, persist, and read the sheet number + plan-noted
+  // scale off the same page while it's warm. Any failure just skips the card
+  // (destroyed doc on unmount / render-cancel).
+  const thumbOne = async (key, seq) => {
+    if (thumbCacheRef.current.has(key)) return;
+    const want = thumbPixelWidth();
+    let rec = await loadThumb(key, want);
+    if (seq !== seqRef.current) return;
+    if (!rec) {
+      const { file, page } = parseSheetKey(key);
+      const pdf = await getDoc(file);
+      const pg = await pdf.getPage(page);
+      if (seq !== seqRef.current) return;
+      rec = await renderThumb(pg, want);
+      if (seq !== seqRef.current) return;
+      if (!labels[key] || !detectedScales[key]) {
+        try {
           const tc = await pg.getTextContent();
           const vpL = pg.getViewport({ scale: RENDER_SCALE });
-          const lbl = extractSheetNumber(tc, vpL);
-          if (lbl) onLabel(key, lbl);
-          const det = detectScale(tc, vpL);
-          if (det) onDetect(key, det);
-        }
-      } catch { /* destroyed doc on unmount / render-cancel — skip */ }
+          rec.label = extractSheetNumber(tc, vpL) || null;
+          rec.det = detectScale(tc, vpL) || null;
+        } catch { /* text layer is optional */ }
+      }
+      saveThumb(key, rec);
     }
-    pumpingRef.current = false;
+    if (thumbCacheRef.current.has(key)) return;
+    thumbCacheRef.current.set(key, URL.createObjectURL(rec.blob));
+    if (rec.label && !labels[key]) onLabel(key, rec.label);
+    if (rec.det && !detectedScales[key]) onDetect(key, rec.det);
+    scheduleBump();
+  };
+
+  // coalesce card reveals to one React render per frame
+  const bumpRafRef = useRef(0);
+  const scheduleBump = () => {
+    if (bumpRafRef.current) return;
+    bumpRafRef.current = requestAnimationFrame(() => { bumpRafRef.current = 0; bump((n) => n + 1); });
+  };
+
+  const activeRef = useRef(0);
+  const pump = () => {
+    while (activeRef.current < THUMB_PAR && queueRef.current.length) {
+      const seq = seqRef.current;
+      const key = queueRef.current.shift();
+      if (thumbCacheRef.current.has(key)) continue;
+      activeRef.current++;
+      (async () => {
+        // the canvas's own open sequence (doc → page → geometry) owns the main
+        // thread for its moment; yield to it rather than compete
+        while (busyRef.current === "rendering" && seq === seqRef.current) await new Promise((r) => setTimeout(r, 150));
+        if (seq !== seqRef.current) return;
+        await thumbOne(key, seq);
+      })().catch((e) => {
+        // a destroyed doc (unmount / render-cancel) is routine; anything else
+        // used to vanish into a bare catch and read as "thumbnails never load"
+        if (!/destroyed|cancel/i.test(String(e?.message || e))) console.warn(`[thumbs] ${key}:`, e);
+      }).finally(() => { activeRef.current--; pump(); });
+    }
   };
 
   useEffect(() => {
@@ -350,10 +381,37 @@ export default function PlanNavigator({
     return () => obsRef.current?.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  // Cards commit their ref callbacks BEFORE the mount effect above creates
+  // the observer, so a gallery whose page counts are all known up front
+  // (#302's persisted cache — the common reopen) rendered every card in the
+  // first pass and none of them was ever observed: 19 skeletons, forever.
+  // Sweep the grid after every key-set change and hand the observer whatever
+  // it hasn't seen; observe() on an already-observed element is a no-op.
+  const gridRef = useRef(null);
+  const keySig = allKeys.join("\u0000");
+  useEffect(() => {
+    const obs = obsRef.current, grid = gridRef.current;
+    if (!obs || !grid) return;
+    for (const el of grid.querySelectorAll("[data-sheetkey]")) {
+      if (!thumbCacheRef.current.has(el.dataset.sheetkey)) obs.observe(el);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keySig, mode]);
 
   const toggleSel = (key) => setSel((g) => (g.includes(key) ? g.filter((k) => k !== key) : [...g, key]));
-  const shapeCount = (key) => shapes.reduce((n, s) => n + (s.sheet_id === key ? 1 : 0), 0);
-  const pdfShapeCount = (file) => shapes.reduce((n, s) => n + (parseSheetKey(s.sheet_id).file === file ? 1 : 0), 0);
+  // shape tallies once per shapes change, not once per card per render — a
+  // thumbnail reveal re-renders the grid, and N cards × M shapes added up
+  const shapeTally = useMemo(() => {
+    const bySheet = new Map(), byFile = new Map();
+    for (const s of shapes) {
+      bySheet.set(s.sheet_id, (bySheet.get(s.sheet_id) || 0) + 1);
+      const f = parseSheetKey(s.sheet_id).file;
+      byFile.set(f, (byFile.get(f) || 0) + 1);
+    }
+    return { bySheet, byFile };
+  }, [shapes]);
+  const shapeCount = (key) => shapeTally.bySheet.get(key) || 0;
+  const pdfShapeCount = (file) => shapeTally.byFile.get(file) || 0;
   const labelOf = (key) => {
     if (labels[key]) return labels[key];
     const t = parseSheetKey(key);
@@ -586,7 +644,7 @@ export default function PlanNavigator({
   // ── PLAN body + footer ──────────────────────────────────────────────────
   const planBody = (
     <>
-      <div style={{ flex: 1, overflow: "auto", padding: 18 }}>
+      <div ref={gridRef} style={{ flex: 1, overflow: "auto", padding: 18 }}>
         {groups.map((grp) => (
         <div key={grp.level ?? "__all"} style={{ marginBottom: grp.level !== null ? 22 : 0 }}>
         {grp.level !== null && (
@@ -618,7 +676,7 @@ export default function PlanNavigator({
                 </div>
                 <div style={{ height: 185, display: "flex", alignItems: "center", justifyContent: "center", background: "var(--well)", borderBottom: "1px solid var(--ink-faint)", overflow: "hidden" }}>
                   {thumb
-                    ? <img src={thumb} alt={labelOf(key)} style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }} />
+                    ? <img src={thumb} alt={labelOf(key)} decoding="async" draggable={false} style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }} />
                     : <div className="skeleton" style={{ width: "86%", height: "78%" }} />}
                 </div>
                 <div style={{ padding: "8px 10px", display: "flex", alignItems: "baseline", gap: 8 }}>

--- a/web/src/lib/store.js
+++ b/web/src/lib/store.js
@@ -463,6 +463,22 @@ export async function metaPut(key, value) {
 export async function metaDelete(key) {
   await withDb((db) => tx(db, META_STORE, "readwrite", (os) => os.delete(key)));
 }
+/** Delete every meta key that starts with `prefix` (one transaction). Keys are
+ *  strings, so a bound range [prefix, prefix + U+FFFF) is the prefix scan.
+ *  @param {string} prefix @returns {Promise<number>} keys removed */
+export async function metaDeletePrefix(prefix) {
+  if (!prefix) return 0;
+  return withDb((db) => new Promise((resolve, reject) => {
+    const t = db.transaction(META_STORE, "readwrite");
+    const os = t.objectStore(META_STORE);
+    let n = 0;
+    const req = os.openKeyCursor(IDBKeyRange.bound(prefix, prefix + "\uffff", false, true));
+    req.onsuccess = () => { const c = req.result; if (c) { os.delete(c.primaryKey); n++; c.continue(); } };
+    t.oncomplete = () => resolve(n);
+    t.onerror = () => reject(t.error);
+    t.onabort = () => reject(t.error);
+  }));
+}
 
 // ── the mode-aware store seam ──────────────────────────────────────────────
 // The default build is byte-for-byte the old client-only app: `store` is

--- a/web/src/lib/thumbs.js
+++ b/web/src/lib/thumbs.js
@@ -1,0 +1,84 @@
+// Gallery thumbnails: crisp, cheap, and remembered.
+//
+// Three rules, each answering a complaint that was live:
+//   1. SHARP — raster at THUMB_W × devicePixelRatio (capped at 2×). A 380px
+//      raster on a 2× screen was being stretched to 760 device px in the
+//      card: every plan looked soft, and soft thumbnails are what make a
+//      user squint at the gallery wondering which sheet they're opening.
+//   2. OFF THE MAIN THREAD where the platform allows — encoding goes through
+//      canvas.toBlob (async, worker-side in Chromium) instead of the
+//      synchronous toDataURL that stalled the gallery for every card.
+//      WebP is preferred (small AND lossless-looking on linework); a browser
+//      that can't encode it silently hands back PNG, which we accept.
+//   3. REMEMBERED — the blob (plus the sheet number and plan-noted scale the
+//      pump reads off the same page) lands in the meta store keyed by sheet,
+//      so reopening a gallery draws every card from IndexedDB without loading
+//      a single pdf.js document. Sites that drop a file's bytes (close,
+//      remove, revise-by-redrop, clear, restore) call forgetThumbs, so a
+//      stale thumbnail can never outlive the PDF it pictured.
+//
+// Pure-ish helpers (DOM canvas + IndexedDB, no React) so PlanNavigator stays
+// a view.
+import { metaGet, metaPut, metaDelete, metaDeletePrefix } from "./store.js";
+
+export const THUMB_W = 380;           // CSS px — the card well is 270..~400 wide
+const THUMB_VERSION = 2;              // bump to invalidate every persisted thumb
+const PREFIX = `thumb:v${THUMB_VERSION}:`;
+
+/** Device px the raster should be wide for a crisp card on this screen. */
+export function thumbPixelWidth() {
+  const dpr = typeof window !== "undefined" ? (window.devicePixelRatio || 1) : 1;
+  return Math.round(THUMB_W * Math.min(2, Math.max(1, dpr)));
+}
+
+const keyOf = (sheetKey) => `${PREFIX}${sheetKey}`;
+
+/** Rasterize `pg` (a pdf.js page) into a Blob `w` device px wide. */
+export async function renderThumb(pg, w = thumbPixelWidth()) {
+  const vp1 = pg.getViewport({ scale: 1 });
+  const vp = pg.getViewport({ scale: w / vp1.width });
+  const c = document.createElement("canvas");
+  c.width = Math.ceil(vp.width); c.height = Math.ceil(vp.height);
+  const ctx = c.getContext("2d", { alpha: false });
+  await pg.render({ canvasContext: ctx, viewport: vp, background: "#ffffff" }).promise;
+  let blob = await new Promise((res) => c.toBlob(res, "image/webp", 0.9));
+  if (!blob) blob = await new Promise((res) => c.toBlob(res, "image/jpeg", 0.9));
+  if (!blob) throw new Error("thumbnail encode failed");
+  return { blob, w: c.width, h: c.height };
+}
+
+/** Persisted record for `sheetKey`, or null when absent / rastered narrower
+ *  than this screen now wants (a 1× thumb re-renders on a 2× screen). */
+export async function loadThumb(sheetKey, minW = thumbPixelWidth()) {
+  try {
+    const rec = await metaGet(keyOf(sheetKey));
+    if (!rec || !(rec.blob instanceof Blob) || !(rec.w >= minW)) return null;
+    return rec;
+  } catch { return null; }
+}
+
+/** Best-effort persist; a quota failure only costs the next open a re-render. */
+export function saveThumb(sheetKey, rec) {
+  return metaPut(keyOf(sheetKey), { w: rec.w, h: rec.h, blob: rec.blob, label: rec.label ?? null, det: rec.det ?? null, ts: Date.now() }).catch(() => {});
+}
+
+/** Drop every thumb for these FILE names — persisted AND the live object
+ *  URLs in `liveMap` (sheetKey → blob URL), which are revoked. */
+export async function forgetThumbs(fileNames, liveMap) {
+  for (const file of fileNames) {
+    if (liveMap) {
+      for (const [k, url] of liveMap) {
+        if (k === file || k.startsWith(`${file}#`)) { try { URL.revokeObjectURL(url); } catch { /* not ours */ } liveMap.delete(k); }
+      }
+    }
+    // a sheet key is `file` or `file#N`: the exact key, then the `file#` prefix
+    // (the `#` bound keeps `plan.pdf` from sweeping `plan.pdf2`'s thumbs)
+    try { await metaDelete(keyOf(file)); await metaDeletePrefix(keyOf(`${file}#`)); } catch { /* cache only */ }
+  }
+}
+
+/** Revoke + clear every live thumb URL (project switch / clear workspace). */
+export function releaseThumbs(liveMap) {
+  for (const [, url] of liveMap) { try { URL.revokeObjectURL(url); } catch { /* not ours */ } }
+  liveMap.clear();
+}

--- a/web/src/lib/tileCompositor.ts
+++ b/web/src/lib/tileCompositor.ts
@@ -51,7 +51,7 @@
 import { RENDER_SCALE } from "./sheets";
 import { LOW_MEMORY_DEVICE } from "./deviceClass";
 import { createTilePool } from "./tilePool";
-import { TileLRU, buildLevels, pickLevel, levelDims, visibleTiles, visibleTilesAtDensity, fitDensity, BASE_LEVEL, tileKey as rawTileKey, TILE_SIZE } from "./tiles";
+import { TileLRU, buildLevels, pickLevel, levelDims, visibleTiles, visibleTilesAtDensity, fitDensity, tileGrid, BASE_LEVEL, BASE_COARSE_LEVEL, BASE_MID_LEVEL, isBaseLevel, tileKey as rawTileKey, TILE_SIZE } from "./tiles";
 
 // ~450MB shared across every open sheet/panel — the old per-group ceiling
 // ("4-up ≈ 450MB" per canvasConstants.js), now a BUDGET instead of a floor
@@ -66,6 +66,24 @@ const BYTE_BUDGET = (LOW_MEMORY_DEVICE ? 120 : 450) * 1024 * 1024;
 // shipped for years before #86; tiling just makes hitting that number
 // bounded-memory instead of one giant backing store.
 const BASE_TARGET_AREA = 28_000_000;
+// Tile edge for the base family (coarse / screen-fit / budget composites).
+// Measured live on a hatch-heavy finish plan: EVERY tile cost ~300 ms in the
+// worker whether it was a 512-px coarse tile or a 512-px full-density tile —
+// pdf.js walks the sheet's whole operator list per render, and the pixels
+// are the cheap part. So a 20MP base cut into 512s was ~77 walks (5+ s on a
+// 5-worker pool); cut into 2048s it is ~8 walks. The pyramid keeps 512
+// (detail crops are viewport-sized and cached per tile); only the whole-
+// sheet rasters use this. Phones keep 512: a 2048² OffscreenCanvas plus its
+// ImageBitmap is 32 MB of transient memory per tile.
+const BASE_TILE = LOW_MEMORY_DEVICE ? TILE_SIZE : 2048;
+const tileSizeOf = (level: number) => (isBaseLevel(level) ? BASE_TILE : TILE_SIZE);
+// Tile ceiling for the screen-fit stand-in painted between the coarse
+// placeholder and the budget composite (paintBase's phase 1.5), in BASE
+// tiles: one pool round. With 2048-px base tiles the budget composite is
+// itself only ~8 tiles, so this pass fires only for sheets big enough that
+// the budget pass is still several rounds (midLevel requires it to be under
+// half the budget's tile count).
+const BASE_MID_TILES = 4;
 // Sanity ceiling on ONE detail crop's backing store. In normal use the crop
 // is viewport*dpr — about 8MP — at every zoom, because zooming in shrinks the
 // image-space region by exactly the factor it raises the density. This only
@@ -118,6 +136,10 @@ export function createTileCompositor() {
   // exact-fit density the BASE composite was painted at, per sheet — the
   // placeholder search needs it to rank the base against the pyramid levels
   const baseDensityBySheet = new Map<string, number>();
+  // every base-family layer painted for a sheet (coarse / screen-fit /
+  // budget) with its density — all are placeholder candidates, ranked by
+  // density alongside the pyramid levels in bestPlaceholder
+  const baseLayersBySheet = new Map<string, { level: number; density: number }[]>();
   const opened = new Set<string>();
   // Every tile request awaits this before hitting the worker — dataPromise
   // (an IndexedDB read) resolves well after openSheet() returns, so without
@@ -164,6 +186,8 @@ export function createTileCompositor() {
     dimsBySheet.clear();
     readyBySheet.clear();
     visibleKeys.clear();
+    baseDensityBySheet.clear();
+    baseLayersBySheet.clear();
   }
 
   async function getOrFetchTile(sheetKey: string, level: number, tx: number, ty: number, density: number, dark: boolean): Promise<ImageBitmap | undefined> {
@@ -189,13 +213,19 @@ export function createTileCompositor() {
       try { await readyBySheet.get(sheetKey); } catch { return undefined; } // sheet failed to open
       if (myGen !== generation) return undefined; // superseded while we waited on open
       const { w: levelW, h: levelH } = levelDims(dims.w, dims.h, density);
-      const x = tx * TILE_SIZE, y = ty * TILE_SIZE;
-      const rect = { x, y, w: Math.min(TILE_SIZE, levelW - x), h: Math.min(TILE_SIZE, levelH - y) };
+      const tile = tileSizeOf(level);
+      const x = tx * tile, y = ty * tile;
+      const rect = { x, y, w: Math.min(tile, levelW - x), h: Math.min(tile, levelH - y) };
       if (rect.w <= 0 || rect.h <= 0) return undefined;
       const { promise, cancel } = pool.requestTile({ sheetKey, scale: RENDER_SCALE * density, rect, dark });
       cancelRef.cancel = cancel;
+      const tReq = performance.now();
       try {
         const { bitmap, w, h } = await promise;
+        {
+          const w = window as unknown as { __OT_DETAIL_DEBUG?: boolean; __otBaseLog?: string[] };
+          if (w.__OT_DETAIL_DEBUG) (w.__otBaseLog ||= []).push(`[tile] L${level} ${tx},${ty} ${rect.w}x${rect.h} d=${density.toFixed(3)} took ${Math.round(performance.now() - tReq)}ms`);
+        }
         if (myGen !== generation) { bitmap.close(); return undefined; } // superseded by resetAll
         cache.set(key, bitmap, w * h * 4);
         return bitmap;
@@ -223,7 +253,7 @@ export function createTileCompositor() {
    *  `level` is the cache-key id only; it need not index `levels`. */
   async function paintBaseAtLevel(canvas: HTMLCanvasElement, sheetKey: string, imgW: number, imgH: number, density: number, level: number, dark: boolean, myGen: number) {
     const { w: lw, h: lh } = levelDims(imgW, imgH, density);
-    const tiles = visibleTilesAtDensity(imgW, imgH, density, level, 0, 0, imgW, imgH);
+    const tiles = visibleTilesAtDensity(imgW, imgH, density, level, 0, 0, imgW, imgH, tileSizeOf(level));
     const back = document.createElement("canvas");
     back.width = lw; back.height = lh;
     const bctx = back.getContext("2d");
@@ -239,6 +269,26 @@ export function createTileCompositor() {
     visibleKeys.set(`${sheetKey}|base`, new Set(tiles.map((t) => modeKey(rawTileKey(sheetKey, level, t.tx, t.ty), dark))));
     canvas.width = lw; canvas.height = lh;
     canvas.getContext("2d")?.drawImage(back, 0, 0);
+    const fam = baseLayersBySheet.get(sheetKey) || [];
+    baseLayersBySheet.set(sheetKey, [...fam.filter((f) => f.level !== level), { level, density }]);
+  }
+
+  /** Index of the densest pyramid level that (a) is denser than the coarse
+   *  placeholder, (b) is under the budget density, (c) needs at most
+   *  BASE_MID_TILES tiles, and (d) is worth a separate pass — fewer than half
+   *  the budget composite's tiles. Undefined when no level qualifies. */
+  function midLevel(levels: number[], imgW: number, imgH: number, bd: number): number | undefined {
+    const count = (d: number) => { const g = tileGrid(imgW, imgH, d, BASE_TILE); return g.cols * g.rows; };
+    const budgetTiles = count(bd);
+    let best: number | undefined;
+    for (let i = 1; i < levels.length; i++) {
+      const d = levels[i];
+      if (d >= bd) break;
+      const n = count(d);
+      if (n > BASE_MID_TILES || n * 2 > budgetTiles) break;
+      best = i;
+    }
+    return best;
   }
 
   /** Two-phase whole-sheet base layer, painted once per sheet: an instant
@@ -248,21 +298,47 @@ export function createTileCompositor() {
   async function paintBase(canvas: HTMLCanvasElement, sheetKey: string, imgW: number, imgH: number, dark: boolean) {
     const levels = levelsFor(sheetKey, imgW, imgH);
     const myGen = generation;
-    await paintBaseAtLevel(canvas, sheetKey, imgW, imgH, levels[0], 0, dark, myGen);
+    const t0 = performance.now();
+    const dbg = (what: string, d: number) => {
+      const w = window as unknown as { __OT_DETAIL_DEBUG?: boolean; __otBaseLog?: string[] };
+      if (!w.__OT_DETAIL_DEBUG) return;
+      const line = `[base] ${sheetKey} ${what} density=${d.toFixed(3)} +${Math.round(performance.now() - t0)}ms`;
+      console.debug(line);
+      (w.__otBaseLog ||= []).push(line);
+    };
+    await paintBaseAtLevel(canvas, sheetKey, imgW, imgH, levels[0], BASE_COARSE_LEVEL, dark, myGen);
     if (myGen !== generation) return;
+    dbg("coarse", levels[0]);
     // Record the density the base is ACTUALLY showing, as each phase lands —
     // paintDetail's floor reads this, and promising phase 2's density while
     // phase 1's coarse pass is still on screen would suppress a crop that is
     // genuinely sharper than what the user is looking at, for the whole
     // duration of the phase-2 render.
     baseDensityBySheet.set(sheetKey, levels[0]);
+    const bd = fitDensity(imgW, imgH, BASE_TARGET_AREA);
+    // Phase 1.5 — a SCREEN-FIT stand-in. The coarse placeholder is ~768 px
+    // on its long edge; the budget composite is ~28MP, 100+ tiles, seconds
+    // on a 3-worker pool. Between them the user was looking at a smeared
+    // sheet at fit-to-view for the whole wait — the exact "is this even the
+    // right plan?" moment. This paints the densest pyramid level under
+    // BASE_MID_TILES BASE tiles (~3K px long edge: near-1:1 for a fit-to-view
+    // sheet on a 2× laptop) in a fraction of the time, and its tiles stay
+    // cached as placeholders for the pyramid. Skipped when the sheet is
+    // small enough that the budget composite IS quick.
+    const mid = midLevel(levels, imgW, imgH, bd);
+    if (mid !== undefined) {
+      await paintBaseAtLevel(canvas, sheetKey, imgW, imgH, levels[mid], BASE_MID_LEVEL, dark, myGen);
+      if (myGen !== generation) return;
+      baseDensityBySheet.set(sheetKey, levels[mid]);
+      dbg("screen-fit", levels[mid]);
+    }
     // Phase 2 at the EXACT budget density, not the nearest level under it —
     // see fitDensity for the 37%-of-budget shortfall that snapping caused.
-    const bd = fitDensity(imgW, imgH, BASE_TARGET_AREA);
-    if (bd > levels[0]) {
+    if (bd > (mid !== undefined ? levels[mid] : levels[0])) {
       await paintBaseAtLevel(canvas, sheetKey, imgW, imgH, bd, BASE_LEVEL, dark, myGen);
       if (myGen !== generation) return;
       baseDensityBySheet.set(sheetKey, bd);
+      dbg("budget", bd);
     }
   }
 
@@ -275,16 +351,15 @@ export function createTileCompositor() {
   function bestPlaceholder(sheetKey: string, levels: number[], target: number, x0: number, y0: number, x1: number, y1: number, dark: boolean): { level: number; density: number } {
     const dims = dimsBySheet.get(sheetKey)!;
     const cached = (level: number, density: number) => {
-      const tiles = visibleTilesAtDensity(dims.w, dims.h, density, level, x0, y0, x1, y1);
+      const tiles = visibleTilesAtDensity(dims.w, dims.h, density, level, x0, y0, x1, y1, tileSizeOf(level));
       return tiles.length > 0 && tiles.every((t) => cache.has(modeKey(rawTileKey(sheetKey, level, t.tx, t.ty), dark)));
     };
-    const baseDensity = baseDensityBySheet.get(sheetKey);
     const candidates: { level: number; density: number }[] = [];
     for (let l = target - 1; l >= 0; l--) candidates.push({ level: l, density: levels[l] });
-    if (baseDensity !== undefined && baseDensity < levels[target]) candidates.push({ level: BASE_LEVEL, density: baseDensity });
+    for (const f of baseLayersBySheet.get(sheetKey) || []) if (f.density < levels[target]) candidates.push(f);
     candidates.sort((a, b) => b.density - a.density); // densest stand-in first
     for (const c of candidates) if (cached(c.level, c.density)) return c;
-    return { level: 0, density: levels[0] }; // always fetched by paintBase — safe even if not yet cached (draws nothing, not a crash)
+    return { level: BASE_COARSE_LEVEL, density: levels[0] }; // always fetched by paintBase — safe even if not yet cached (draws nothing, not a crash)
   }
 
   /** Paints [x0,y0,x1,y1) (image px, margin already applied by the caller)
@@ -363,7 +438,7 @@ export function createTileCompositor() {
     if (!bctx) return { cancel() {} };
 
     const { level: placeholderLevel, density: phDensity } = bestPlaceholder(sheetKey, levels, pickLevel(levels, targetDensity), x0, y0, x1, y1, dark);
-    const phTiles = visibleTilesAtDensity(dims.w, dims.h, phDensity, placeholderLevel, x0, y0, x1, y1);
+    const phTiles = visibleTilesAtDensity(dims.w, dims.h, phDensity, placeholderLevel, x0, y0, x1, y1, tileSizeOf(placeholderLevel));
     for (const t of phTiles) {
       const bmp = cache.get(modeKey(rawTileKey(sheetKey, placeholderLevel, t.tx, t.ty), dark)) as ImageBitmap | undefined;
       if (!bmp) continue;

--- a/web/src/lib/tilePool.ts
+++ b/web/src/lib/tilePool.ts
@@ -38,9 +38,16 @@ type OutMsg =
 // and on an iPhone that 3× footprint is what got the workers jetsam-killed
 // (reported live 2026-08-15: "worker failed", planset stuck half-rendered).
 // Desktop pool sizing is unchanged.
+// Desktop: 3 workers was sized for a 4-core laptop. Every tile is a full
+// operator-list walk in pdf.js, so a ~28MP base composite (100+ tiles) on a
+// vector-heavy sheet is pool-bound — measured 6.5 s at 3 workers on an
+// 8+-core Mac with the cores idle. Machines with 8+ logical cores get 5
+// (leaving headroom for the main thread and the browser's own compositor);
+// smaller machines keep the old cores-1-capped-at-3 sizing.
+const CORES = typeof navigator !== "undefined" ? navigator.hardwareConcurrency || 4 : 4;
 const POOL_SIZE = LOW_MEMORY_DEVICE
   ? 1
-  : Math.max(1, Math.min(3, (typeof navigator !== "undefined" ? navigator.hardwareConcurrency : 4) - 1 || 2));
+  : CORES >= 8 ? 5 : Math.max(1, Math.min(3, CORES - 1));
 
 interface SheetOpenState {
   promise: Promise<void>;

--- a/web/src/lib/tiles.ts
+++ b/web/src/lib/tiles.ts
@@ -42,6 +42,15 @@ export const MAX_DENSITY = 4;
  *  real level's — the base is rendered at its own exact-fit density (see
  *  fitDensity), not at a power-of-two level. */
 export const BASE_LEVEL = -1;
+/** The two stand-ins paintBase shows BEFORE the budget composite lands — the
+ *  instant coarse pass and the optional screen-fit pass. Same negative-id
+ *  namespace as BASE_LEVEL: all three are whole-sheet rasters cut with the
+ *  BASE tile size (see tileCompositor's BASE_TILE), so their keys must never
+ *  collide with the 512-px pyramid tiles of the same density. */
+export const BASE_COARSE_LEVEL = -2;
+export const BASE_MID_LEVEL = -3;
+/** Every base-family level (whole-sheet, base tile size) has a negative id. */
+export const isBaseLevel = (level: number) => level < 0;
 
 /** The exact density whose full-sheet composite hits `targetArea` device px.
  *  The pyramid is power-of-two, so snapping a budget DOWN to a level wastes
@@ -83,9 +92,9 @@ export function levelDims(imgW: number, imgH: number, density: number) {
   return { w: Math.max(1, Math.ceil(imgW * density)), h: Math.max(1, Math.ceil(imgH * density)) };
 }
 
-export function tileGrid(imgW: number, imgH: number, density: number) {
+export function tileGrid(imgW: number, imgH: number, density: number, tile = TILE_SIZE) {
   const { w, h } = levelDims(imgW, imgH, density);
-  return { cols: Math.ceil(w / TILE_SIZE), rows: Math.ceil(h / TILE_SIZE), w, h };
+  return { cols: Math.ceil(w / tile), rows: Math.ceil(h / tile), w, h };
 }
 
 export function tileKey(sheetKey: string, level: number, tx: number, ty: number) {
@@ -93,9 +102,9 @@ export function tileKey(sheetKey: string, level: number, tx: number, ty: number)
 }
 
 /** Tile rect in LEVEL px (edge tiles are smaller than TILE_SIZE). */
-export function tileRect(level: number, tx: number, ty: number, levelW: number, levelH: number) {
-  const x = tx * TILE_SIZE, y = ty * TILE_SIZE;
-  return { x, y, w: Math.min(TILE_SIZE, levelW - x), h: Math.min(TILE_SIZE, levelH - y) };
+export function tileRect(level: number, tx: number, ty: number, levelW: number, levelH: number, tile = TILE_SIZE) {
+  const x = tx * tile, y = ty * tile;
+  return { x, y, w: Math.min(tile, levelW - x), h: Math.min(tile, levelH - y) };
 }
 
 export interface VisibleTile { level: number; tx: number; ty: number; x: number; y: number; w: number; h: number; }
@@ -111,10 +120,13 @@ export function visibleTiles(
 
 /** visibleTiles for a density that is NOT a pyramid level — the base layer's
  *  exact-fit density. `level` is carried through untouched purely as the id
- *  the caller will key the cache on (BASE_LEVEL for the base). */
+ *  the caller will key the cache on (BASE_LEVEL for the base). `tile` is the
+ *  tile edge — TILE_SIZE for the pyramid, the larger BASE tile for the
+ *  base family (every tile is a full operator-list walk in pdf.js, so a
+ *  whole-sheet composite wants as FEW tiles as memory allows). */
 export function visibleTilesAtDensity(
   imgW: number, imgH: number, density: number, level: number,
-  x0: number, y0: number, x1: number, y1: number,
+  x0: number, y0: number, x1: number, y1: number, tile = TILE_SIZE,
 ): VisibleTile[] {
   const { w: levelW, h: levelH } = levelDims(imgW, imgH, density);
   const lx0 = Math.max(0, Math.floor(x0 * density));
@@ -122,12 +134,12 @@ export function visibleTilesAtDensity(
   const lx1 = Math.min(levelW, Math.ceil(x1 * density));
   const ly1 = Math.min(levelH, Math.ceil(y1 * density));
   if (lx1 <= lx0 || ly1 <= ly0) return [];
-  const txMin = Math.floor(lx0 / TILE_SIZE), txMax = Math.floor((lx1 - 1) / TILE_SIZE);
-  const tyMin = Math.floor(ly0 / TILE_SIZE), tyMax = Math.floor((ly1 - 1) / TILE_SIZE);
+  const txMin = Math.floor(lx0 / tile), txMax = Math.floor((lx1 - 1) / tile);
+  const tyMin = Math.floor(ly0 / tile), tyMax = Math.floor((ly1 - 1) / tile);
   const out: VisibleTile[] = [];
   for (let ty = tyMin; ty <= tyMax; ty++) {
     for (let tx = txMin; tx <= txMax; tx++) {
-      const r = tileRect(level, tx, ty, levelW, levelH);
+      const r = tileRect(level, tx, ty, levelW, levelH, tile);
       out.push({ level, tx, ty, ...r });
     }
   }

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -19,6 +19,7 @@ import { Link, useNavigate } from "react-router";
 import * as pdfjsLib from "pdfjs-dist";
 import workerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 import { store, isStaleTabError, STALE_TAB_MESSAGE, projectIdFromUrl, ANN_SCHEMA, emptyAnnotations, metaGet, metaPut } from "../lib/store.js";
+import { forgetThumbs, releaseThumbs } from "../lib/thumbs.js";
 import { Z } from "../lib/ui.js";
 import { getFocusMode, toggleFocusMode, onFocusModeChange } from "../lib/focusMode.js";
 import { seedStampLibrary, instantiateStamp, markupToStampElement } from "../lib/stamps.js";
@@ -740,7 +741,7 @@ export default function TakeoffCanvas() {
   // its onOpenChange effect when the callback identity changes, so an inline
   // arrow here would re-count an open menu on every canvas render
   const onMenuDepth = useCallback((o) => { menuDepthRef.current = Math.max(0, menuDepthRef.current + (o ? 1 : -1)); }, []);
-  const thumbCacheRef = useRef(new Map()); // sheetKey → thumbnail dataURL — survives gallery close
+  const thumbCacheRef = useRef(new Map()); // sheetKey → thumbnail blob URL (lib/thumbs.js) — survives gallery close; persisted twin lives in the meta store
   const legacyPinnedRef = useRef(null);    // old `pinned` page numbers awaiting their one-shot tab migration
   const tabInitRef = useRef(false);        // snap to the first restored tab exactly once
   const statusRef = useRef("loading");     // mirror for the gallery's thumbnail worker
@@ -1228,6 +1229,8 @@ export default function TakeoffCanvas() {
     metaPut(pageCacheKey, next).catch(() => { /* cache only — rediscovered next open */ });
   }, [pageCacheKey]);
   const forgetPages = useCallback((names) => {
+    // a file whose bytes are leaving (or changing) takes its thumbnails with it
+    forgetThumbs(names, thumbCacheRef.current);
     const next = { ...knownPagesRef.current };
     let hit = false;
     for (const n of names) if (n in next) { delete next[n]; hit = true; }
@@ -2181,7 +2184,7 @@ export default function TakeoffCanvas() {
     }
     for (const n of names) { try { await store.removePdf(n); } catch { /* already gone */ } evictDoc(n); }
     forgetPages(names);
-    thumbCacheRef.current.clear();
+    releaseThumbs(thumbCacheRef.current);
     setGalleryLabels({});
     setDetectedScales({});
     reconcileAfterRemoval("", await refreshSheets());

--- a/web/test/tiles.test.ts
+++ b/web/test/tiles.test.ts
@@ -166,3 +166,16 @@ test("TileLRU protect provider shields the visible set when no explicit protect 
   assert.equal(lru.has("visible"), true, "provider-protected key survived");
   assert.equal(lru.has("offscreen"), false, "unprotected key was evicted instead");
 });
+
+test("visibleTilesAtDensity / tileGrid honor a larger BASE tile edge (fewer operator-list walks per composite)", () => {
+  const d = fitDensity(E_W, E_H, BASE_TARGET_AREA);
+  const small = visibleTilesAtDensity(E_W, E_H, d, BASE_LEVEL, 0, 0, E_W, E_H);
+  const big = visibleTilesAtDensity(E_W, E_H, d, BASE_LEVEL, 0, 0, E_W, E_H, 2048);
+  const g = tileGrid(E_W, E_H, d, 2048);
+  assert.equal(big.length, g.cols * g.rows);
+  assert.ok(big.length * 8 <= small.length, `expected ≥8× fewer tiles, got ${small.length} → ${big.length}`);
+  // every big tile is clipped to the level bounds and the set tiles the level exactly
+  const area = big.reduce((a, t) => a + t.w * t.h, 0);
+  assert.equal(area, g.w * g.h);
+  for (const t of big) assert.ok(t.w <= 2048 && t.h <= 2048 && t.x + t.w <= g.w && t.y + t.h <= g.h);
+});


### PR DESCRIPTION
## What
Rendering felt slow and soft in the plan preview — both the canvas after a sheet switch and the Sheets gallery. Two root causes, both measured live before fixing.

### Canvas: sheet switch → crisp
Every tile costs ~300 ms in the render worker **regardless of density** (pdf.js walks the whole operator list per render; the pixels are the cheap part). The whole-sheet base composite was cut into 77+ 512-px tiles, so a hatch-heavy finish plan took **6–8 s** to sharpen.

- Base-family rasters now use **2048-px tiles** (phones keep 512). Same sheet, same machine: coarse placeholder 0.28 s, **crisp base 1.0 s**.
- A screen-fit pass sits between coarse and budget for very large sheets; base-family layers live in their own negative-id key namespace and all serve as placeholders for detail crops (verified sharp at 195%).
- Desktop pool grows to 5 workers on 8+-core machines.
- Perf log gated behind `window.__OT_DETAIL_DEBUG` (console + `window.__otBaseLog`).

### Gallery: crisp, fast, remembered
- Thumbnails raster at `THUMB_W × devicePixelRatio` (cap 2×) — a 380-px raster was being stretched to 760 device px on every laptop. Async `toBlob` WebP (PNG fallback) replaces sync `toDataURL` JPEG; 2 in flight; one React render per frame.
- **Persisted** to the meta store with the sheet number + plan-noted scale, so reopening a gallery draws every card without loading a pdf.js document. `forgetPages` (close / remove / revise-by-redrop / clear / restore) evicts a file's thumbs. Bump `THUMB_VERSION` to invalidate.
- **Bug fix:** cards commit their `ref` callbacks before the mount effect creates the `IntersectionObserver`, so a gallery whose page counts were all cached (#302 reopen path) never observed a card — skeletons forever. A sweep effect now hands the observer every unobserved card.
- Shape tallies memoized.

## Verified
- `npm run check` green (1544 tests; new test for base tile enumeration).
- Live in the running app: base-phase timings above; zoom to 195% renders a sharp detail crop over the big-tile placeholder.
- Gallery driven in a throwaway headless Chrome at dpr 2 with three real plan sets (45 sheets): all 45 thumbnails render and persist, 761×507 rasters in 276×184 cards, sheet numbers + scales on every card, reopen draws from IndexedDB with zero pdf.js loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)