### PR TITLE
README: give the fork a job — own instance + contributor path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ what makes it training data.
 [![OpenArena](https://openarena.to/api/badge/cmsgykvsq0000mkuv7byhlgnl)](https://openarena.to/en/projects/cmsgykvsq0000mkuv7byhlgnl)
 [![Sponsor](https://img.shields.io/github/sponsors/Kentucky-ai?logo=githubsponsors&label=sponsor&color=EA4AAA)](https://github.com/sponsors/Kentucky-ai)
 
-[**For agents**](#for-agents--start-here) · [**Try the canvas**](https://opentakeoff.kentucky-ai.com) · [The engine's contract](#the-contract-that-makes-it-drivable) · [For the person at the canvas](#for-the-person-at-the-canvas) · [The data layer](#the-data-layer--why-this-engine-exists) · [Research](#the-research-program) · [Build on it](#build-on-top-of-it) · [Contribute](#contributing)
+[**For agents**](#for-agents--start-here) · [**Try the canvas**](https://opentakeoff.kentucky-ai.com) · [The engine's contract](#the-contract-that-makes-it-drivable) · [For the person at the canvas](#for-the-person-at-the-canvas) · [The data layer](#the-data-layer--why-this-engine-exists) · [Research](#the-research-program) · [Fork it](#fork-it) · [Contribute](#contributing)
 
 **The two manuals:** [agent manual](docs/AGENT_GUIDE.md) · [user manual](docs/USER_GUIDE.md)
 
@@ -40,7 +40,8 @@ what makes it training data.
 |---|---|
 | **An estimator with a bid due** | [Open the canvas](https://opentakeoff.kentucky-ai.com)—drag in a plan, no account, nothing uploads. The [**user manual**](docs/USER_GUIDE.md) gets you from a blank tab to an exported takeoff in five minutes, and its [working order](docs/USER_GUIDE.md#the-working-order-on-a-real-bid) is the sequence to run on a real bid set. |
 | **An AI agent**—or the person wiring one up | `npx -y opentakeoff-mcp`, then the [**agent manual**](docs/AGENT_GUIDE.md): the operating model, the standard finish every takeoff ends with, what the engine refuses to guess, and why. Tool-by-tool reference is [`mcp/README.md`](mcp/README.md). |
-| **A developer building on the engine** | [`AGENTS.md`](AGENTS.md) is the repo map and the ship discipline; [`FEATURES.md`](FEATURES.md) maps every capability to the code that does it. Apache-2.0—fork it. |
+| **A developer building on the engine** | [`AGENTS.md`](AGENTS.md) is the repo map and the ship discipline; [`FEATURES.md`](FEATURES.md) maps every capability to the code that does it. |
+| **A crew that wants its own copy** | [**Fork it**](#fork-it)—your own instance on your own URL in a few minutes, Apache-2.0, nothing phones home. Same path if you're going to send a pull request. |
 
 ### Windows, macOS, Linux — all of it
 
@@ -146,6 +147,11 @@ Point any stdio MCP client at the published package. Node 20+, no clone, no buil
   }
 }
 ```
+
+If you carry a GitHub identity, [fork the repository](https://github.com/Kentucky-ai/opentakeoff/fork)
+as well: that's where an engine change you make gets tested—every pull request from a fork runs the
+full CI with a read-only token—and tested pull requests from agents merge under the same bar as
+anyone else's. The [contributor path](#fork-it) is the same one.
 
 Claude Code: `claude mcp add opentakeoff -- npx -y opentakeoff-mcp`. Claude Desktop users can
 double-click the `opentakeoff-mcp.mcpb` bundle from the
@@ -589,9 +595,22 @@ static files. Running your own reverse proxy—nginx, Docker, Tailscale? Check
 knowing about. Deployment notes and the optional AI backend:
 [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md).
 
-## Build on top of it
+## Fork it
 
 Apache-2.0: fork it, change it, ship it—for your own crew or as the base of your own product.
+A fork is the unit of ownership here, and it's the unit of contribution: the same three steps
+give you a private instance and a branch to send back.
+
+1. **[Fork on GitHub](https://github.com/Kentucky-ai/opentakeoff/fork)**, then clone your fork.
+2. **Run it:** `cd web && npm ci && npm run dev` — the canvas is at `localhost:5173`, and
+   `npm run check` is the exact CI gate (typecheck, lint, test, build).
+3. **Put it on your own URL:** the repo carries its [`netlify.toml`](netlify.toml) (base `web`,
+   publish `dist`), so importing your fork into Netlify deploys with no settings; any static host
+   works, and [`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md) names the one nginx gotcha. Your
+   instance keeps every plan local exactly as the public one does.
+
+Pull requests from a fork run the full CI with no secrets and a read-only token
+([`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md)), so a green check on your fork is a green check here.
 The codebase is deliberately small and readable, and the geometry libraries are pure so you can
 lift them straight out:
 
@@ -690,5 +709,5 @@ instrument producing it.
 
 ## License
 
-[Apache License 2.0](LICENSE)—use it, fork it, ship it, build on top of it. See
+[Apache License 2.0](LICENSE)—use it, [fork it](#fork-it), ship it, build on top of it. See
 [NOTICE](NOTICE) for attribution.

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -7,7 +7,7 @@ OpenTakeoff is an open-source alternative to subscription takeoff software — a
 ## Docs
 
 - [Live app](https://opentakeoff.kentucky-ai.com): try it in the browser — includes a one-click sample plan (a real medical-center floor finish plan)
-- [README](https://github.com/Kentucky-ai/opentakeoff#readme): features, quick start, deploy-it-yourself, build-on-top-of-it
+- [README](https://github.com/Kentucky-ai/opentakeoff#readme): features, quick start, and [Fork it](https://github.com/Kentucky-ai/opentakeoff#fork-it) — your own instance on your own URL, and the contributor path
 - [MCP server](https://github.com/Kentucky-ai/opentakeoff/blob/main/mcp/README.md): `npx -y opentakeoff-mcp` on the [npm registry](https://www.npmjs.com/package/opentakeoff-mcp) — `load_plan`, `read_sheet_text`, `set_scale`, `one_click`, `view_sheet`, `takeoff_summary`, `export_takeoff`, and more
 - [Agent usage guide + example transcript](https://github.com/Kentucky-ai/opentakeoff/blob/main/docs/MCP.md): how an agent opens a plan, adopts the scale, traces rooms, and exports a takeoff over MCP
 - [User guide & shortcuts](https://github.com/Kentucky-ai/opentakeoff/blob/main/docs/USER_GUIDE.md): every tool, keyboard shortcut, and the totals math
@@ -17,7 +17,7 @@ OpenTakeoff is an open-source alternative to subscription takeoff software — a
 ## Key facts
 
 - **Agent-native**: the same engine answers to a person at the canvas or an AI agent over MCP — not two implementations, one. Every shape records its provenance: scale, one-click or hand-drawn, and person or agent.
-- **MCP server**: `opentakeoff-mcp` on npm, official MCP registry listing, 11 tools — an agent loads a plan, reads the title block, adopts the scale (never applied silently), one-clicks rooms, and exports the same payload the app autosaves.
+- **MCP server**: `opentakeoff-mcp` on npm, official MCP registry listing, 40 tools — an agent loads a plan, reads the title block, adopts the scale (never applied silently), one-clicks rooms, and exports the same payload the app autosaves.
 - Measuring: One-Click Area (flood-fill room detection from PDF vectors), Area, Rectangle, Linear, Surface-Area (walls), Count, Deduct
 - Drawing aids: 45°/90° angle lock (polar tracking with ⇧ hard-lock, commits the on-axis point), live angle + segment-length readout at the cursor, endpoint snap
 - Scale: auto-detects the drawn scale note per sheet, or calibrate from a known dimension
@@ -26,5 +26,5 @@ OpenTakeoff is an open-source alternative to subscription takeoff software — a
 - Reports: per-condition SF/SY/LF/EA with and without waste + a materials buy list; CSV/JSON export
 - Storage: IndexedDB + localStorage only — client-side, private by construction
 - Stack: React 18 + Vite + pdf.js; the whole app is a static build
-- License: Apache-2.0 — fork it, ship it, build a product on it
+- License: Apache-2.0 — [fork it](https://github.com/Kentucky-ai/opentakeoff/fork), ship it, build a product on it. Pull requests from a fork run the full CI; tested PRs from agents merge under the same bar as anyone's
 - Maintained by Kentucky AI (applied AI R&D, Louisville, KY): https://kentucky-ai.com


### PR DESCRIPTION
The README said *fork it* three times and never said why or how. This gives the fork a purpose in three places, in the existing voice, with no recruiting language:

- **Start here** gains a row: *a crew that wants its own copy* → own instance on own URL.
- **Build on top of it** → **Fork it**: fork, `npm ci && npm run dev`, deploy from the repo's `netlify.toml`; fork PRs run full CI read-only, so green there is green here.
- **For agents**: an agent carrying a GitHub identity is told what a fork is for (tested PRs from agents merge under the same bar).

`node scripts/check-doc-links.mjs` passes (19 files). No translated README touched — they lag by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)