### PR TITLE
Readout: a MEASUREMENTS tally under the condition total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-26 — the readout keeps a tape log
+
+### Added
+- **MEASUREMENTS under the condition total.** The live readout now lists every linear run and wall of the active condition, numbered in draw order: a run as its length (`01 47.2 LF linear`), a wall as the tape math (`03 39.1 LF × 8 ft = 313.1 SF`), per-wall height winning over the condition height. The lines sum to the totals above them, so a wall-tile figure is checked line by line without opening the panel; metric converts each line. Pure tally in `lib/measurementBreakdown.js` (tested), reading stored shape metrics — nothing is re-measured. Prompted by a downstream fork's spec (replicant026/fork-opentakeoff, PR #341); implemented here independently.
+
 ## 2026-08-24 — the takeoff goes back into CAD
 
 ### Added

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -457,6 +457,8 @@ The **Snap** toggle pulls your cursor onto true PDF endpoints—real corners ext
 
 The top-right readout tracks the armed tool: totals for the tracing tools, `W × H · SF · SY` for Rectangle, wall SF at the condition height for Surface Area, and running One-Click selection totals. Any run or side that reaches **12′ turns the chip amber**—the roll-width warning rides every tool that measures a length.
 
+Under the condition total sits **MEASUREMENTS**—a numbered tally, in draw order, of every linear run and wall on the active condition across the open sheets. A linear run reads its length (`01 47.2 LF linear`); a wall reads the tape math (`03 39.1 LF × 8 ft = 313.1 SF`), using that wall's own height where one is set and the condition height otherwise. The lines add up to the totals above them, so a wall-tile number can be checked line by line without opening the panel. Metric reports convert each line (`11.9 m × 2.44 m = 29.1 m²`). Floor areas and counts are not listed—their check is the shape itself.
+
 ---
 
 ## 6. One-Click Area

--- a/docs/design/READOUT_TALLY.md
+++ b/docs/design/READOUT_TALLY.md
@@ -1,0 +1,33 @@
+# Readout tally — MEASUREMENTS under the condition total
+
+**Date:** 2026-08-26 · **Status:** shipped
+
+## Why
+An estimator builds a total by tallying lines, then checks the total by re-reading the lines. The readout card showed only the sum; checking a wall-tile SF meant selecting each wall in turn or opening the Takeoffs panel. The card is where the eye already is while tracing.
+
+## What
+Under the `<TAG> TOTAL` block, when the active condition has any linear or wall shapes on the visible sheets:
+
+```
+MEASUREMENTS
+01 47.2 LF linear
+02 27.4 LF linear
+03 39.1 LF × 8 ft = 313.1 SF
+```
+
+- Draw order (array order of committed shapes), numbered from 01.
+- `linear` rows: `perimeter_lf` as stored.
+- `surface_area` rows: `LF × H = SF`. Height rule = the readout's own selected-shape rule: `height_override === true` → the shape's height; else shape height, else condition height. SF is the stored `area_sf` (falls back to `LF × H` only when a shape carries no stored area).
+- Floor areas, deducts and counts are not listed — a ring is checked by looking at it.
+- Units go through the same `fl` / `fa` / `heightVal` edges as the rest of the card, so metric converts per line.
+
+## Where
+- `web/src/lib/measurementBreakdown.js` — pure `measurementBreakdown(shapes, conditionId, cond)` + `wallHeightFt`. No React, no DOM.
+- `web/test/measurementBreakdown.test.ts` — 5 tests: order/numbering, role filter, height precedence, SF fallback, null safety.
+- `web/src/pages/TakeoffCanvas.jsx` — one `useMemo` over `visibleShapes` + the JSX block above the card footer. Mono tabular numerals (`--f-mono`), `nowrap` rows.
+
+## Verified live
+Sample plan AF101 at 1/8" = 1'-0", CPT-1 H=8: two Linear runs + one Surface wall → `74.6 LF` and `313.1 SF wall` totals equal the three listed lines; `ft`→`m` toggle re-reads as `11.9 m × 2.44 m = 29.1 m²`.
+
+## Provenance
+Idea and line format from a downstream fork's spec (replicant026/fork-opentakeoff, seen in mis-targeted PR #341, closed by its author). Implemented independently — no code taken.

--- a/web/src/lib/measurementBreakdown.js
+++ b/web/src/lib/measurementBreakdown.js
@@ -1,0 +1,28 @@
+// Readout-card tally: every linear run and wall of ONE condition, in draw
+// order, so an estimator checks a total the way they build one — line by
+// line — without opening the panel. Pure: reads committed shapes (their
+// stored `computed` metrics), never re-measures.
+//
+// Height rule matches the readout's own selected-shape reading: an explicit
+// per-wall override wins, then the shape's own height, then the condition's.
+
+export function wallHeightFt(shape, cond) {
+  if (shape?.height_override === true) return Number(shape.height_ft) || 0;
+  return Number(shape?.height_ft) || Number(cond?.height_ft) || 0;
+}
+
+/** @returns {{n:number, id:string, role:"linear"|"wall", lf:number, h:number, sf:number}[]} */
+export function measurementBreakdown(shapes, conditionId, cond) {
+  const rows = [];
+  for (const s of shapes || []) {
+    if (!s || s.condition_id !== conditionId) continue;
+    const c = s.computed || {};
+    if (s.measure_role === "linear") {
+      rows.push({ n: rows.length + 1, id: s.id, role: "linear", lf: c.perimeter_lf || 0, h: 0, sf: 0 });
+    } else if (s.measure_role === "surface_area") {
+      const lf = c.perimeter_lf || 0, h = wallHeightFt(s, cond);
+      rows.push({ n: rows.length + 1, id: s.id, role: "wall", lf, h, sf: c.area_sf ?? lf * h });
+    }
+  }
+  return rows;
+}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -77,6 +77,7 @@ import { buildLayerInfos, effectiveLayerRoles, layerRoleCodes, segRoles, sanitiz
 import { detectCandidateRule, buildRuleFromSeed, applyRuleToProject } from "../lib/rules";
 import { deriveTransitionRuns, transitionRefusal } from "../lib/transitions";
 import { conditionTotals, verticalWallSf, downloadText } from "../lib/totals.js";
+import { measurementBreakdown } from "../lib/measurementBreakdown.js";
 import { shapesInZone } from "../lib/zone.js";
 import { sanitizeSheetLevels } from "../lib/sheetLevels.js";
 import { sanitizeConditionColumns, sanitizeConditionAttrs, renameColumnValue, columnLabel } from "../lib/conditionColumns.js";
@@ -6640,6 +6641,9 @@ export default function TakeoffCanvas() {
   // display-only derived metric: floor-area perimeters × the condition height
   const condH = Number(aCond?.height_ft) || 0; // the live-readout JSX below still reads this
   const vertTotal = verticalWallSf(visibleShapes, activeCond, aCond?.height_ft, condMult);
+  // the tally under the total: every linear run and wall of the active
+  // condition on the visible sheets, in draw order (lib/measurementBreakdown)
+  const tally = useMemo(() => measurementBreakdown(visibleShapes, activeCond, aCond), [visibleShapes, activeCond, aCond]);
   const num = (v, d = 1) => v.toLocaleString(undefined, { maximumFractionDigits: d });
   // unit-system display edge: internal math is always feet (lib/units.ts)
   const fa = (sf, d = 1) => `${num(areaVal(sf, units), d)} ${areaUnit(units)}`;
@@ -8799,6 +8803,24 @@ export default function TakeoffCanvas() {
           {countTotal > 0 && <div style={{ fontSize: 15, fontWeight: 700, marginTop: 2 }}>{num(countTotal, 0)} <span style={{ fontSize: 12, fontWeight: 600 }}>EA</span></div>}
           {vertTotal > 0 && <div style={{ fontSize: 11.5, color: "var(--ink-muted)", marginTop: 2 }} title="Display only — floor-area perimeters × this condition's height (not committed)">{fa(vertTotal)} vert (perim × H)</div>}
           {condTotal === 0 && lfTotal === 0 && countTotal === 0 && wallTotal === 0 && borderTotal === 0 && <div style={{ fontSize: 12.5, color: "var(--ink-muted)", marginTop: 2 }}>—</div>}
+          {tally.length > 0 && (
+            <>
+              <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.4, opacity: 0.5, marginTop: 8 }}>Measurements</div>
+              <div style={{ fontFamily: "var(--f-mono)", fontSize: 11.5, lineHeight: 1.5, marginTop: 2 }}>
+                {tally.map((r) => (
+                  <div key={r.id} style={{ display: "flex", gap: 6, whiteSpace: "nowrap" }}>
+                    <span style={{ opacity: 0.45 }}>{String(r.n).padStart(2, "0")}</span>
+                    <span>
+                      {fl(r.lf)}
+                      {r.role === "wall"
+                        ? <> × {num(heightVal(r.h, units), 2)} {heightUnit(units)} = {fa(r.sf)}</>
+                        : <span style={{ color: "var(--ink-muted)" }}> linear</span>}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
           <div style={{ fontSize: 10.5, opacity: 0.45, marginTop: 6 }}>{visibleShapes.length} shapes on {groupKeys.length > 1 ? `${groupKeys.length} sheets` : "sheet"} · zoom {(tf.scale * 100).toFixed(0)}%</div>
         </div>
 

--- a/web/test/measurementBreakdown.test.ts
+++ b/web/test/measurementBreakdown.test.ts
@@ -1,0 +1,39 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { measurementBreakdown, wallHeightFt } from "../src/lib/measurementBreakdown.js";
+
+const lin = (id: string, cid: string, lf: number) => ({ id, condition_id: cid, measure_role: "linear", computed: { perimeter_lf: lf } });
+const wall = (id: string, cid: string, lf: number, extra: any = {}) => ({ id, condition_id: cid, measure_role: "surface_area", computed: { perimeter_lf: lf, area_sf: lf * (extra.height_ft ?? 8) }, ...extra });
+const floor = (id: string, cid: string) => ({ id, condition_id: cid, measure_role: "floor_area", computed: { area_sf: 100, perimeter_lf: 40 } });
+const cond = { id: "c1", height_ft: 8 };
+
+test("breakdown lists linear + wall rows of one condition in draw order, numbered from 1", () => {
+  const rows = measurementBreakdown([lin("a", "c1", 45.4), floor("f", "c1"), wall("b", "c1", 41.4), lin("z", "c2", 9)], "c1", cond);
+  assert.deepEqual(rows.map((r) => [r.n, r.id, r.role]), [[1, "a", "linear"], [2, "b", "wall"]]);
+  assert.equal(rows[0].lf, 45.4);
+  assert.equal(rows[1].lf, 41.4);
+  assert.equal(rows[1].h, 8);
+  assert.equal(rows[1].sf, 41.4 * 8);
+});
+
+test("floor areas, counts and other conditions never appear", () => {
+  assert.deepEqual(measurementBreakdown([floor("f", "c1"), { id: "k", condition_id: "c1", measure_role: "count", computed: { count: 3 } }], "c1", cond), []);
+  assert.deepEqual(measurementBreakdown([lin("a", "c2", 5)], "c1", cond), []);
+});
+
+test("wall height: explicit override wins, then shape height, then condition height", () => {
+  assert.equal(wallHeightFt({ height_override: true, height_ft: 4 }, cond), 4);
+  assert.equal(wallHeightFt({ height_ft: 10 }, cond), 10);
+  assert.equal(wallHeightFt({}, cond), 8);
+  assert.equal(wallHeightFt({}, {}), 0);
+});
+
+test("a wall without stored area falls back to LF × H", () => {
+  const w = { id: "w", condition_id: "c1", measure_role: "surface_area", computed: { perimeter_lf: 10 } };
+  assert.equal(measurementBreakdown([w], "c1", cond)[0].sf, 80);
+});
+
+test("empty and null input are safe", () => {
+  assert.deepEqual(measurementBreakdown([], "c1", cond), []);
+  assert.deepEqual(measurementBreakdown(null as any, "c1", cond), []);
+});


### PR DESCRIPTION
## What
The live readout lists every linear run and wall of the active condition, numbered in draw order, under the condition total:

```
MEASUREMENTS
01 47.2 LF linear
02 27.4 LF linear
03 39.1 LF × 8 ft = 313.1 SF
```

A run reads its length; a wall reads the tape math, per-wall height winning over the condition height. The lines sum to the totals above them, so a wall-tile figure is checked line by line without opening the panel. Metric converts each line (`11.9 m × 2.44 m = 29.1 m²`). Floor areas and counts are not listed — a ring is checked by looking at it.

## How
- `web/src/lib/measurementBreakdown.js` — pure tally reading stored shape metrics; nothing re-measured. No React, no DOM.
- `web/test/measurementBreakdown.test.ts` — order/numbering, role filter, height precedence, SF fallback, null safety.
- `TakeoffCanvas.jsx` — one `useMemo` over `visibleShapes` + one JSX block above the card footer.
- Design doc `docs/design/READOUT_TALLY.md`; USER_GUIDE §5; CHANGELOG 2026-08-26.

## Verified live
Sample plan AF101 @ 1/8" = 1'-0", CPT-1 H=8: two Linear runs + one Surface wall → `74.6 LF` and `313.1 SF wall` totals equal the three listed lines; `ft`→`m` re-reads per line. `npm run check` green (1589 tests).

## Provenance
Idea and line format from a downstream fork's spec (replicant026/fork-opentakeoff, seen in #341). Implemented independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)