### PR TITLE
Image annotations: capture or upload a picture, place it across sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 ### Fixed
 - **A rectangular deduct drew in the drafting tool's ink instead of its own danger red.** The ring-tool deduct (drag a polygon) has always flipped to `#b03a26` red for a cut; the deduct-**rect** marquee shared the same preview ref as the plain rect/symbol tools and fell through to the accent color instead — a deduct rectangle drew exactly like a positive one while you were still drawing it. Found and fixed while wiring that shared rect preview to the new drawing-style tokens.
 
+## 2026-08-25 — an image is a markup now
+
+### Added
+- **Image markups — a picture on the sheet, two ways.** A new **🖼 Image** tool in the Markup menu, plus **Upload image…** in the Markups panel. Marquee a region of the plan and it drops back as a floating screenshot you can park anywhere; or upload a PNG/JPEG (a spec-sheet clip, a site photo) onto the sheet. Both move, resize from the corner (aspect locked), link to a condition or an RFI, persist to the browser, ride the JSON export/import round-trip, and burn into the Marked Set PDF — rotated source sheets included — like every other markup, a separate layer the totals never count. Images are stored inline and capped: each is downscaled to 1600 px on its longest side, oversized files are refused before they can exhaust memory, and an SVG upload is rejected in favor of pixels only (a raster re-encode, so nothing scriptable rides in).
+
 ## 2026-08-24 — the drawing overlay stays crisp through a zoom
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -386,8 +386,9 @@ live takeoff first, so it's never a one-way door.
 
 ### Markups, seals, and RFIs
 A separate layer the totals never count: revision clouds, callouts, text notes, highlighter
-ink, and reusable **stamps** (plank direction, seam direction, pattern origin—build your own,
-or import an `.svg`). **Approval seals** are the estimator's ink: click a committed takeoff to
+ink, **images** (upload a PNG/JPEG, or marquee a region of the plan to drop it back as a
+floating screenshot—move, resize, and it burns into the marked set), and reusable **stamps**
+(plank direction, seam direction, pattern origin—build your own, or import an `.svg`). **Approval seals** are the estimator's ink: click a committed takeoff to
 approve it, and the Marked Set's cover gains a tally line—*N estimator-approved · N
 agent-marked* — so a PM knows exactly how much of the set a person has looked at. The **RFI
 register** turns any markup into a tracked question with status, priority, ball-in-court, and
@@ -474,7 +475,7 @@ plus a vision-capable model id.
 | **Report** | Per-condition Floor/Wall/Border SF, LF, EA, SY with and without waste, plus the combined buy list; columns, grouping, saved templates |
 | **Export** | CSV, JSON, **Excel (.xlsx)**, print, **Marked Set PDF**, RFI CSV/JSON |
 | **Revisions** | Save at each bid revision, compare quantity deltas per condition/sheet/buy list, guarded restore |
-| **Markups** | Clouds, callouts, notes, highlighter, stamps, **approval seals**, RFI register—separate layer, never counted |
+| **Markups** | Clouds, callouts, notes, highlighter, **images** (upload or marquee screenshot), stamps, **approval seals**, RFI register—separate layer, never counted |
 | **Voice** | Push-to-talk takeoff commands, recognized on-device in WebAssembly; audio never leaves the browser |
 | **View** | Light or **dark (negative print)**—sheet pixels inverted at draw time, exports follow |
 | **Storage** | IndexedDB + localStorage—client-only, nothing uploaded |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -572,11 +572,11 @@ One more distinction: **Undo last shape** (Edit menu) and `⌫`-with-nothing-in-
 
 ## 9. Markups, stamps, and RFIs
 
-The markup layer is communication, never quantity: clouds, callouts, notes, highlighter ink, and stamps live on a separate layer the totals never count. The left dock (rail buttons on the canvas's right edge) carries three tabs—**Markups**, **Stamps**, **RFIs**.
+The markup layer is communication, never quantity: clouds, callouts, notes, highlighter ink, images, and stamps live on a separate layer the totals never count. The left dock (rail buttons on the canvas's right edge) carries three tabs—**Markups**, **Stamps**, **RFIs**.
 
 ### The markup tools
 
-The **Markup** menu holds six tools:
+The **Markup** menu holds seven tools:
 
 - **Highlighter** (`H`)—freehand marker ink. Press and **drag to paint**, stroke after stroke, no dialog between them. While it's armed, a style popover hangs under the menu: five inks (yellow default), **F / M / B** tip sizes, and a **chisel or round** nib—remembered per browser. Because press-drag paints, press-drag panning is off while the highlighter is armed; pan with `Space`-drag, middle-drag, or right-drag. Strokes stick to their sheet, scale like real ink, and are real objects: with Select, click one (it glows), drag to move it, `⌫` deletes it.
 - **Revision cloud**—two corner clicks; the cloud lands immediately, then an optional note editor opens (`Esc` keeps the cloud, skips the note). Clouds can carry a **Rev △** revision number from the panel.
@@ -584,8 +584,9 @@ The **Markup** menu holds six tools:
 - **Text note**—one click, type in place. Empty text doesn't commit.
 - **Highlight box**—two corners, done.
 - **Dimension line** (`N`)—a standalone dimension string for the width or height the plan never printed: click one end, a live length chip follows the cursor, click the other end. It lands as a line with end ticks labeled with the measured length at the sheet's scale (`12'-6"`), tied to nothing—no condition, no quantity, only the sheet's scale. It needs that scale set (the first click refuses otherwise, same as the measure tools) and won't span sheets. Double-click it to add a note after the length; it prints on the Marked Set like any markup.
+- **Image**—a picture on the sheet, two ways. Arm the tool and **marquee a region** of the plan (two corner clicks) to capture it as a floating screenshot; or click **Upload image…** in the Markups panel to place a **PNG or JPEG** from your machine (a spec-sheet clip, a site photo). Either way it lands centered, and with Select you **drag to move it** and **drag the bottom-right handle to resize** (the proportions stay locked). Images downscale to a sensible size on the way in, so a huge file won't bloat your project; an SVG isn't accepted (only pixels). Images burn into the Marked Set PDF like any markup, rotated sheets included.
 
-Every markup is editable after the fact: with Select, click to select it, drag to move it, **double-click to edit its text in place**. The Markups panel lists them all with an edit pencil, a **color** row (auto or any palette color), **line style** and **weight** controls, and a **Hide layer / Show layer** toggle for the whole layer. (Markup moves are plain edits, not undo steps—the `⌘Z` stack is for measured shapes.)
+Every markup is editable after the fact: with Select, click to select it, drag to move it, **double-click to edit its text in place** (an image carries no text—it's select-only). The Markups panel lists them all with an edit pencil, a **color** row (auto or any palette color), **line style** and **weight** controls, and a **Hide layer / Show layer** toggle for the whole layer. (Markup moves are plain edits, not undo steps—the `⌘Z` stack is for measured shapes.) A large image sits over what it covers—much like a highlight box—so if you can't click a shape beneath one, move the image aside. Images travel **with** the takeoff: they save to your browser, ride the JSON export/import, and sync to your team folder along with the rest of the annotations.
 
 ### Stamps
 

--- a/docs/plans/image-annotation-plan.md
+++ b/docs/plans/image-annotation-plan.md
@@ -1,0 +1,358 @@
+# Plan — Image annotation markup (upload + marquee screenshot)
+
+> Revised after four parallel adversarial plan reviews (correctness, regression,
+> test-design, security/edge). Every finding is folded into the body below; the
+> "Review findings → resolution" table at the end is the audit trail.
+
+## Problem
+
+The markup layer (a separate layer the takeoff totals never count) supports
+`cloud`, `callout`, `text`, `highlight` (box + freehand), `dimension`, plus
+`arrow`/`bubble`/`svg` (via stamps and SVG import). There is **no way to place a
+raster image** on a sheet. Estimators want to drop:
+
+- an **uploaded image** — a photo, a spec-sheet clip, a detail from another
+  document — onto the sheet as an annotation; and
+- a **marquee screenshot** — rubber-band a rectangle over the current sheet and
+  capture that region of the rendered plan as a floating image.
+
+Both should render on the canvas, move/resize, persist, round-trip through
+export/import, and burn into the Marked Set PDF — like every other markup.
+
+## Design
+
+Add a markup type **`image`**, modeled on the `svg` markup (`at` center + a
+width fraction + a fixed aspect, sized off sheet width, placed centered on `at`).
+
+### Record shape
+
+```js
+{
+  // common fields minted by addMarkup():
+  id, type: "image", sheet_id, created_at, rfi_id: "", condition_id,
+  at: [nx, ny],     // CENTER, normalized to the panel image (0..1)
+  w: number,        // width as a fraction of sheet WIDTH (like svg m.w)
+  aspect: number,   // natural height / width (> 0)
+  src: string,      // data URL — ALWAYS "data:image/png;base64,…" or "data:image/jpeg;…"
+  source: "capture" | "upload",   // provenance (audit trail)
+}
+```
+
+No `color`/`line_style`/`weight` — an image renders as-is. Selection halo and the
+RFI/condition-link badges still apply (shared render helpers).
+
+### Storage decision — inline data URL, hard-capped, NOT a separate store
+
+Inline `src` on the record (not a side IndexedDB store). Verified reasons:
+
+- **Round-trip is free.** `importTakeoff.js:143-144,170` passes markups through
+  wholesale; `buildPayload` (`TakeoffCanvas.jsx:2060`) serializes them wholesale.
+  An inline `src` survives `export_takeoff` → `import_takeoff` unchanged. A side
+  store would vanish on JSON export/import and across devices.
+- **Cloud sync is free.** Annotations sync as one blob; a side store needs its own
+  channel or images disappear across devices.
+- **Render/move/delete are synchronous.** `<image href={src}>` needs no async
+  resolve.
+- **Privacy holds.** `contribute.js` whitelists derived shape data only and never
+  includes markups (`contribute.js:8`) — a screenshot can't leak into the
+  training-contribution payload.
+
+The cost — the `annotations` blob re-saves (debounced, `TakeoffCanvas.jsx:2288`)
+on every markup/shape edit, and re-uploads to Drive on the sync path — is bounded
+**three ways**, all mandatory (reviews flagged the single 1600px cap as
+insufficient):
+
+1. **Per-image pixel cap.** Every stored image is downscaled to
+   `MARKUP_IMG_MAX = 1600` px longest side and re-encoded through a canvas
+   (capture AND upload). ~0.1–0.6 MB each.
+2. **Decode-area guard (pixel bomb).** Reject/limit an upload whose *decoded*
+   dimensions exceed a `MAX_CANVAS_AREA`-style ceiling **before** it is drawn — a
+   small file can declare 30000×30000 and OOM the tab at decode. Use
+   `createImageBitmap(file, { resizeWidth, resizeQuality, imageOrientation })` so
+   the decode itself allocates at the capped size.
+3. **Aggregate budget.** Refuse a new image (with a message) when the project's
+   total image-markup bytes would exceed `MAX_IMAGE_MARKUP_BYTES` (≈16 MB) — N
+   capped images otherwise defeat the per-image cap and push the blob past quota.
+
+And the quota failure that inline images first make reachable is no longer
+silent: the autosave catch (`TakeoffCanvas.jsx:2278-2281`) currently surfaces
+only stale-tab errors, dropping `QuotaExceededError` to `"idle"` with no message —
+so a too-big blob silently fails to persist *the entire takeoff*. Fix: on a
+non-stale error, `setCommitMsg(friendlyStoreError(e))` (the quota copy already
+exists, `store.js:139-141`) and set an explicit error save-state, not `"idle"`.
+
+Migration to a dedicated blob store stays **out of scope**.
+
+### Coordinate frame (verified)
+
+Markup coords are normalized `[0,1]` of the panel image (`p.img.w`/`p.img.h`, the
+`RENDER_SCALE = 2.0` viewport dims). Canvas `p.img.w` and export `W = vpR.width`
+are **both** `pageW × 2.0` from the same `lib/sheets.ts`, so `w`-as-width-fraction
+maps identically screen↔PDF. `w` is a fraction of sheet **width**; placed box is
+`bw = w*sheetW`, `bh = bw*aspect`, centered on `at`.
+
+### Pure, testable helpers — `web/src/lib/markupImage.ts` (new)
+
+The risky math is pulled OUT of the canvas/PDF integration into pure functions
+(the `winAnsiSafe`/`svgPlacedBox` precedent — export/geometry modules keep their
+branchy logic node-testable):
+
+- `imagePlacedBox(w, aspect, sheetW) → {bw, bh}` — `bw = w*sheetW`,
+  `bh = bw*aspect`. Guard `w>0 && aspect>0 && Number.isFinite(sheetW)` → else
+  `{bw:0, bh:0}`. **Note the deliberate difference from `svgPlacedBox`**
+  (`svgpath.js:451`), which scales off the *longest* viewBox extent; `image` is
+  *width-anchored*. Documented in a header comment; the tall-aspect test pins it.
+- `captureRectToImageGeom(rect, sheetW, sheetH) → {at, w, aspect}` — rect is in
+  image px (already clamped to sheet bounds by the caller). `w = |x1-x0|/sheetW`,
+  `aspect = |y1-y0|/|x1-x0|`, `at = [midX/sheetW, midY/sheetH]`. Corner-order
+  independent. Guard `sheetW>0 && sheetH>0` finite and `|x1-x0|>0`; degenerate →
+  `w:0, aspect:0` (never NaN/Infinity); clamp `at` into `[0,1]`.
+- `resizeImageFromCorner(fixedTL, pointer, aspect, sheetW, sheetH) → {w, at}` —
+  fixed top-left corner stays put; `bw = pointerX − fixedTL.x`; **clamp `w` first**
+  (`clampImageWidth`), THEN derive `bh = bw*aspect` and the new center so the
+  top-left is invariant *including at the clamp rails*. Cross-axis normalization is
+  explicit: `at = [(fixedTL.x + bw/2)/sheetW, (fixedTL.y + bh/2)/sheetH]` (bw over
+  width, bh over height). This is the highest-risk new math — it is a pure helper
+  precisely so it is tested.
+- `clampImageWidth(w) → number` — clamp into `[0.02, 2]`.
+- `aspectFromDims(w, h) → number` — `h/w` with `w<=0`/non-finite → fallback `1`.
+- `pickEmbedFormat(src) → "jpg" | "png" | null` — `"jpg"` for
+  `data:image/jpeg`, `"png"` for `data:image/png`, else `null`. The export and the
+  store-time assertion both use it; `null` is a clean skip, never an exception.
+
+`imagePlacedBox` and `pickEmbedFormat` are imported by `markedset.js` (JS importing
+a `.ts` lib is fine — `markedset.js` already imports `./sheets`). Use the
+**extensionless** specifier `from "./markupImage"` (matches `./sheets`; a
+`.ts` extension trips `tsc --noEmit`).
+
+### Two entry points
+
+1. **Marquee screenshot** — a new `image` tool in `MARKUP_TOOLS`. Armed, it is a
+   two-click marquee like `schedule`/`symbol` (`TakeoffCanvas.jsx:2770-2778`):
+   first click drops `imageAnchor`, second click calls
+   `captureRegionMarkup(anchor, p)`. Live rubber-band reuses `rectRef` — wire an
+   `imgDraw` flag into `TakeoffCanvas.jsx:3186-3194` beside `schedDraw`/`symDraw`.
+   `image` routes **only** through this marquee branch — it must NOT be added to
+   the `placeMarkup` OR-list at `2780` (that has no image case and would no-op).
+   Capture:
+   - Guards mirror `importScheduleFromRect` (`5816-5823`): both corners in one
+     panel; a real `pageObjsRef` page (refuse on a stitched composite — no single
+     source page, message the user); a non-degenerate box.
+   - **Clamp the rect to `[0,p.img.w]×[0,p.img.h]` before geom** (an over-drag past
+     the sheet edge must not park `at` outside `[0,1]`).
+   - Render offscreen with its **own** factor `min(1, MARKUP_IMG_MAX/max(regW,regH))`
+     in rs-viewport px — do NOT inherit `rasterizeRegion`'s `scanRasterScale`
+     (which caps at 4096 and blows the 1600 budget). `canvas.toDataURL("image/png")`.
+   - `captureRectToImageGeom` → `at/w/aspect`; `addMarkup({type:"image", …,
+     source:"capture"})` after the aggregate-budget check.
+2. **Upload** — an "Upload image…" button in the Markups dock (near the markup
+   list `7325-7425`), reusing the StampPanel hidden-file-input pattern
+   (`StampPanel.jsx:86-89`, incl. `e.target.value=""` to allow re-picking).
+   `accept="image/*"`, but **do not trust `accept`**:
+   - **Reject SVG explicitly** (`f.type === "image/svg+xml"` or `/\.svg$/i`) — an
+     SVG can carry script; it is exactly what `svgImport.js:423-428` bans.
+   - Decode via `createImageBitmap(file, { imageOrientation: "from-image" })`
+     (honors JPEG EXIF orientation) with a decode-area ceiling.
+   - **Unconditional re-encode** through a downscale canvas (≤1600 longest) →
+     `toDataURL` — PNG, or JPEG when the source is JPEG (smaller for photos). Only
+     the canvas output is stored; original file bytes are never kept. This reduces
+     the feature to "pixels only" (SSRF-/script-safe) and guarantees
+     `pickEmbedFormat(src) !== null`.
+   - Wrap decode+encode in try/catch → "Couldn't read that image." on failure
+     (corrupt, zero-byte, tainted-canvas `SecurityError`).
+   - `aspect = aspectFromDims(bitmap.width, bitmap.height)`; default `w = 0.2`;
+     place centered in the current view; `source:"upload"`; aggregate-budget check.
+
+### Move & resize
+
+- **Move** needs **no new move code**, but ships with the hit-test: an `image` has
+  `at`, so the existing markup move-drag arms with `orig = { at }`
+  (`2978`, the fallthrough) and onPointerMove translates `at` (`3446`) — *only once*
+  `hitMarkup` has an `image` branch (below). Not independently "done."
+- **Resize** (new): when an image is selected, render a small BR corner handle
+  (screen-constant, `/z`). In `selectAt`, BEFORE the generic markup search (insert
+  ~`2957`), resolve `selectedMarkupId` → markup, **confirm `type === "image"`**,
+  and if the pointer is on its BR handle, arm
+  `dragRef = { kind:"markupResize", markupId, sheetId, tl:[…], aspect, ox, imgW,
+  imgH }` (fixed top-left). onPointerMove calls `resizeImageFromCorner` and live
+  `setMarkups`. onPointerUp (`3488-3511`) sees `kind` ∉ {vertex,edge,move},
+  dispatches no shape command, releases capture (verified — mirrors `markupMove`).
+  Like every markup edit, resize is **not** on the ⌘Z stack (markups aren't;
+  consistency over inventing undo).
+
+### Rendering (canvas)
+
+Add an `image` branch in the markup map (`7787` region, beside `svg`). It must be
+**self-contained and always return** — the map ends in an unconditional `text`
+fallthrough (`7807-7816`), so a guard-failing image would otherwise paint a
+phantom empty note box:
+
+```jsx
+if (m.type === "image") {
+  const { bw, bh } = imagePlacedBox(m.w, m.aspect, p.img.w);
+  if (!(m.src && Array.isArray(m.at) && bw > 0 && bh > 0)) return null;   // never fall through
+  const x0 = m.at[0]*p.img.w - bw/2, y0 = m.at[1]*p.img.h - bh/2;
+  return (
+    <g key={m.id}>
+      {halo(x0, y0, x0+bw, y0+bh)}
+      <image href={m.src} x={x0} y={y0} width={bw} height={bh}
+             preserveAspectRatio="none" style={{ pointerEvents:"none" }} />
+      {selM && <rect x={x0+bw-4/z} y={y0+bh-4/z} width={8/z} height={8/z}
+                     fill="#1f3fc7" stroke="#fff" strokeWidth={1.5/z} />}
+      {badge(x0, y0 - 9/z)}
+    </g>
+  );
+}
+```
+
+No dark-mode inversion (a screenshot is captured from the light PDF render).
+
+### Hit-test
+
+Add an `image` branch to `hitMarkup` (`2874`-style, `at ± box/2` via
+`imagePlacedBox`; `&&`-guarded so a bad record falls to `false`). In `selectAt`'s
+markup search and `editMarkupAt`, test images **last** (three tiers:
+non-image-non-highlight → highlight → image) so a large image never shadows other
+markups from selection; shapes beneath a large image are shielded (same as a
+highlight box today) — documented in the user guide.
+
+`editMarkupAt` (`4732`): add `|| m.type === "image"` to the select-only guard
+(images carry no text — no dead-end editor writing a phantom `m.text`).
+
+### Marked Set PDF export
+
+Add `else if (m.type === "image" && m.at && m.src)` in `markedset.js:788` (before
+the `text` fallthrough), inside the async `for (const m of marksHere)` (sequential
+`await` preserves draw order):
+
+- **Skip rotated sheets for v1**: if `page.rotate % 360 !== 0`, skip the image
+  (canvas `toPage` carries the rotation affine but `pg.drawImage` takes only a
+  bottom-left point + axis-aligned w/h, so a rotated sheet mis-places AND
+  mis-proportions it). Documented limitation.
+- `const fmt = pickEmbedFormat(m.src); if (!fmt) continue;` (clean skip, not an
+  exception).
+- `{bw,bh} = imagePlacedBox(m.w, m.aspect, W)`; box top-left `(x0,y0)` in image px;
+  map the box's bottom-left `(x0, y0+bh)` through `toPage`; size via `ptScale`;
+  `img = await (fmt === "jpg" ? doc.embedJpg : doc.embedPng)(m.src)`;
+  `pg.drawImage(img, { x, y, width: bw*ptScale, height: bh*ptScale })`.
+- Wrap in try/catch → skip on failure (the logo precedent `277`) so one corrupt
+  image never kills the marked set.
+
+## Files touched
+
+**New**
+- `web/src/lib/markupImage.ts` — the pure helpers above.
+- `web/test/markupImage.test.ts` — node:test over every helper.
+- `docs/plans/image-annotation-plan.md` — this file.
+
+**Edited**
+- `web/src/lib/canvasConstants.js` — add the `image` tool to `MARKUP_TOOLS`; add
+  `MARKUP_IMG_MAX`, `MAX_IMAGE_MARKUP_BYTES` (and a decode-area constant if not
+  reusing `MAX_CANVAS_AREA`).
+- `web/src/pages/TakeoffCanvas.jsx` — `imageAnchor` state; marquee dispatch
+  (`~2779`, NOT the `2780` OR-list); `rectRef` preview (`3186-3194`); Escape +
+  tool-change reset of `imageAnchor` (`~2647`); `captureRegionMarkup`; upload
+  handler + browser decode/downscale util; aggregate-budget guard; autosave
+  quota-error surfacing (`2278-2281`); render branch (`~7787`); `hitMarkup` branch
+  + three-tier ordering (`2874`/`2961-2967`); `editMarkupAt` guard (`4732`);
+  `selectAt` resize-handle arm (`~2957`); onPointerMove `markupResize`; Markups-dock
+  "Upload image…" button (`~7325`); import the new helpers. **Do NOT touch
+  `reportJson` in `totals.js`** (its markup key whitelist is asserted by
+  `totals.test.ts:156`).
+- `web/src/lib/markedset.js` — import `imagePlacedBox`/`pickEmbedFormat`; the
+  `image` export branch.
+- `web/src/components/ReportPanel.jsx` — exclude `image` from the "Revisions
+  noted" table (`827` and `840`: `m.type !== "svg" && m.type !== "image"`).
+- `web/src/brand/icons.jsx` — add an `image` icon (none exists).
+- `README.md`, `docs/USER_GUIDE.md`, `CHANGELOG.md` — per AGENTS.md doc-sync list
+  (Markups feature line + "What's in the box" row; user-guide markups section, the
+  shadowing note, the "images sync/export with the takeoff" note, and the
+  rotated-sheet export limitation). **No MCP docs** (no new MCP verb; the export
+  branch benefits MCP for free via `markedset.js`).
+
+## Test plan
+
+Pure math is the red→green TDD target (`web/test/markupImage.test.ts`, node:test
+via tsx). Red is natural: `markupImage.ts` doesn't exist, so the import fails.
+
+- `imagePlacedBox`: `(0.5,0.5,1000)→{500,250}`; `(0.25,2,800)→{200,400}` (tall
+  case — documents the width-anchor divergence from `svgPlacedBox`); `w≤0`,
+  `aspect≤0`, non-finite `sheetW`→`{0,0}`.
+- `captureRectToImageGeom`: `({100,50,300,150},1000,800)→{w:0.2, aspect:0.5,
+  at:[0.2,0.125]}`; corner-order independent; degenerate `x0==x1`→`{w:0,aspect:0}`;
+  `sheetW=0`/non-finite guarded (no Infinity); `at` clamped `[0,1]`.
+- `resizeImageFromCorner`: top-left invariant on a normal drag; **top-left still
+  invariant at both clamp rails**; aspect preserved; a non-square `sheetW/sheetH`
+  case (catches a width/height-swap bug).
+- `clampImageWidth`: rails and just-outside (`0.019→0.02`, `2.001→2`, `NaN→`clamp).
+- `aspectFromDims`: `(200,100)→0.5`; `w≤0`/non-finite→`1`.
+- `pickEmbedFormat`: `jpeg→"jpg"`, `png→"png"`, `webp`/`gif`/`""`/`svg`→`null`.
+
+Canvas wiring, upload/decode/downscale, capture, resize interaction, and PDF
+export are integration — **hand-verified in the running app** (AGENTS.md: grep new
+identifiers; load the app once). Phase 6 verification:
+
+1. `cd web && npm run check` green (typecheck+lint+test+bench+build).
+2. Sample plan, set a scale.
+3. Marquee-screenshot a detail → lands within the marquee, drag it away, resize by
+   the corner (aspect locked, top-left fixed), reload → persists.
+4. Upload PNG + JPEG (rotated phone photo → correct orientation); move/resize/persist.
+   Upload an SVG → refused. Upload a huge image → capped/refused, no OOM.
+5. Export Takeoff JSON → new project → Import → images reappear.
+6. Export Marked Set (light + dark) → images at right place/size; rotated sheet →
+   image omitted (documented).
+7. Delete (Delete key) → gone; RFI-link an image → badge shows and prints; image
+   is NOT a row in the report's "Revisions noted".
+8. Fill the aggregate budget → placement refused with a message (not a silent
+   quota failure).
+
+## Risks / edge cases (post-review)
+
+- **Blob bloat / quota** — bounded by the three caps + surfaced quota errors;
+  blob-store migration is future work (out of scope).
+- **Rotated sheets** — RESOLVED in a follow-up: `imageDrawParams` derives the
+  drawImage anchor + rotation from `toPage`, so images land correctly on rotated
+  source pages in the marked set (was omitted in the first cut).
+- **Large image shadows shapes/markups beneath** — images hit last among markups
+  (other markups stay clickable); shapes under an image are shielded like a
+  highlight box; documented ("move it to reach what's under it").
+- **Stitched composites** — capture refuses (no single `pageObj`); upload is fine
+  (export uses the composite `toPage`).
+- **Privacy** — never in the contribution payload; but for Drive/JSON users the
+  inline image *does* travel with the takeoff (a screenshot is a render of the
+  PDF, which already syncs) — noted in the user guide so it isn't a surprise.
+- **Corrupt `src`** — render returns null; export `pickEmbedFormat`→skip + try/catch.
+
+## Out of scope
+
+- A dedicated IndexedDB blob store for image bytes (future).
+- An MCP `annotate` image verb (canvas only).
+- Rotating/cropping after placement; multi-select; freehand (non-rect) capture.
+
+## Review findings → resolution (audit trail)
+
+| # | Finding (lens) | Resolution |
+|---|---|---|
+| Corr-D1 / Sec-8 | Capture inherits `rasterizeRegion`'s 4096 cap, blows the 1600 budget | Capture computes its own `min(1,1600/max(regW,regH))` factor |
+| Corr-D2 / Reg-D2 | Render guard-fail falls through to text renderer → phantom box | `image` branch is self-contained, `return null` on guard-fail |
+| Corr-D3 / Reg-D3 | `editMarkupAt` writes phantom `text` onto images | Add `|| m.type==="image"` at 4732 (required, not descriptive) |
+| Corr-D4 | Rotated-sheet export mis-placed/mis-proportioned | Skip images on rotated sheets in v1; documented |
+| Corr-D5 | Escape/tool-change must clear `imageAnchor` | Explicit `setImageAnchor(null)` at 2647 + tool switch |
+| Corr-D7 | Over-drag parks `at` off-sheet | Clamp rect to sheet bounds before geom; `at` clamped in helper |
+| Reg-D1 / Sec-3 | Quota failure silently loses whole takeoff | Autosave catch → `friendlyStoreError` + error state |
+| Reg-D4 | Large image shadows shapes/markups | Images hit last; shielding documented |
+| Reg-D5 / Sec-3 | No cap on image count | `MAX_IMAGE_MARKUP_BYTES` aggregate budget, refuse up front |
+| Reg-D6 | Image becomes empty NOTE row in report | Exclude `image` at ReportPanel 827/840 |
+| Reg-D7 | `reportJson` key-whitelist test breaks if edited | Leave `totals.js` untouched; noted for implementer |
+| Reg-D8 | `image` in `placeMarkup` OR-list → no-op | Route only via the marquee branch |
+| Reg-D9 | Resize arm could fire on a non-image markup | Gate the arm on resolved `type==="image"` |
+| Test-1 | Resize math untested in `onPointerMove` | Pure `resizeImageFromCorner`, tested incl. clamp rails |
+| Test-2 | Export sniff inlined/untested | Pure `pickEmbedFormat`, tested; skip on `null` |
+| Test-3 | Upload re-encode invariant unstated | Unconditional re-encode; pure `aspectFromDims` guard |
+| Test-4 | Duplicates `svgPlacedBox` silently | Documented width-anchor distinction; tall-case test |
+| Test-5 | Coverage gaps (non-finite/degenerate/clamp) | Added to the test list above |
+| Sec-1 | SVG upload not rejected | Explicit SVG reject + unconditional raster re-encode |
+| Sec-2 | Pixel/decompression bomb | Decode-area guard via `createImageBitmap` resize |
+| Sec-5 | JPEG EXIF orientation dropped | `createImageBitmap({imageOrientation:"from-image"})` |
+| Sec-6/7 | Decode/encode failure, objectURL leak | try/catch + message; no `createObjectURL` |
+| Sec-9 | "Never leaves browser" false for sync/export | User-guide note that images travel with the takeoff |

--- a/docs/plans/image-captures-plan.md
+++ b/docs/plans/image-captures-plan.md
@@ -1,0 +1,162 @@
+# Plan — "Captures": a cross-sheet image library in the sidebar
+
+Reshapes image markups on `feat/206-image-annotation` from per-sheet annotations
+into a portable **Captures** library. Verified against the branch (file:line refs
+are the current worktree). Approved in chat; this is the spec for adversarial
+review before implementation.
+
+## Already built this session (uncommitted, verified green)
+- Panel row click → `selectMarkup` + `flyToMarkup` (locate/select from the list).
+- Re-enterable **Place**: `placingImageId` + cursor-follow with a grab-offset (no
+  teleport), centre-on-place via `flyToMarkup`, Esc/commit clear. `onPointerMove`
+  `:3644`, `onPointerDown` `:2846`, Place button in the row.
+- Permanent double-stroke frame on the canvas image render (`:8390`) — visible when
+  deselected.
+- Naming: `<sheetBaseLabel>-NN` written into `text`; `author = authorName()`
+  stamped; upload uses the file name. `addImageMarkup` `:6462`.
+- Memory-only thumbnail (`ensureThumb`, `imgThumbs`) + provenance `title` tooltip
+  in the row.
+
+## Current seam (why cross-sheet fails today)
+A markup is bound to one sheet by `sheet_id`, enforced in:
+1. Panel list + count — `markups.filter(m => panelKeySet.has(m.sheet_id))`
+   (`:7949`, `:6920`). ← the seam.
+2. `visibleMarkups` — `markups.filter(m => keys.has(m.sheet_id))` (`:1073`).
+3. Canvas render — per panel `m.sheet_id === p.key` (`:8265`). ← keep (a capture
+   draws on the sheet it currently lives on).
+Placement already sets `sheet_id: tp.key` on drop, so a capture CAN change sheets;
+it just can't be reached from another sheet. Fix = the panel list (#1).
+
+## Design (v2 — revised after review round 1)
+
+### A. Captures section (Markups tab, below per-sheet annotations)
+- Per-sheet list changes to `type !== "image"`. New **Captures** section lists ALL
+  `type === "image"` (global, every sheet). Upload button moves into its header.
+- Row: `[thumb] name(✎)  ·<sheet badge>·  <relative time>  Place  <◎ trace>
+  <caption-toggle>  [link]  🗑`. Drops color/line-style/weight (raster-meaningless).
+  Uploads omit the trace + toggle (no source); the row anchors on **Place**, which
+  both share — no empty gaps.
+- **Sheet badge = current `sheet_id`** (where the capture lives now). When it
+  differs from the origin, the trace control reads **"◎ from <src>"** so
+  "captured on A, now on B" is legible without hovering; when they match, "◎ Source".
+- **Always-on name search** (one `<input>` + `.filter()`, matching the
+  `TakeoffsPanel`/`RfiPanel` always-on-filter idiom). The this-sheet/all-sheets
+  **scope toggle is CUT to v2** — the list is global (all sheets) and the per-row
+  sheet badge already gives at-a-glance "which sheet" legibility, so a scope control
+  earns nothing for a handful of captures and risks re-introducing the seam. Add it
+  only on real demand.
+- **Discoverability:** the per-sheet section's empty state (`:7946`) gains a pointer
+  — "Images now live in **Captures** below" — so a user who placed an image doesn't
+  lose it when it leaves the annotation list.
+
+### B. Relative timestamps
+- Compact natural-language age of `created_at` (`just now`, `2h ago`, `yesterday`,
+  `3d ago`, older → a date). Pure helper `relativeAge(iso, nowMs)`.
+- Hover `title` → explicit `Aug 25, 2026, 7:58 PM (UTC)` via `absoluteUtc(iso)`.
+- **No live tick.** No precedent in the app for a re-render-to-age timer, and a
+  top-level 60 s `setState` would re-render the whole ~9,500-line canvas component.
+  Accept staleness; the panel re-renders on any interaction and the hover gives the
+  exact time. (`imageProvenance` must also switch to `src_sheet_id` — see C.)
+
+### C. Source trace (◎) — captures only
+- Capture records `src_sheet_id = panel.key` and
+  `src_rect = [[x0/panel.img.w, y0/panel.img.h], [x1/panel.img.w, y1/panel.img.h]]`
+  reusing the ALREADY-CLAMPED `x0..y1` from `captureRegionMarkup` (`:6430-6433`).
+  NOT the raw stage-px `a`/`b` (carry `xOffset`, unclamped) and NOT `bw`/`bh` (the
+  1600px raster size). Uploads omit both. `rs` never enters normalization —
+  `renderScalesRef` is pinned to `RENDER_SCALE`, so rect and `at` share one frame.
+- **Dedicated navigation — NOT `flyToMarkup`.** `flyToMarkup` resolves `m.sheet_id`
+  (the current sheet) and `pendingFlyRef` can only carry a markup id, so it cannot
+  express "open the SOURCE sheet and frame a rect." Add `pendingSourceRef =
+  {sheet_id, rect, token}` and a mirror of the open-then-center effect (`:2169`) that
+  opens `src_sheet_id` (via `openSheets` if not loaded) and centers on the rect
+  midpoint by **replicating the transform math at `:5411-5416`** (NOT calling
+  `centerOnMarkup`, which centers on `m.at` and then `selectMarkup`s — it can't take
+  a synthetic `{sheet_id, rect}`). Flash renders **inside the source panel's `<g>`**
+  (same `n * p.img.w` mapping as `:8446`). Transient `sourceFlash` is its OWN
+  `useState` — never written onto a markup.
+  - **Staleness guard (riskiest new mechanism):** `pendingSourceRef` carries no
+    markup id to validate against, so a ref parked in a broadly-keyed effect is a
+    latent view-teleport if the source panel never reaches `img.w>0`. Clear it on
+    `status==="error"` and with a bounded retry / attempt-token; never leave it set.
+  - **Mid-Place guard:** starting a trace while `placingImageId` is set must
+    `setPlacingImageId(null)` + clear `placeGrabRef` first, or the riding image drops
+    onto the source sheet on the navigation click.
+  - `openSheets(…,false)` collapses a side-by-side group (`goToSheet` → `setSheetGroup([])`) — acceptable (the user asked to go to the source), noted.
+- `imageProvenance` (`:6501`) must read `src_sheet_id` (fallback `sheet_id` for
+  uploads/legacy) — today it reads `sheet_id` and would misreport the origin.
+
+### D. Source caption (toggle) — captures only, DEFAULT OFF
+- `source_label: false` by default; a per-row toggle sets it true, its off-state
+  clearly styled "off".
+- When true, draw a caption **hugging the image frame** — a chip on the top edge,
+  attached to the box so it stays inside `hitMarkup`/`halo`/framing — with
+  `pointerEvents:"none"` (every child of the image `<g>` is), reading
+  `Source: <label> · p.<page>` where page comes from `parseSheetKey(src_sheet_id)`
+  (`file`/`page`, already imported `:41`) and `<label>` from `sheetBaseLabel(
+  src_sheet_id)`. Explicit legible color (a white/ink-backed chip like the
+  text-markup chip — the image render does no dark-mode invert). Anchor it clear of
+  the link **badge** at `(x0, y0-9/z)` (`:8457`) and guard a short capture so the
+  fixed-screen-size chip doesn't overrun into the bottom-right resize-handle zone.
+- **Exports too:** the marked-set PDF's image path gains the caption — but mirror
+  the **rotated cloud-chip path (`markedset.js:762`, `rotate: chipRot`), NOT the
+  axis-aligned svg text (`:787`)**, because the image path is the rotated-page path
+  (`imageDrawParams`); an axis-aligned caption would detach from a rotated capture.
+  Derive the label the SAME way as the canvas (`sheetBaseLabel`) so screen and PDF
+  agree (`sheets[].label` = `tabLabel` carries a "Level 1 · " prefix — don't use it).
+- Uploads: no source → no toggle, no caption.
+
+### Cross-sheet placement (correcting the already-built Place)
+- **Place is two cases** (reconciling Kevin's "center on it" hop-fix with cross-sheet
+  drop):
+  - **On an open sheet (same-sheet reposition):** keep today's behavior —
+    `flyToMarkup(m)` centers the view on it + grab-in-place (offset preserves where
+    the image sits, no teleport). This is the hop-fix Kevin asked for.
+  - **On another sheet (cross-sheet place):** do NOT navigate — enter
+    `placingImageId` on the CURRENT sheet and **zero the grab offset** (`dx=dy=0`)
+    so the image centers under the cursor on first contact (its `at` from the other
+    sheet is meaningless here). Commit message must not claim "the view centered on
+    it" in this branch.
+  - Branch on `panelKeySet.has(m.sheet_id)` in the Place handler and in the first-
+    contact grab (`:3670`).
+- **Sync durability:** an image move/resize must stamp `updated_at: nowIso()`, else
+  a 3-way sync tie (`created_at` equal) resolves remote-wins and silently reverts
+  it. Stamp at the **commit boundaries** — `onPointerUp` (`:3831`, covers both
+  `markupMove` at `:3805` and `markupResize`) and the Place commit in `onPointerDown`
+  (`:2853`) — NOT the per-frame preview mappers (`:3676`/`:3815`): the house doctrine
+  (`:149-157`) is that live-drag preview frames don't stamp, the commit does. The
+  preview-mapper approach also misses the ordinary same-sheet `markupMove` drag.
+
+### Capture record — new fields (captures only; uploads omit)
+`src_sheet_id: string`, `src_rect: [[n,n],[n,n]]`, `source_label: boolean`.
+Additive — ride `markups[]` wholesale (`buildPayload :2194`, hydrate `...m` `:1524`,
+`importTakeoff :144`, `merge.js stable()`), **no `ANN_SCHEMA` bump**, old payloads
+degrade cleanly (absent → caption off / trace hidden). `contribute.js` excludes
+markups, so the new fields cannot leak into the training payload.
+
+## Slices
+1. Capture record fields + the correct `src_rect` formula in `captureRegionMarkup`;
+   `updated_at` stamps on move/resize; `imageProvenance` → `src_sheet_id`. Pure
+   `relativeAge`/`absoluteUtc`/caption-text helpers + node tests.
+2. Canvas: source caption (frame-hugging chip, exports to marked-set) + the
+   `sourceFlash` overlay in the source panel `<g>`.
+3. Place: strip navigation, zero off-sheet grab offset, fix message. Dedicated
+   `pendingSourceRef` navigation for ◎ trace.
+4. Captures section: split per-sheet (`type !== "image"`) from the global Captures
+   list; row (thumb/name/badge/time/Place/trace/toggle/link/delete); Upload moved
+   in; always-on **name search** (scope toggle deferred); per-sheet empty-state
+   pointer.
+5. Live-verify: capture on A, switch to B, place on B; ◎ flashes A's region;
+   caption toggles + exports; relative time + hover.
+
+## Review outcome — GO (2 rounds)
+Round 1 surfaced 5 blocker/majors (Source-nav, Place-nav, provenance origin, sync
+stamp, caption export); round 2 verified the v2 fixes and returned **GO**, with the
+refinements now folded in: stamp at commit boundaries not preview mappers; source
+centering replicates the transform math (not `centerOnMarkup`); `pendingSourceRef`
+staleness guard + mid-Place guard; caption mirrors the rotated chip path (`:762`)
+with one label derivation; scope toggle cut to v2. Resolved & confirmed clean:
+coordinate frame (formula pinned), schema round-trip (additive, no bump), privacy
+(markups excluded from `contribute.js`), `sourceFlash`/`src_rect` load-bearing,
+no live-tick. Riskiest remaining item to watch during build: the `pendingSourceRef`
+lifecycle.

--- a/docs/plans/image-markup-provenance-plan.md
+++ b/docs/plans/image-markup-provenance-plan.md
@@ -1,0 +1,145 @@
+# Plan — image-markup provenance, naming, thumbnails, placement & audit
+
+Enhancements to the image-markup feature on `feat/206-image-annotation` (PR #206).
+Verified against the branch rebased on `main` (2026-08-25); file:line refs are
+that tree. **This version is post-adversarial-review** — three reviewers
+(data-model/sync, scope/simplicity, UX) rewrote the first draft. Their convergent
+findings and the resulting cuts are recorded below.
+
+## Current state (verified)
+
+- Capture (`TakeoffCanvas.jsx:2903-2907`) is a two-click marquee; 2nd click calls
+  `captureRegionMarkup`, drops the image **at the marquee centre**, resets to
+  select. Upload (`:6091`) drops at view centre. `source` is already
+  `"capture"|"upload"`.
+- `addMarkup` (`:4998`) already stamps `created_at`; markups carry **no** `author`,
+  `name`, or thumbnail.
+- Panel row (`:7878`) renders text only → an image row shows `(no text)`; `svg`
+  gets a special-cased `(vector symbol)`. The image render branch (`:8340`) never
+  paints `m.text`, so a name stored in `text` cannot leak onto the canvas.
+- Canvas image render (`:8352-8358`) draws its frame via `halo(...)`, which
+  **returns null unless selected** (`:8211`) — so a deselected screenshot is
+  visually identical to the sheet under it. **This is the "invisible drop."**
+- `deleteMarkup` (`:5175`) is a bare `setMarkups` filter — **not** on the undo
+  stack (`undoStackRef` `:571` is shapes-only) and the 🗑 (`:7881`) has no confirm.
+- Provenance primitives (`lib/provenance.js`): `authorName()`
+  (`localStorage["ot-author"]`, `null` when undeclared), `nowIso()`, `mintUuid()`.
+  Author is declarable only via the command line (`author <name>`, `:7483/5779`) —
+  no plain GUI field.
+- Sync/merge: `markups[]` on a synced project is rewritten by
+  `lib/sync/merge.js` (resurrect/union/winner-pick) and can be wiped by the
+  remote-wins fallback (`syncStore.js:170`) or an older-build teammate. Wholesale
+  replaces — hydrate (`:1508`), Restore, remote-adopt, `importTakeoff` — bypass
+  `addMarkup`/`deleteMarkup` entirely.
+
+## Requirements (from Kevin)
+1. A real **placement** feel (not an invisible drop over its source).
+2. **Thumbnail** in the side panel.
+3. **Name** after the source sheet + a sequence number.
+4. **Provenance** for capture and upload — who, when taken/uploaded, when placed.
+5. An **auditable log** of everything placed or removed.
+
+## Design (post-review minimum)
+
+### 1. Panel thumbnail + name — KEEP (fixes an existing panel gap; ~zero schema)
+- **Name** = `"<sheetBaseLabel>-<NN>"`, `sheetBaseLabel` from `labelFor` (the bare
+  sheet base, **not** the mutable compound `tabLabel` which yields
+  `Level 1 · A-101 · 3-01`). `NN = 1 + count(image markups on same sheet_id)`,
+  zero-padded, **collisions tolerated after deletes (NOT called monotonic)** — the
+  first draft's `1+count` "monotonic" claim was false (delete 02 of 01/02/03 →
+  next = 03, dup). Stored in the **existing `text` field** at creation → the
+  existing panel row renders it and the existing ✎ edits it (images aren't `svg`,
+  so they already get a ✎). Upload → filename sans extension.
+- **Thumbnail** generated at capture/upload as a ~64 px-longest-side JPEG, held in
+  a module-level **memory-only** `Map<markupId, dataURL>` (rebuilt from `m.src` on
+  load), rendered in the panel row. **Never persisted** — the aggregate gate
+  `MAX_IMAGE_MARKUP_BYTES` (16 MB, project-wide) sums `src.length`; a stored thumb
+  would eat that budget, and a 40 px `<img src=fullDataURL>` decodes the full
+  1600 px source (hundreds of MB of live RGBA across a busy sheet).
+
+### 2. Placement is a first-class, re-enterable action (corrected after live test)
+Kevin, testing the branch: "the placement UI sort of functions but I don't see
+any way to select the image from the list and then place it — only immediately
+after capture do I have the chance to place." That's the real requirement, and the
+first draft's "drop-in-place only, ghost-follow is speculative" was wrong. The app
+already has every piece; they just aren't wired for image placement.
+
+- **Row click = select + fly-to.** The markups panel row (`:7866`) has NO click
+  handler; `flyToMarkup` (`:5374`) exists but is wired only to the RFI register
+  (`:7981`). Wire a row click to `selectMarkup(m.id)` + `flyToMarkup(m)` (guarding
+  the ✎/🗑/link controls from double-firing) so selecting an image from the list
+  locates and selects it on canvas — the same affordance the RFI panel already has.
+- **Re-enterable Place/Reposition.** Add a **Place** action on the image row (and
+  keep the post-capture placement) that arms a placement mode: the image follows
+  the cursor and the next click drops it. Re-placeable at any time, not only in the
+  half-second after capture. `armStamp`/`placeStamp` (`:5188/5192`) is the existing
+  arm-then-click-to-place precedent to model on. State: one `pendingPlaceId`; Esc
+  cancels; clicking the toolbar/panel/another sheet cancels cleanly.
+- **Permanent frame.** Render image markups with a **permanent low-weight
+  double-stroke frame** (white + ink, thin — legible in both canvas themes, since
+  images draw without dark-mode invert) **regardless of selection**, so a placed
+  image stays a visible object after deselect instead of vanishing into the sheet
+  (the halo is selection-only today, `:8211`).
+
+### 3. `author` on the image record — SIMPLIFY (the defensible "who")
+- Stamp `author = authorName()` at creation on both paths (images-only scope).
+  Timestamps come from the existing `created_at` (= when placed). Surface
+  provenance as a native `title=` tooltip on the panel row, degrading gracefully
+  when `author` is null.
+- **CUT `source_at` and `src_sheet_id`:** both are provably always-equal to
+  `created_at` / `sheet_id` in the shipped flow; add them the day a
+  capture-here-place-there flow exists.
+
+### 4. Removed-only audit log — separate append-only store
+- Log **removals only** — placements are reconstructable from live records
+  (`created_at` + `author`); a parallel `placed` entry is a second source of truth
+  that drifts. One hook in `deleteMarkup`. Entry: `{ id: mintUuid(), markup_id,
+  name, sheet_id, ts, actor }`.
+- **Home = a dedicated append-only IndexedDB store** (new object store beside
+  `SNAP_STORE`/`REV_STORE`). This is what "auditable" *requires*, not a costlier
+  alternative to it: an array in the synced payload is provably wipeable — the
+  sync merge (`merge.js`) never writes it, the remote-wins fallback and an
+  older-build teammate can delete it, and wholesale replaces bypass the hooks. A
+  store that never round-trips through the merge is the only thing that keeps the
+  log intact under sync.
+- **Known gap (deferred):** wholesale replaces (Restore, remote-adopt, import) are
+  not interactive removals and won't be logged by the `deleteMarkup` hook alone.
+  Closing it means reconciling the store against `markups[]` after each wholesale
+  replace — real work, out of this slice, but named so it isn't mistaken for done.
+
+### CUT entirely
+`source_at`, `src_sheet_id`, monotonic/high-water counter, `placed` entries,
+extending author/audit to all markup types.
+(Ghost-follow placement is back IN — see §2; Kevin's live test proved it's a
+requirement, not speculation.)
+
+## Decisions (made 2026-08-25)
+- **Audit home:** dedicated append-only IndexedDB store (§4) — the requirement,
+  not the costly option.
+- **Delete safety:** add a confirm on the 🗑 / Delete key for image markups (the
+  destructive-action pattern conditions already use). Delete stays destructive but
+  is no longer a single silent click.
+- **Author identity in the UI:** identity is CLI-only today (`author <name>`).
+  Expose it as a first-class UI field (a "Your name" input in
+  settings/overflow) writing the same `localStorage["ot-author"]` key
+  `authorName()` reads. Provenance's "who" then populates for every user, not just
+  those who know the command.
+- **Scope:** image markups only for this PR; the audit store is keyed generically
+  so extending to other markup types later is additive, not a rewrite.
+
+## Still open
+- **Audit visibility:** the store surfaces only on inspection/export unless given a
+  viewer. Default: export/inspection for this PR; a viewer is a follow-up.
+
+## Slices (tracer-bullet, each builds + node tests green)
+1. Name into `text` (pure `markupName(labelFor, sheetId, markups)` helper + tests)
+   + `author` stamp on both capture and upload paths.
+2. Panel thumbnail (memory-only thumb Map) + name render + `title` provenance
+   tooltip. Visual verify.
+3. Placement: row click = `selectMarkup` + `flyToMarkup`; re-enterable **Place**
+   action (arm → cursor-follow → click to drop, Esc cancels); permanent
+   double-stroke frame on the canvas render. Visual verify.
+4. Removed-only audit store (new IndexedDB object store) + `deleteMarkup` hook.
+   Node test.
+5. Delete confirm for image markups (🗑 / Delete key).
+6. "Your name" author field in the UI, writing the `ot-author` key.

--- a/web/src/brand/icons.jsx
+++ b/web/src/brand/icons.jsx
@@ -37,6 +37,7 @@ export const icons = {
   textNote: (s) => <I size={s}><path d="M5 5 H 19 M5 5 V 7.5 M19 5 V 7.5 M12 5 V 19 M9.5 19 H 14.5" /></I>,
   highlight: (s) => <I size={s}><rect x="4" y="7" width="16" height="10" /><line x1="7" y1="12" x2="17" y2="12" /></I>,
   dimension: (s) => <I size={s}><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="8" x2="3" y2="16" /><line x1="21" y1="8" x2="21" y2="16" /><path d="M1.8 13.4 L 4.2 10.6 M19.8 13.4 L 22.2 10.6" /></I>,
+  image: (s) => <I size={s}><rect x="3" y="5" width="18" height="14" /><circle cx="8.5" cy="10.5" r="1.7" /><path d="M3 16 L 9 11 L 13 14.5 L 16.5 11.5 L 21 16" /></I>,
   highlighter: (s) => <I size={s}><path d="M5 21 L8.5 17.5 M8.5 17.5 L6.8 14 L14 6.8 L17.2 10 L10 17.2 Z M14 6.8 L15.8 5 L19 8.2 L17.2 10" /></I>,
   copy: (s) => <I size={s}><rect x="8" y="8" width="12" height="12" /><path d="M16 8 V 4 H 4 V 16 H 8" /></I>,
   paste: (s) => <I size={s}><rect x="5" y="5" width="14" height="16" /><rect x="9" y="3" width="6" height="4" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="15" y2="16" /></I>,

--- a/web/src/components/ReportPanel.jsx
+++ b/web/src/components/ReportPanel.jsx
@@ -855,9 +855,9 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
             </p>
           </div>
         )}
-        {markups.some((m) => m.type !== "svg") && (
+        {markups.some((m) => m.type !== "svg" && m.type !== "image") && (
           <div style={{ maxWidth: 980, margin: "26px auto 0" }}>
-            {/* svg symbols are decorative vector stamps, not revision notes — excluded */}
+            {/* svg symbols and image markups aren't revision notes — excluded */}
             <h3 style={{ fontFamily: "var(--f-display)", fontSize: 12, fontWeight: 700, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--ink)", margin: "0 0 10px", paddingBottom: 5, borderBottom: "1.25px solid var(--ink)" }}>Revisions noted</h3>
             <table style={{ width: "100%", borderCollapse: "collapse", background: "var(--paper-bright)", border: "1px solid var(--ink-faint)" }}>
               <thead>
@@ -868,7 +868,7 @@ export default function ReportPanel({ projectName, onProjectName, conditions, sh
                 </tr>
               </thead>
               <tbody>
-                {markups.filter((m) => m.type !== "svg").map((m) => (
+                {markups.filter((m) => m.type !== "svg" && m.type !== "image").map((m) => (
                   <tr key={m.id}>
                     <td style={{ ...td, textAlign: "left" }}>
                       <span style={{ fontFamily: "var(--f-mono)", fontSize: 9.5, fontWeight: 700, letterSpacing: "0.08em", border: "1px solid var(--ink-faint)", padding: "1px 6px", color: "var(--ink-soft)" }}>

--- a/web/src/lib/canvasConstants.js
+++ b/web/src/lib/canvasConstants.js
@@ -22,6 +22,10 @@ export const QUALITY_CEILING = 8.0;                  // hard cap on render scale
 export const MAX_CANVAS_DIM  = 16384;                // safe max side for a single canvas (Chrome/Firefox/Safari desktop)
 export const MAX_CANVAS_AREA = 16384 * 16384 * 0.9;  // per-canvas pixel cap — the DETAIL view's density factor uses this
 export const MAX_PANEL_AREA  = 28e6;                 // base-raster pixel budget per panel (~112MB RGBA; 4-up ≈ 450MB)
+export const MARKUP_IMG_MAX = 1600;                  // px longest side of a stored image markup (capture AND upload downscale to this, then re-encode)
+export const MAX_IMAGE_MARKUP_BYTES = 16 * 1024 * 1024;  // aggregate cap across a project's image markups — refuse a new one that would push the annotations blob past this
+export const MARKUP_UPLOAD_MAX_BYTES = 25 * 1024 * 1024; // reject an upload FILE larger than this BEFORE decode (cheap OOM guard for a huge file)
+export const MARKUP_DECODE_MAX_AREA = 40e6;          // reject a decoded upload above ~40M px — a 1600px annotation never needs more, and this bounds the transient RGBA allocation (NOT the 241M render-canvas cap)
 // Detail view: once zoomed past the base raster's 1:1 IN DEVICE PIXELS, we overlay a
 // crop of JUST the visible region, re-rendered from the PDF vectors at the current zoom —
 // the way desktop CAD viewers do. Crispness becomes unbounded (up to the per-region canvas cap)
@@ -71,6 +75,7 @@ export const MARKUP_TOOLS = [
   { id: "highlight", icon: "highlight", label: "Highlight box" },
   // N, not M — M is the push-to-talk dictation hold, globally
   { id: "dimension", icon: "dimension", label: "Dimension line", shortcut: "N" },
+  { id: "image", icon: "image", label: "Image — marquee a region, or upload a file" },
 ];
 export const MARKUP_IDS = MARKUP_TOOLS.map((t) => t.id);
 // highlighter inks — literal hex (SVG attrs; CSS vars don't resolve there).

--- a/web/src/lib/markedset.js
+++ b/web/src/lib/markedset.js
@@ -228,7 +228,7 @@ function invertPixels(cv) {
   ctx.restore();
 }
 
-export async function buildMarkedSetPdf({ projectName, dark, sheets, shapes, markups, approvals = [], rfis = [], conditions, getPage, loadPdfData, company, clientInfo, credit = null, provenance = null, coverTitle = "Marked Set", units = "imperial" }) {
+export async function buildMarkedSetPdf({ projectName, dark, sheets, srcLabels = {}, shapes, markups, approvals = [], rfis = [], conditions, getPage, loadPdfData, company, clientInfo, credit = null, provenance = null, coverTitle = "Marked Set", units = "imperial" }) {
   // display-unit edge (lib/units contract): quantities arrive as internal feet;
   // metric converts at the drawn string only — legend rows, by-sheet rows, and
   // the per-shape chips. ASCII "m2" (Helvetica WinAnsi has no superscript 2).
@@ -803,13 +803,18 @@ export async function buildMarkedSetPdf({ projectName, dark, sheets, shapes, mar
               const x0 = m.at[0] * W - bw / 2, y0 = m.at[1] * H - bh / 2;
               const dp = imageDrawParams(toPage, x0, y0, bw, bh);
               pg.drawImage(img, { x: dp.x, y: dp.y, width: dp.width, height: dp.height, rotate: degrees(dp.rotateDeg) });
-              // Source caption (captures only; dormant until slice 4 flips source_label
-              // true) — derived EXACTLY like the canvas (sheetBaseLabelFromKey +
-              // sourceCaption), so screen and PDF read byte-identical text, and empty
-              // (stitch source, or a corrupt non-string src_sheet_id caught below) draws
-              // nothing — same suppression as the canvas.
+              // Source caption (captures only) — the ORIGIN sheet NAME. The caller
+              // (exportMarkedSet) resolves each src_sheet_id to the on-screen sheet
+              // label via srcLabels, so the PDF caption matches the canvas caption
+              // exactly. Fall back to the pure file/page derivation if a label is
+              // missing (a defensive path — also what the unit tests exercise, where
+              // no srcLabels is passed, so a stitch key still degrades to ""). Empty
+              // label ⇒ draw nothing, not an empty chip.
+              const capLabel = m.src_sheet_id != null && srcLabels[m.src_sheet_id] != null
+                ? srcLabels[m.src_sheet_id]
+                : sheetBaseLabelFromKey(m.src_sheet_id);
               const capText = m.source === "capture" && m.source_label && m.src_sheet_id
-                ? sourceCaption(sheetBaseLabelFromKey(m.src_sheet_id), parseSheetKey(m.src_sheet_id).page)
+                ? sourceCaption(capLabel, parseSheetKey(m.src_sheet_id).page)
                 : "";
               if (capText) {
                 // MIRRORS the rotated chip() path (rotate: chipRot), NOT the

--- a/web/src/lib/markedset.js
+++ b/web/src/lib/markedset.js
@@ -228,7 +228,7 @@ function invertPixels(cv) {
   ctx.restore();
 }
 
-export async function buildMarkedSetPdf({ projectName, dark, sheets, srcLabels = {}, shapes, markups, approvals = [], rfis = [], conditions, getPage, loadPdfData, company, clientInfo, credit = null, provenance = null, coverTitle = "Marked Set", units = "imperial" }) {
+export async function buildMarkedSetPdf({ projectName, dark, sheets, shapes, markups, approvals = [], rfis = [], conditions, getPage, loadPdfData, company, clientInfo, credit = null, provenance = null, coverTitle = "Marked Set", units = "imperial" }) {
   // display-unit edge (lib/units contract): quantities arrive as internal feet;
   // metric converts at the drawn string only — legend rows, by-sheet rows, and
   // the per-shape chips. ASCII "m2" (Helvetica WinAnsi has no superscript 2).
@@ -803,18 +803,16 @@ export async function buildMarkedSetPdf({ projectName, dark, sheets, srcLabels =
               const x0 = m.at[0] * W - bw / 2, y0 = m.at[1] * H - bh / 2;
               const dp = imageDrawParams(toPage, x0, y0, bw, bh);
               pg.drawImage(img, { x: dp.x, y: dp.y, width: dp.width, height: dp.height, rotate: degrees(dp.rotateDeg) });
-              // Source caption (captures only) — the ORIGIN sheet NAME. The caller
-              // (exportMarkedSet) resolves each src_sheet_id to the on-screen sheet
-              // label via srcLabels, so the PDF caption matches the canvas caption
-              // exactly. Fall back to the pure file/page derivation if a label is
-              // missing (a defensive path — also what the unit tests exercise, where
-              // no srcLabels is passed, so a stitch key still degrades to ""). Empty
-              // label ⇒ draw nothing, not an empty chip.
-              const capLabel = m.src_sheet_id != null && srcLabels[m.src_sheet_id] != null
-                ? srcLabels[m.src_sheet_id]
-                : sheetBaseLabelFromKey(m.src_sheet_id);
+              // Source caption (captures only) — the ORIGIN sheet NAME, read from the
+              // frozen m.src_label the canvas stamped at capture time, so the PDF text
+              // is the SAME string the canvas shows (no runtime label resolution here,
+              // which markedset can't do anyway). Legacy captures without src_label
+              // fall back to the pure file/page derivation. A stitch origin has no
+              // page number → drop "· p.N". Empty label ⇒ draw nothing.
+              const capLabel = m.src_label != null ? m.src_label : sheetBaseLabelFromKey(m.src_sheet_id);
+              const capPage = typeof m.src_sheet_id === "string" && m.src_sheet_id.startsWith("stitch:") ? 0 : parseSheetKey(m.src_sheet_id).page;
               const capText = m.source === "capture" && m.source_label && m.src_sheet_id
-                ? sourceCaption(capLabel, parseSheetKey(m.src_sheet_id).page)
+                ? sourceCaption(capLabel, capPage)
                 : "";
               if (capText) {
                 // MIRRORS the rotated chip() path (rotate: chipRot), NOT the

--- a/web/src/lib/markedset.js
+++ b/web/src/lib/markedset.js
@@ -38,9 +38,9 @@ export function authorTallyLine(shapes) {
 }
 import { pointInPoly, starPath, arrowheadPath, cloudBezier, chiselRibbon } from "./geometry.js";
 import { transformPath, svgPlacedBox } from "./svgpath.js";
-import { imagePlacedBox, pickEmbedFormat, imageDrawParams } from "./markupImage";
+import { imagePlacedBox, pickEmbedFormat, imageDrawParams, sourceCaption } from "./markupImage";
 import { rfiStatus } from "./rfi.js";
-import { RENDER_SCALE } from "./sheets";
+import { RENDER_SCALE, parseSheetKey, sheetBaseLabelFromKey } from "./sheets";
 import { stitchPagePlan, memberEmbed } from "./stitches";
 import { pdfDashFor, boostForDark, clampWeight } from "./lineStyles.js";
 import { dimLabel } from "./units";
@@ -803,8 +803,45 @@ export async function buildMarkedSetPdf({ projectName, dark, sheets, shapes, mar
               const x0 = m.at[0] * W - bw / 2, y0 = m.at[1] * H - bh / 2;
               const dp = imageDrawParams(toPage, x0, y0, bw, bh);
               pg.drawImage(img, { x: dp.x, y: dp.y, width: dp.width, height: dp.height, rotate: degrees(dp.rotateDeg) });
+              // Source caption (captures only; dormant until slice 4 flips source_label
+              // true) — derived EXACTLY like the canvas (sheetBaseLabelFromKey +
+              // sourceCaption), so screen and PDF read byte-identical text, and empty
+              // (stitch source, or a corrupt non-string src_sheet_id caught below) draws
+              // nothing — same suppression as the canvas.
+              const capText = m.source === "capture" && m.source_label && m.src_sheet_id
+                ? sourceCaption(sheetBaseLabelFromKey(m.src_sheet_id), parseSheetKey(m.src_sheet_id).page)
+                : "";
+              if (capText) {
+                // MIRRORS the rotated chip() path (rotate: chipRot), NOT the
+                // axis-aligned pg.drawText — this IS the rotated-page path
+                // (imageDrawParams derives anchor+rotation from toPage). But
+                // chip()'s own rectangle math sets its anchor via PAGE-POINT
+                // arithmetic on the already-mapped centroid (px - w/2, py -
+                // 5.5) and only THEN rotates the far corners around it — on a
+                // rotated source page that anchor point does not track the
+                // image at all (a pre-existing chip() issue, left alone here;
+                // see the task report). So this box is built the same way the
+                // image itself is: as an IMAGE-PX rectangle passed through
+                // imageDrawParams, which is already proven correct on rotated
+                // pages. Sizes come in as PAGE POINTS and are converted to
+                // image-px via ptScale BEFORE mapping (the same "divide by
+                // ptScale" trick already used for the offsets at :695/:707),
+                // so the gap and box stay an exact point size in the
+                // correctly rotated direction at any page rotation.
+                const textPt = 7.5, capHpt = 12, gapPt = 6;
+                const tw = font.widthOfTextAtSize(winAnsiSafe(capText), textPt) + 8;
+                const capWimg = tw / ptScale, capHimg = capHpt / ptScale, gapImg = gapPt / ptScale;
+                const capX0 = x0 + bw / 2 - capWimg / 2, capY0 = y0 - gapImg - capHimg;
+                const cdp = imageDrawParams(toPage, capX0, capY0, capWimg, capHimg);
+                pg.drawRectangle({
+                  x: cdp.x, y: cdp.y, width: cdp.width, height: cdp.height, rotate: chipRot,
+                  color: dark ? rgb(0.08, 0.1, 0.12) : rgb(1, 1, 1), opacity: 0.85,
+                  borderColor: ink, borderWidth: 0.7,
+                });
+                text(capText, capX0 + 4 / ptScale, capY0 + capHimg - 3 / ptScale, textPt, ink);
+              }
             }
-          } catch { /* corrupt image data — skip this one, never fail the whole marked set */ }
+          } catch { /* corrupt image data or a bad provenance record — skip this one, never fail the whole marked set */ }
         }
       }
     }

--- a/web/src/lib/markedset.js
+++ b/web/src/lib/markedset.js
@@ -38,6 +38,7 @@ export function authorTallyLine(shapes) {
 }
 import { pointInPoly, starPath, arrowheadPath, cloudBezier, chiselRibbon } from "./geometry.js";
 import { transformPath, svgPlacedBox } from "./svgpath.js";
+import { imagePlacedBox, pickEmbedFormat, imageDrawParams } from "./markupImage";
 import { rfiStatus } from "./rfi.js";
 import { RENDER_SCALE } from "./sheets";
 import { stitchPagePlan, memberEmbed } from "./stitches";
@@ -785,8 +786,26 @@ export async function buildMarkedSetPdf({ projectName, dark, sheets, shapes, mar
           const t = lbl(m.text);
           if (t) text(t, m.at[0] * W - bw / 2, y0 - 6 / ptScale, 8, mcol, bold);
         }
-      } else if (m.type === "text" && m.at) {
-        text(lbl(m.text), m.at[0] * W, m.at[1] * H, 8.5, mcol, bold);
+      } else if (m.type === "image" && m.at && m.src) {
+        // a raster image markup (an uploaded file, or a marquee screenshot of the
+        // sheet). drawImage takes an anchor + rotation, and imageDrawParams derives
+        // both from toPage — so the image lands correctly on ROTATED source pages
+        // too (and on the dark-raster / stitch paths, where toPage carries no
+        // rotation, it comes out axis-aligned as before). Only PNG/JPEG embed, and
+        // the store only ever mints those (pickEmbedFormat → null is a clean skip).
+        // A corrupt dataURL must not kill the export — the logo precedent, in a try.
+        const fmt = pickEmbedFormat(m.src);
+        if (fmt) {
+          try {
+            const { bw, bh } = imagePlacedBox(m.w, m.aspect, W);
+            if (bw > 0 && bh > 0) {
+              const img = fmt === "jpg" ? await doc.embedJpg(m.src) : await doc.embedPng(m.src);
+              const x0 = m.at[0] * W - bw / 2, y0 = m.at[1] * H - bh / 2;
+              const dp = imageDrawParams(toPage, x0, y0, bw, bh);
+              pg.drawImage(img, { x: dp.x, y: dp.y, width: dp.width, height: dp.height, rotate: degrees(dp.rotateDeg) });
+            }
+          } catch { /* corrupt image data — skip this one, never fail the whole marked set */ }
+        }
       }
     }
     // approval seals burn in ABOVE the markups, exactly as the canvas layers

--- a/web/src/lib/markupImage.ts
+++ b/web/src/lib/markupImage.ts
@@ -153,6 +153,18 @@ export function sourceCaption(label: string, page: number): string {
   return hasPage ? `Source: ${label} · p.${page}` : `Source: ${label}`;
 }
 
+// The Captures panel's list (slice 4): GLOBAL — every image markup in the
+// project, not filtered to the sheets currently open — narrowed by the
+// always-on name search over `text` (case-insensitive substring; an empty/
+// whitespace query returns every capture unfiltered, never an empty list).
+// Pure so the two states the panel renders (no captures at all vs. a query
+// that matches none) are node-testable without mounting React.
+export function filterCaptures<T extends { type?: string; text?: string }>(markups: readonly T[], query: string): T[] {
+  const images = markups.filter((m) => m.type === "image");
+  const q = (query || "").trim().toLowerCase();
+  return q ? images.filter((m) => (m.text || "").toLowerCase().includes(q)) : images;
+}
+
 function clamp01(n: number): number {
   if (!Number.isFinite(n)) return 0;
   return Math.min(1, Math.max(0, n));

--- a/web/src/lib/markupImage.ts
+++ b/web/src/lib/markupImage.ts
@@ -1,0 +1,148 @@
+// Pure image-markup geometry — no DOM, no deps, no Date/Math.random. Every helper
+// is total (never throws) and guards non-finite / degenerate inputs, so the risky
+// canvas/PDF integration math is node-testable in isolation (the winAnsiSafe /
+// svgPlacedBox precedent). An `image` markup is `at` (center, normalized 0..1) +
+// `w` (a fraction of sheet WIDTH) + a fixed `aspect` (= natural height / width).
+//
+// WIDTH-ANCHORED, on purpose: the placed box is `bw = w*sheetW`, `bh = bw*aspect`.
+// This is DELIBERATELY different from svgPlacedBox (svgpath.js), which scales off
+// the LONGEST viewBox extent so a symbol's longest side matches `w`. An image is
+// anchored to its width alone — so a tall image (aspect > 1) grows past `w*sheetW`
+// in height. The (0.25, 2, 800) → {200, 400} test pins that divergence.
+
+type Rect = { x0: number; y0: number; x1: number; y1: number };
+type Pt = { x: number; y: number };
+
+// Width fraction bounds — an image is 2%..200% of sheet width.
+const MIN_W = 0.02;
+const MAX_W = 2;
+
+// Placed box in target px. bw = clampedW*sheetW, bh = bw*aspect. Guard-fail →
+// {0,0} (a caller renders nothing rather than a phantom box). `w` is clamped to
+// the [MIN_W, MAX_W] rails HERE so every caller (render, hit-test, export) is
+// bounded — an imported/corrupt record with an extreme `w` can't mint a giant box.
+export function imagePlacedBox(
+  w: number,
+  aspect: number,
+  sheetW: number,
+): { bw: number; bh: number } {
+  if (!(w > 0 && Number.isFinite(w) && aspect > 0 && Number.isFinite(aspect) && Number.isFinite(sheetW))) return { bw: 0, bh: 0 };
+  const bw = clampImageWidth(w) * sheetW;
+  return { bw, bh: bw * aspect };
+}
+
+// A marquee rect (image px, any corner order) → image-markup geometry.
+// w = |x1-x0|/sheetW, aspect = |y1-y0|/|x1-x0|, at = box center normalized.
+// Degenerate width or non-finite sheet dims → {w:0, aspect:0}; at is always
+// clamped into [0,1] and finite (never NaN/Infinity).
+export function captureRectToImageGeom(
+  rect: Rect,
+  sheetW: number,
+  sheetH: number,
+): { at: [number, number]; w: number; aspect: number } {
+  const x0 = Number(rect?.x0);
+  const y0 = Number(rect?.y0);
+  const x1 = Number(rect?.x1);
+  const y1 = Number(rect?.y1);
+  const dx = Math.abs(x1 - x0);
+  const dy = Math.abs(y1 - y0);
+  const okSheet = sheetW > 0 && sheetH > 0 && Number.isFinite(sheetW) && Number.isFinite(sheetH);
+  if (!okSheet || !(dx > 0) || !Number.isFinite(dx) || !Number.isFinite(dy)) {
+    return { at: [0, 0], w: 0, aspect: 0 };
+  }
+  const midX = (x0 + x1) / 2;
+  const midY = (y0 + y1) / 2;
+  return {
+    at: [clamp01(midX / sheetW), clamp01(midY / sheetH)],
+    w: dx / sheetW,
+    aspect: dy / dx,
+  };
+}
+
+// Resize by dragging the bottom-right corner while the top-left corner (fixedTL)
+// stays put. bw = pointerX - fixedTL.x; clamp `w` FIRST, THEN derive bh and the
+// new center from the clamped box — so the top-left is invariant even at the
+// clamp rails. Cross-axis normalization is explicit: bw over sheetW, bh over
+// sheetH (a non-square sheet would expose a width/height swap otherwise).
+export function resizeImageFromCorner(
+  fixedTL: Pt,
+  pointer: Pt,
+  aspect: number,
+  sheetW: number,
+  sheetH: number,
+): { w: number; at: [number, number] } {
+  // total-function contract: bail to a safe, finite result on degenerate sheet
+  // dims or aspect rather than dividing by zero / a non-finite (the call sites
+  // always pass a real panel, but the helper guards so it can never mint NaN).
+  const tlx = Number(fixedTL?.x), tly = Number(fixedTL?.y);
+  if (!(sheetW > 0 && Number.isFinite(sheetW) && sheetH > 0 && Number.isFinite(sheetH) && aspect > 0 && Number.isFinite(aspect))) {
+    return { w: clampImageWidth(NaN), at: [0, 0] };
+  }
+  const w = clampImageWidth((Number(pointer?.x) - tlx) / sheetW);
+  const bw = w * sheetW;
+  const bh = bw * aspect;
+  // NOT clamped to [0,1]: the center may sit past the edge at the clamp rails,
+  // which is what keeps the fixed top-left corner invariant during a resize.
+  return { w, at: [(tlx + bw / 2) / sheetW, (tly + bh / 2) / sheetH] };
+}
+
+// Clamp a width fraction into [MIN_W, MAX_W]; NaN / non-finite → MIN_W.
+export function clampImageWidth(w: number): number {
+  if (!Number.isFinite(w)) return MIN_W;
+  return Math.min(MAX_W, Math.max(MIN_W, w));
+}
+
+// aspect = height / width; w<=0 or non-finite → fallback 1 (square).
+export function aspectFromDims(w: number, h: number): number {
+  if (!(w > 0) || !Number.isFinite(w) || !Number.isFinite(h)) return 1;
+  return h / w;
+}
+
+// Sniff the embeddable format from a data URL. Only PNG and JPEG round-trip
+// (the store re-encodes to one of these); everything else → null (a clean skip,
+// never an exception) for the export path and the store-time assertion.
+export function pickEmbedFormat(src: string): "jpg" | "png" | null {
+  if (typeof src !== "string") return null;
+  // EXACT media type, terminated by a `;` param or the `,` before the payload —
+  // this is a security gate (render / hit-test / export accept only what it
+  // returns), so `data:image/jpeg2000,…` must NOT read as jpeg.
+  if (/^data:image\/jpeg[;,]/.test(src)) return "jpg";
+  if (/^data:image\/png[;,]/.test(src)) return "png";
+  return null;
+}
+
+// pdf-lib drawImage parameters that place an image markup's box so its four
+// corners land exactly at `toPage(box corner)` — CORRECT ON ROTATED PAGES too.
+//
+// `toPage` (image px → PDF page points) is a similarity transform: on a plain
+// page it is a y-flip + uniform scale; on a rotated source page it also carries
+// the page's rotation; on the dark-raster and stitch paths it is a plain y-flip
+// (rotation already baked into the frame). drawImage takes a bottom-left ANCHOR
+// plus a rotation, so we reconstruct the (possibly rotated) rectangle from three
+// mapped corners: anchor at the image's bottom-left, the width axis' angle from
+// bottom-left→bottom-right, and the two side lengths measured in page points.
+// Because toPage preserves right angles and (being orientation-reversing) sends
+// the image's up-direction to +90° of its right-direction — exactly drawImage's
+// own height convention — the image never mirrors, at any page rotation.
+//
+// `toPage(x, y) => [px, py]`; the box is image px: top-left (x0, y0), size bw×bh.
+export function imageDrawParams(
+  toPage: (x: number, y: number) => [number, number] | number[],
+  x0: number,
+  y0: number,
+  bw: number,
+  bh: number,
+): { x: number; y: number; width: number; height: number; rotateDeg: number } {
+  const bl = toPage(x0, y0 + bh);          // image bottom-left  (PNG's bottom-left pixel)
+  const br = toPage(x0 + bw, y0 + bh);      // image bottom-right (the width axis' far end)
+  const tl = toPage(x0, y0);               // image top-left     (the height axis' far end)
+  const width = Math.hypot(br[0] - bl[0], br[1] - bl[1]);
+  const height = Math.hypot(tl[0] - bl[0], tl[1] - bl[1]);
+  const rotateDeg = (Math.atan2(br[1] - bl[1], br[0] - bl[0]) * 180) / Math.PI;
+  return { x: bl[0], y: bl[1], width, height, rotateDeg };
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(1, Math.max(0, n));
+}

--- a/web/src/lib/markupImage.ts
+++ b/web/src/lib/markupImage.ts
@@ -142,6 +142,17 @@ export function imageDrawParams(
   return { x: bl[0], y: bl[1], width, height, rotateDeg };
 }
 
+// Frame-hugging caption text for a source-traced capture: "Source: <label> ·
+// p.<page>". `label` empty/non-string → "" (no caption at all — the caller
+// skips rendering rather than showing a bare "Source:"). A `page` that isn't
+// a positive finite integer omits the "· p.<page>" clause instead of printing
+// a garbage page number. No Date, no deps — stays in markupImage.ts.
+export function sourceCaption(label: string, page: number): string {
+  if (typeof label !== "string" || !label) return "";
+  const hasPage = Number.isFinite(page) && page > 0 && Number.isInteger(page);
+  return hasPage ? `Source: ${label} · p.${page}` : `Source: ${label}`;
+}
+
 function clamp01(n: number): number {
   if (!Number.isFinite(n)) return 0;
   return Math.min(1, Math.max(0, n));

--- a/web/src/lib/reltime.ts
+++ b/web/src/lib/reltime.ts
@@ -1,0 +1,63 @@
+// Relative-age + explicit-UTC-timestamp formatting for the Captures panel row.
+// A UI helper (unlike markupImage.ts, whose header forbids Date) — it MAY use
+// Date/Intl. Both functions take their instant as an argument (relativeAge
+// also takes "now") so callers are deterministic and node-testable: no
+// internal `Date.now()`, no live tick (see the plan's "no live-tick" note —
+// the panel re-renders on interaction and the hover title gives the exact
+// time, so staleness between renders is accepted by design).
+//
+// Total functions: an unparseable/non-string `iso` never throws — it degrades
+// to "" so a bad/legacy record renders no age chip rather than crashing the row.
+
+// Bucket thresholds, in ms, checked against the RAW elapsed time (not the
+// rounded display value) — so e.g. "23h ago" and "yesterday" split cleanly at
+// the 24h wall-clock boundary even though rounding alone could blur it.
+const MIN_MS = 60 * 1000;
+const HOUR_MS = 60 * MIN_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+// Parse an ISO-8601 instant → epoch ms, or NaN for anything that isn't a
+// parseable string (guards both a wrong runtime type and a malformed string
+// in one place, since Date.parse only accepts a string argument usefully).
+function parseIsoMs(iso: string): number {
+  return typeof iso === "string" ? Date.parse(iso) : NaN;
+}
+
+// "Aug 25, 2026" — UTC, independent of the reader's local zone (a plan shared
+// across time zones must show the same day for the same instant).
+function formatUtcDate(ms: number): string {
+  return new Intl.DateTimeFormat("en-US", { timeZone: "UTC", month: "short", day: "numeric", year: "numeric" }).format(new Date(ms));
+}
+
+// Compact natural-language age of `iso` relative to `nowMs`:
+//  <45s → "just now" | <60m → "<n>m ago" | <24h → "<n>h ago" | <48h →
+//  "yesterday" | <7d → "<n>d ago" | else → a plain UTC date. `nowMs` is a
+// caller-supplied argument (not `Date.now()`) so a fixed epoch pins every
+// bucket boundary in tests.
+export function relativeAge(iso: string, nowMs: number): string {
+  const t = parseIsoMs(iso);
+  if (!Number.isFinite(t) || !Number.isFinite(nowMs)) return "";
+  const diffMs = nowMs - t;
+  if (diffMs / 1000 < 45) return "just now";
+  // Rounds to the nearest unit; the "min 1" floor for minutes falls out for
+  // free — every diffMs in this bucket is >= 45_000ms (0.75min), which
+  // already rounds up to 1.
+  if (diffMs < 60 * MIN_MS) return `${Math.round(diffMs / MIN_MS)}m ago`;
+  if (diffMs < DAY_MS) return `${Math.round(diffMs / HOUR_MS)}h ago`;
+  if (diffMs < 2 * DAY_MS) return "yesterday";
+  if (diffMs < 7 * DAY_MS) return `${Math.round(diffMs / DAY_MS)}d ago`;
+  return formatUtcDate(t);
+}
+
+// Explicit human timestamp with the zone spelled out — the hover `title` that
+// backs up `relativeAge`'s compact (and eventually stale) chip with the exact
+// instant. e.g. "Aug 25, 2026, 7:58 PM (UTC)". Formatted in UTC so it reads
+// the same on every machine regardless of the reader's local zone.
+export function absoluteUtc(iso: string): string {
+  const t = parseIsoMs(iso);
+  if (!Number.isFinite(t)) return "";
+  const s = new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC", month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit", hour12: true,
+  }).format(new Date(t));
+  return `${s} (UTC)`;
+}

--- a/web/src/lib/sheets.ts
+++ b/web/src/lib/sheets.ts
@@ -2,10 +2,29 @@
 // sheet-key codec, standard scales, title-block sheet numbers, drawn-scale notes.
 import * as pdfjsLib from "pdfjs-dist";
 import type { Token } from "./scheduleParse";
+import { parseSheetKey } from "./sheetKey";
+import { isStitchKey } from "./stitches";
 export { parseSheetKey, compareSheetKeys } from "./sheetKey"; // moved to a pdfjs-free module; re-exported for existing importers
 export type { ParsedSheetKey } from "./sheetKey";
 
 export const RENDER_SCALE = 2.0;
+
+// Pure fallback branch of the canvas `sheetBaseLabel` closure (TakeoffCanvas.jsx
+// `sheetBaseLabel`, ~:1001) — just the file/page math, none of the runtime-state
+// overrides (`galleryLabels`, `pageLabels`) that closure also honors. Exists so
+// the source-caption text can be computed identically on the canvas AND inside
+// markedset.js (a pure module with no access to that runtime state), keeping
+// the on-screen caption and the exported PDF caption byte-identical.
+// A stitch key resolves through `stitchById[k].name` on the canvas — state this
+// module can't see — so it deliberately returns "" for one; `sourceCaption("",
+// …)` already renders nothing, so both surfaces suppress the caption together
+// for a stitch source (screen and PDF agree: neither draws one).
+export function sheetBaseLabelFromKey(key: string): string {
+  if (typeof key !== "string" || !key || isStitchKey(key)) return "";
+  const t = parseSheetKey(key);
+  const base = t.file.replace(/\.pdf$/i, "");
+  return t.page > 1 ? `${base}-${t.page}` : base;
+}
 
 /** Side-by-side panel cap — shared by the canvas group logic and the gallery's
  * open-side-by-side gate so the two can never disagree. Hi-res sheets render at

--- a/web/src/lib/sheets.ts
+++ b/web/src/lib/sheets.ts
@@ -11,14 +11,13 @@ export const RENDER_SCALE = 2.0;
 
 // Pure fallback branch of the canvas `sheetBaseLabel` closure (TakeoffCanvas.jsx
 // `sheetBaseLabel`, ~:1001) — just the file/page math, none of the runtime-state
-// overrides (`galleryLabels`, `pageLabels`) that closure also honors. Exists so
-// the source-caption text can be computed identically on the canvas AND inside
-// markedset.js (a pure module with no access to that runtime state), keeping
-// the on-screen caption and the exported PDF caption byte-identical.
-// A stitch key resolves through `stitchById[k].name` on the canvas — state this
-// module can't see — so it deliberately returns "" for one; `sourceCaption("",
-// …)` already renders nothing, so both surfaces suppress the caption together
-// for a stitch source (screen and PDF agree: neither draws one).
+// overrides (`galleryLabels`, `pageLabels`) that closure also honors.
+// The source caption's PRIMARY label is now the frozen `src_label` stamped on each
+// capture at creation time (screen and PDF read that same stored string). This
+// helper is the DEFENSIVE fallback markedset uses only for a legacy capture that
+// predates `src_label`. It returns "" for a stitch key (whose real name lives in
+// canvas-only `stitchById` state); `sourceCaption("", …)` then renders nothing, so
+// a legacy stitch source degrades to no caption rather than to garbage.
 export function sheetBaseLabelFromKey(key: string): string {
   if (typeof key !== "string" || !key || isStitchKey(key)) return "";
   const t = parseSheetKey(key);

--- a/web/src/lib/sourceTrace.ts
+++ b/web/src/lib/sourceTrace.ts
@@ -1,0 +1,84 @@
+// Pure helpers for the ◎ source-trace mechanism (slice 3 of the Captures
+// feature). No DOM, no React, no Date/Math.random — the risky part of this
+// slice (the pendingSourceRef staleness guard) is factored here so it is
+// node-testable in isolation, matching the reltime.ts / markupImage.ts
+// precedent: every function is total (never throws) and degrades safely on
+// malformed input.
+
+// A capture's src_rect: normalized [[nx0,ny0],[nx1,ny1]] corners, in the
+// SOURCE panel's own 0..1 space (see markupImage's capture site — the rect is
+// normalized against the panel it was drawn on, not the panel it's traced
+// back to display on).
+export type NormRect = [[number, number], [number, number]];
+
+// Midpoint of a normalized rect, order-independent (works for either corner
+// order since (a+b)/2 doesn't care which corner is which). Total: a
+// malformed shape (wrong arity, non-array, non-finite numbers) degrades to
+// null rather than throwing or handing back a NaN anchor — a caller must
+// treat null as "don't arm anything for this trace" (see
+// pendingSourceOutcome's caller-side contract: validate BEFORE arming a
+// pendingSourceRef, or a malformed rect burns the whole attempt budget on a
+// trace that can never complete).
+export function rectMidpoint(rect: unknown): [number, number] | null {
+  if (!Array.isArray(rect) || rect.length !== 2) return null;
+  const [c0, c1] = rect as unknown[];
+  if (!Array.isArray(c0) || !Array.isArray(c1) || c0.length !== 2 || c1.length !== 2) return null;
+  const [x0, y0] = c0 as unknown[];
+  const [x1, y1] = c1 as unknown[];
+  const nums = [x0, y0, x1, y1];
+  if (!nums.every((n) => typeof n === "number" && Number.isFinite(n))) return null;
+  return [((x0 as number) + (x1 as number)) / 2, ((y0 as number) + (y1 as number)) / 2];
+}
+
+// A pending source-trace: the sheet named `sheet_id` was opened this tick but
+// its panel bitmap isn't ready yet, so the phase-2 effect keeps re-checking
+// until it is. Unlike pendingFlyRef (which carries a markup id it can
+// re-validate against the live markups array), this carries no markup id —
+// there IS no markup on the source sheet, only a synthetic rect — so it
+// cannot ask "does the thing I'm waiting for still exist?" the same way.
+export interface PendingSourceRef {
+  sheet_id: string;
+  rect: NormRect;
+  token: number;
+  attempts: number;
+}
+
+export type PendingSourceOutcome =
+  | { action: "give-up" }
+  | { action: "wait"; attempts: number }
+  | { action: "complete" };
+
+// Backstop attempt cap. This is deliberately NOT the primary guard — the
+// primary guards are status==="error" and the source sheet no longer
+// resolving to a real sheet (both computed by the caller from live state and
+// passed in as ctx.status / ctx.sheetIsLive, since this module has no access
+// to the sheets/stitches list). This cap only matters when something keeps
+// nudging the effect's deps (panelImgs/groupSig/status) without the target
+// sheet's render ever actually finishing — the scenario the plan calls out
+// as the latent view-teleport: a pendingSourceRef with no markup id to
+// validate against, sitting armed forever, ready to fire a stale
+// center+flash the next time its target sheet happens to render for an
+// unrelated reason.
+export const MAX_SOURCE_TRACE_ATTEMPTS = 30;
+
+// The single decision point for the pendingSourceRef phase-2 effect. Pure:
+// given the ref and a snapshot of the three facts that matter (load status,
+// whether the target sheet key still resolves to something real, whether its
+// panel bitmap is ready), decide what the effect should do this tick. The
+// effect owns the actual centering/flashing/ref-mutation; this function only
+// picks the outcome, so the "never left set on a terminal outcome" claim is
+// checkable by reading this one function instead of tracing the effect body.
+export function pendingSourceOutcome(
+  ref: PendingSourceRef | null,
+  ctx: { status: string; sheetIsLive: boolean; panelReady: boolean },
+): PendingSourceOutcome | null {
+  if (!ref) return null;
+  // terminal guards first — either one ends the trace regardless of how far
+  // along `attempts` is, so a doomed trace doesn't wait out its own budget
+  if (ctx.status === "error") return { action: "give-up" };
+  if (!ctx.sheetIsLive) return { action: "give-up" };
+  if (ctx.status === "ready" && ctx.panelReady) return { action: "complete" };
+  const attempts = ref.attempts + 1;
+  if (attempts >= MAX_SOURCE_TRACE_ATTEMPTS) return { action: "give-up" };
+  return { action: "wait", attempts };
+}

--- a/web/src/lib/sourceTrace.ts
+++ b/web/src/lib/sourceTrace.ts
@@ -82,3 +82,23 @@ export function pendingSourceOutcome(
   if (attempts >= MAX_SOURCE_TRACE_ATTEMPTS) return { action: "give-up" };
   return { action: "wait", attempts };
 }
+
+// ── Captures panel row (slice 4) — the ◎ button's gate + label ─────────────
+// The panel row wires the ◎ button (and the caption toggle, same gate) to
+// this pair. Captures only, and only once the origin is known: legacy
+// pre-slice-1 image markups and uploads both have no src_sheet_id (uploads
+// are source==="upload"), so BOTH halves of the check matter — a lone
+// `src_sheet_id !== sheet_id` would be true for an upload's undefined vs its
+// real sheet_id and light up a button that has nothing to trace.
+export function isTraceable(m: { source?: string; src_sheet_id?: string | null } | null | undefined): boolean {
+  return !!m && m.source === "capture" && !!m.src_sheet_id;
+}
+
+// The ◎ button's label. When the capture has moved off the sheet it was
+// captured on, name the origin so "captured on A, now on B" reads without a
+// hover ("◎ from A"); otherwise the terse "◎ Source". Callers must only call
+// this once isTraceable(m) is true — it doesn't re-check the gate itself,
+// since the caller already has both ids in hand at that point.
+export function traceLabel(srcSheetId: string, currentSheetId: string, srcBaseLabel: string): string {
+  return srcSheetId !== currentSheetId ? `◎ from ${srcBaseLabel}` : "◎ Source";
+}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -6683,22 +6683,38 @@ export default function TakeoffCanvas() {
     } catch { setCommitMsg("Couldn't capture that region."); return; }
     const { at, w, aspect } = captureRectToImageGeom({ x0, y0, x1, y1 }, panel.img.w, panel.img.h);
     if (!(w > 0)) return;
+    // FROZEN origin label. sheetBaseLabel resolves a detected sheet number only for
+    // the ACTIVE file (or an already gallery-scanned sheet); on the non-active panel
+    // of a multi-FILE side-by-side group it would fall back to the file base. Since
+    // that panel is rendered here anyway, scan its title block NOW (the same
+    // extractSheetNumber the active-file scan at ~:2056 uses) so the frozen number is
+    // real — but only when it isn't already known, and only as a best-effort upgrade:
+    // a null result (unusual title block) keeps the file-base fallback, never worse.
+    let srcLabel = sheetBaseLabel(panel.key);
+    const pk = parseSheetKey(panel.key);
+    const labelKnown = isStitchKey(panel.key) || !!galleryLabels[panel.key] || (pk.file === active && !!pageLabels[pk.page]);
+    if (!labelKnown) {
+      try {
+        const lbl = extractSheetNumber(await pageObj.getTextContent(), pageObj.getViewport({ scale: RENDER_SCALE }));
+        if (lbl) srcLabel = lbl;
+      } catch { /* title block unreadable — keep the file-base fallback */ }
+    }
     // Capture-only provenance fields (uploads have no source, so addImageFromFile
     // omits them): src_sheet_id is the ORIGIN sheet (sheet_id tracks where the
     // image currently lives and moves on a cross-sheet place — see imageProvenance
     // below). src_rect reuses the ALREADY-CLAMPED x0..y1 above, NOT the raw marquee
     // corners a/b (they carry xOffset and are unclamped) and NOT bw/bh (the 1600px
     // capture raster size) — normalizing by those would silently drift the traced
-    // region off the real source box. src_label FREEZES the origin sheet's display
-    // name at capture time (panel.key is the active sheet here, so sheetBaseLabel
-    // resolves the real "AF101"): both the canvas caption and the marked-set PDF
-    // read this stored string, so they can never diverge on runtime label state
-    // (which sheetBaseLabel derives only for the currently-active file).
+    // region off the real source box. src_label is the FROZEN origin sheet name,
+    // resolved just above (sheetBaseLabel, upgraded via a title-block scan when the
+    // number isn't cached for a non-active side-by-side file): both the canvas caption
+    // and the marked-set PDF read this stored string, so they can never diverge on
+    // runtime label state (which sheetBaseLabel derives only for the active file).
     addImageMarkup({
       at, w, aspect, src, source: "capture",
       src_sheet_id: panel.key,
       src_rect: [[x0 / panel.img.w, y0 / panel.img.h], [x1 / panel.img.w, y1 / panel.img.h]],
-      src_label: sheetBaseLabel(panel.key),
+      src_label: srcLabel,
       source_label: false,
     }, panel.key);
   }

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -25,8 +25,9 @@ import { getFocusMode, toggleFocusMode, onFocusModeChange } from "../lib/focusMo
 import { seedStampLibrary, instantiateStamp, markupToStampElement } from "../lib/stamps.js";
 import { extractSvgPrimitives, svgToStamp } from "../lib/svgImport.js";
 import { transformPath, svgPlacedBox } from "../lib/svgpath.js";
-import { imagePlacedBox, captureRectToImageGeom, resizeImageFromCorner, aspectFromDims, pickEmbedFormat, sourceCaption } from "../lib/markupImage";
-import { rectMidpoint, pendingSourceOutcome } from "../lib/sourceTrace";
+import { imagePlacedBox, captureRectToImageGeom, resizeImageFromCorner, aspectFromDims, pickEmbedFormat, sourceCaption, filterCaptures } from "../lib/markupImage";
+import { rectMidpoint, pendingSourceOutcome, isTraceable, traceLabel } from "../lib/sourceTrace";
+import { relativeAge, absoluteUtc } from "../lib/reltime";
 import { ingestFiles } from "../lib/ingest.js";
 import { parseTakeoffImport, mergeTakeoffImport } from "../lib/importTakeoff.js";
 import { buildProjectArchive, parseProjectArchive, isProjectArchive, downloadArchive } from "../lib/projectArchive.js";
@@ -336,6 +337,7 @@ export default function TakeoffCanvas() {
   const [showMarkups, setShowMarkups] = useState(true);       // markup SVG layer visibility (orthogonal to the export checkbox)
   const [editor, setEditor] = useState(null);                 // inline on-canvas text editor { left, top, value, multiline, commit } (retires window.prompt; screen-space overlay, NOT an SVG child)
   const [panelEditId, setPanelEditId] = useState(null);       // markup id whose text is being edited inline in the markup panel (off-screen fallback for the ✎ button)
+  const [captureQuery, setCaptureQuery] = useState("");       // always-on name filter over the GLOBAL Captures list (transient, mirrors condQuery)
   // Stamp library (browser-global, meta store) — reusable annotation stamps
   // dropped click-to-place (#40). armedStamp holds the stamp picked from the
   // palette; while tool==="stamp" each canvas click instantiates it as normal,
@@ -8131,16 +8133,7 @@ export default function TakeoffCanvas() {
                  {/* layer show/hide — hides the on-canvas markup layer AND its hit-testing
                      (can't select/delete/fly-to an invisible markup); orthogonal to the
                      marked-set export, which still includes markups. */}
-                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "6px 10px", borderBottom: "1px solid var(--ink-faint)" }}>
-                   {/* hidden input reused by the Upload button — re-encoded through addImageFromFile */}
-                   <input name="markup-image-file" ref={imageInputRef} type="file" accept="image/*" style={{ display: "none" }}
-                     onChange={(e) => { const f = e.target.files?.[0]; if (f) addImageFromFile(f); e.target.value = ""; }} />
-                   <button
-                     onClick={() => imageInputRef.current?.click()}
-                     title="Upload a raster image (PNG or JPEG) as a floating annotation on the current sheet"
-                     style={{ background: "transparent", border: "1px solid var(--ink-faint)", color: "var(--ink)", fontSize: 11, cursor: "pointer", padding: "2px 7px" }}>
-                     Upload image…
-                   </button>
+                 <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", padding: "6px 10px", borderBottom: "1px solid var(--ink-faint)" }}>
                    <button
                      onClick={() => { const nv = !showMarkups; setShowMarkups(nv); if (!nv) setSelectedMarkupId(null); }}
                      title={showMarkups ? "Hide the markup layer on the canvas" : "Show the markup layer on the canvas"}
@@ -8149,12 +8142,15 @@ export default function TakeoffCanvas() {
                    </button>
                  </div>
                  <div style={{ padding: "8px 10px", color: "var(--ink-muted)" }}>
-                   Pick <b>☁ Cloud</b>, <b>▨ Highlight</b>, <b>💬 Callout</b>, <b>T Text</b>, or <b>⟷ Dimension</b> above, then click the plan to annotate it. <b>🖼 Image</b> marquees a region (two clicks) — or use <b>Upload image…</b> above.
+                   Pick <b>☁ Cloud</b>, <b>▨ Highlight</b>, <b>💬 Callout</b>, <b>T Text</b>, or <b>⟷ Dimension</b> above, then click the plan to annotate it. <b>🖼 Image</b> marquees a region (two clicks) — or use <b>Upload image…</b> in Captures below.
                  </div>
-                 {markups.filter((m) => panelKeySet.has(m.sheet_id)).length === 0 && (
-                   <div style={{ padding: "4px 12px 14px", color: "var(--ink-muted)" }}>No markups {groupKeys.length > 1 ? "on these sheets" : "on this sheet"} yet.</div>
+                 {markups.filter((m) => panelKeySet.has(m.sheet_id) && m.type !== "image").length === 0 && (
+                   <div style={{ padding: "4px 12px 14px", color: "var(--ink-muted)" }}>
+                     No markups {groupKeys.length > 1 ? "on these sheets" : "on this sheet"} yet.
+                     <div style={{ marginTop: 4, fontSize: 11 }}>Images now live in <b>Captures</b> below.</div>
+                   </div>
                  )}
-                 {markups.filter((m) => panelKeySet.has(m.sheet_id)).map((m) => (
+                 {markups.filter((m) => panelKeySet.has(m.sheet_id) && m.type !== "image").map((m) => (
                    <div key={m.id} style={{ padding: "10px 12px", borderTop: "1px solid var(--ink-faint)", background: selectedMarkupId === m.id ? "var(--surface-pop)" : "transparent" }}>
                      {/* the header line selects + flies to the markup (parity with the RFI
                          register's onFlyTo) — the inner controls stopPropagation so only the
@@ -8266,6 +8262,159 @@ export default function TakeoffCanvas() {
                      })()}
                    </div>
                  ))}
+                 {/* Captures — a GLOBAL image-markup library, every sheet, NOT
+                     filtered to the panels open right now (unlike the per-sheet
+                     list above): that global-ness is the whole point of the
+                     feature — find, re-place, trace, or caption any capture
+                     regardless of which sheet is open. Uploads live here too
+                     (no source fields, so ◎ and the caption toggle are hidden
+                     — see isTraceable). */}
+                 <div style={{ borderTop: "2px solid var(--ink-faint)" }}>
+                   <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "6px 10px", borderBottom: "1px solid var(--ink-faint)", gap: 8 }}>
+                     <span style={{ fontSize: 10.5, fontWeight: 700, color: "var(--ink-muted)", textTransform: "uppercase", letterSpacing: "0.06em" }}>Captures</span>
+                     {/* hidden input reused by the Upload button — re-encoded through addImageFromFile */}
+                     <input name="markup-image-file" ref={imageInputRef} type="file" accept="image/*" style={{ display: "none" }}
+                       onChange={(e) => { const f = e.target.files?.[0]; if (f) addImageFromFile(f); e.target.value = ""; }} />
+                     <button
+                       onClick={() => imageInputRef.current?.click()}
+                       title="Upload a raster image (PNG or JPEG) as a floating annotation on the current sheet"
+                       style={{ background: "transparent", border: "1px solid var(--ink-faint)", color: "var(--ink)", fontSize: 11, cursor: "pointer", padding: "2px 7px" }}>
+                       Upload image…
+                     </button>
+                   </div>
+                   {/* always-on name search — mirrors the condQuery idiom
+                       (TakeoffsPanel ~:718/763/1054-1056) */}
+                   <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "6px 10px", borderBottom: "1px solid var(--ink-faint)" }}>
+                     <input name="capture-filter" value={captureQuery} onChange={(e) => setCaptureQuery(e.target.value)} placeholder="filter captures…"
+                       style={{ flex: 1, minWidth: 0, padding: "4px 8px", borderRadius: 0, border: "1px solid var(--ink-faint)", fontSize: 12 }} />
+                     {captureQuery && <button onClick={() => setCaptureQuery("")} title="Clear the filter" style={{ border: "none", background: "none", color: "var(--ink-muted)", cursor: "pointer", fontSize: 13, padding: 0 }}>×</button>}
+                   </div>
+                   {(() => {
+                     const allCaptures = filterCaptures(markups, "");
+                     const captures = filterCaptures(markups, captureQuery);
+                     if (allCaptures.length === 0) {
+                       return <div style={{ padding: "4px 12px 14px", color: "var(--ink-muted)" }}>No captures yet. Marquee a region with 🖼 or use Upload image… above.</div>;
+                     }
+                     if (captures.length === 0) {
+                       return <div style={{ padding: "4px 12px 14px", color: "var(--ink-muted)" }}>No captures match “{captureQuery}”.</div>;
+                     }
+                     return captures.map((m) => {
+                       // Captures-only gate for ◎ + the caption toggle — legacy
+                       // pre-slice-1 images and uploads both lack src_sheet_id.
+                       const traceable = isTraceable(m);
+                       return (
+                         <div key={m.id} style={{ padding: "10px 12px", borderTop: "1px solid var(--ink-faint)", background: selectedMarkupId === m.id ? "var(--surface-pop)" : "transparent" }}>
+                           {/* header line — thumb, name(✎), sheet badge, age,
+                               Place, ◎ trace, caption toggle, delete. Mirrors the
+                               per-sheet row's click-to-fly / stopPropagation
+                               pattern above. */}
+                           <div onClick={() => flyToMarkup(m)} title={imageProvenance(m)} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", flexWrap: "wrap" }}>
+                             {(() => {
+                               const th = ensureThumb(m);
+                               return <span style={{ flex: "0 0 auto", width: 30, height: 30, border: "1px solid var(--ink-faint)", background: "var(--paper-bright)", display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden" }}>
+                                 {th ? <img src={th} alt="" style={{ maxWidth: "100%", maxHeight: "100%", display: "block" }} /> : <span style={{ fontSize: 14 }}>🖼</span>}
+                               </span>;
+                             })()}
+                             {panelEditId === m.id ? (
+                               <input name="capture-text" autoComplete="off" autoFocus defaultValue={m.text || ""}
+                                 onClick={(e) => e.stopPropagation()}
+                                 onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); updateMarkup(m.id, { text: e.currentTarget.value.trim() }); setPanelEditId(null); } else if (e.key === "Escape") { e.preventDefault(); e.currentTarget.value = m.text || ""; setPanelEditId(null); } }}
+                                 onBlur={(e) => { updateMarkup(m.id, { text: e.currentTarget.value.trim() }); setPanelEditId(null); }}
+                                 style={{ flex: 1, minWidth: 0, fontSize: 12.5, padding: "1px 4px", border: "1px solid var(--cobalt)", borderRadius: 0, outline: "none" }} />
+                             ) : (
+                               <span style={{ flex: "0 1 auto", minWidth: 0, color: "var(--ink)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{m.text || <em style={{ color: "var(--ink-muted)" }}>(no name)</em>}</span>
+                             )}
+                             <button onClick={(e) => { e.stopPropagation(); setPanelEditId((id) => (id === m.id ? null : m.id)); }} title="Edit name" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--ink-muted)" }}>✎</button>
+                             <span style={{ color: "var(--ink-faint)" }}>·</span>
+                             <span title={`Currently on ${sheetBaseLabel(m.sheet_id)}`} style={{ fontSize: 10.5, color: "var(--ink-muted)", padding: "1px 6px", border: "1px solid var(--ink-faint)", borderRadius: 4, background: "var(--paper-cream)", whiteSpace: "nowrap" }}>{sheetBaseLabel(m.sheet_id)}</span>
+                             {/* legacy/imported captures can predate created_at (see
+                                 imageProvenance's own guard on the same field) — a
+                                 blank relativeAge must not leave a dangling "·" */}
+                             {(() => {
+                               const age = relativeAge(m.created_at, Date.now());
+                               return age ? (
+                                 <>
+                                   <span style={{ color: "var(--ink-faint)" }}>·</span>
+                                   <span style={{ fontSize: 10.5, color: "var(--ink-muted)", whiteSpace: "nowrap" }} title={absoluteUtc(m.created_at)}>{age}</span>
+                                 </>
+                               ) : null;
+                             })()}
+                             <button onClick={(e) => { e.stopPropagation(); beginPlace(m); }} title={panelKeySet.has(m.sheet_id) ? "Reposition: centers the view on the image, then it follows the cursor — click the sheet to drop it" : "Place this image on the current sheet — it follows the cursor until you click to drop it"} style={{ border: "1px solid var(--ink-faint)", background: placingImageId === m.id ? "var(--cobalt)" : "transparent", color: placingImageId === m.id ? "#fff" : "var(--cobalt)", cursor: "pointer", fontSize: 11, padding: "1px 7px" }}>Place</button>
+                             {traceable && (
+                               <button onClick={(e) => { e.stopPropagation(); traceSource(m); }} title="Jump to the source sheet and flash the captured region" style={{ border: "1px solid var(--ink-faint)", background: "transparent", color: "var(--cobalt)", cursor: "pointer", fontSize: 11, padding: "1px 7px", whiteSpace: "nowrap" }}>
+                                 {traceLabel(m.src_sheet_id, m.sheet_id, sheetBaseLabel(m.src_sheet_id))}
+                               </button>
+                             )}
+                             {traceable && (
+                               <button onClick={(e) => { e.stopPropagation(); updateMarkup(m.id, { source_label: !m.source_label }); }}
+                                 title="Show/Hide the source caption on the image"
+                                 style={{ padding: "2px 7px", border: `1px solid ${m.source_label ? "var(--cobalt)" : "var(--ink-faint)"}`, background: m.source_label ? "var(--cobalt)" : "transparent", color: m.source_label ? "var(--paper-bright)" : "var(--ink-muted)", cursor: "pointer", fontSize: 10.5, fontFamily: "var(--f-mono)", lineHeight: 1.4 }}>
+                                 caption
+                               </button>
+                             )}
+                             <button onClick={(e) => { e.stopPropagation(); deleteMarkup(m.id); }} title="Delete capture" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--c-danger)" }}>🗑</button>
+                           </div>
+                           {/* Condition link — identical block to the per-sheet row's
+                               (8211–8235 pre-slice-4); keys off `m` and works for any
+                               markup type, captures included. */}
+                           {(() => {
+                             const lc = m.condition_id ? condById[m.condition_id] : null;
+                             const ctrl = { padding: "2px 7px", border: "1px solid var(--ink-faint)", background: "transparent", cursor: "pointer", fontSize: 11 };
+                             return (
+                               <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 7, flexWrap: "wrap" }}>
+                                 {lc ? (
+                                   <>
+                                     <span title={`Annotation is about ${lc.finish_tag}`}
+                                       style={{ display: "inline-flex", alignItems: "center", gap: 5, fontFamily: "var(--f-mono)", fontSize: 11, fontWeight: 700 }}>
+                                       <span style={{ width: 9, height: 9, background: lc.color, border: "1px solid var(--ink-faint)" }} />
+                                       {lc.finish_tag}
+                                     </span>
+                                     <button onClick={() => { setActiveCond(lc.id); }} style={{ ...ctrl, color: "var(--cobalt)" }} title="Make this the active condition">Select</button>
+                                     <button onClick={() => unlinkCondition(m)} style={{ ...ctrl, color: "var(--ink-muted)" }} title="Detach this annotation from its condition">Detach</button>
+                                   </>
+                                 ) : conditions.length > 0 && (
+                                   <select name="link-condition" value="" onChange={(e) => { if (e.target.value) linkCondition(m, e.target.value); }}
+                                     title="Attach this annotation to a condition" style={{ ...ctrl, background: "var(--paper-bright)", maxWidth: 170 }}>
+                                     <option value="">Attach to condition…</option>
+                                     {conditions.map((c) => <option key={c.id} value={c.id}>{c.finish_tag}</option>)}
+                                   </select>
+                                 )}
+                               </div>
+                             );
+                           })()}
+                           {/* RFI controls — identical block to the per-sheet row's
+                               (8237–8262 pre-slice-4). */}
+                           {(() => {
+                             const linked = m.rfi_id ? rfis.find((r) => r.id === m.rfi_id) : null;
+                             const ctrl = { padding: "2px 7px", border: "1px solid var(--ink-faint)", background: "transparent", cursor: "pointer", fontSize: 11 };
+                             return (
+                               <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 7, flexWrap: "wrap" }}>
+                                 {linked ? (
+                                   <>
+                                     <span style={{ fontFamily: "var(--f-mono)", fontSize: 11, fontWeight: 700, color: "var(--cobalt)" }}>⬢ {String(linked.number ?? "")}</span>
+                                     <button onClick={() => { setLeftTab("rfi"); }} style={{ ...ctrl, color: "var(--cobalt)" }} title="Open the RFI register">Open</button>
+                                     <button onClick={() => unlinkRfi(m)} style={{ ...ctrl, color: "var(--ink-muted)" }} title="Unlink this markup from its RFI">Unlink</button>
+                                   </>
+                                 ) : (
+                                   <>
+                                     <button onClick={() => raiseRfi(m)} style={{ ...ctrl, color: "var(--cobalt)", fontWeight: 600 }} title="Create a new RFI from this markup">Raise RFI</button>
+                                     {rfis.length > 0 && (
+                                       <select name="link-rfi" value="" onChange={(e) => { if (e.target.value) linkRfi(m, e.target.value); }}
+                                         title="Link this markup to an existing RFI" style={{ ...ctrl, background: "var(--paper-bright)", maxWidth: 150 }}>
+                                         <option value="">Link existing…</option>
+                                         {rfis.map((r) => <option key={r.id} value={r.id}>{r.number}{r.subject ? ` · ${r.subject}` : ""}</option>)}
+                                       </select>
+                                     )}
+                                   </>
+                                 )}
+                               </div>
+                             );
+                           })()}
+                         </div>
+                       );
+                     });
+                   })()}
+                 </div>
                </div>
              )}
              {leftTab === "stamp" && (

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -26,6 +26,7 @@ import { seedStampLibrary, instantiateStamp, markupToStampElement } from "../lib
 import { extractSvgPrimitives, svgToStamp } from "../lib/svgImport.js";
 import { transformPath, svgPlacedBox } from "../lib/svgpath.js";
 import { imagePlacedBox, captureRectToImageGeom, resizeImageFromCorner, aspectFromDims, pickEmbedFormat, sourceCaption } from "../lib/markupImage";
+import { rectMidpoint, pendingSourceOutcome } from "../lib/sourceTrace";
 import { ingestFiles } from "../lib/ingest.js";
 import { parseTakeoffImport, mergeTakeoffImport } from "../lib/importTakeoff.js";
 import { buildProjectArchive, parseProjectArchive, isProjectArchive, downloadArchive } from "../lib/projectArchive.js";
@@ -655,6 +656,14 @@ export default function TakeoffCanvas() {
   const selectShape = (id) => { setSelectedId(id); setSelectedMarkupId(null); };
   const selectMarkup = (id) => { setSelectedMarkupId(id); setSelectedId(null); };
   const pendingFlyRef = useRef(null);   // fly-to target whose sheet is opening this tick (two-phase center once its bitmap loads)
+  // Source-trace (◎) equivalent of pendingFlyRef: { sheet_id, rect, token, attempts }
+  // for a trace whose SOURCE sheet is opening this tick. Unlike pendingFlyRef it
+  // carries no markup id to re-validate against — there's no markup on the source
+  // sheet, only a synthetic rect — so it is self-limiting via `attempts` (see the
+  // phase-2 effect below and lib/sourceTrace's pendingSourceOutcome, the "never
+  // leave a stale trace armed" guard the plan calls the riskiest part of this slice).
+  const pendingSourceRef = useRef(null);
+  const sourceTraceSeqRef = useRef(0);  // monotonic token minter for sourceFlash — see traceSource
 
   const [snapOn, setSnapOn] = useState(false);   // snap-to-vector (beta) — off until calibrated on real plans
   const [angleOn, setAngleOn] = useState(true);  // 45°/90° angle guides (polar tracking) — on by default; ⇧ = hard lock
@@ -714,6 +723,14 @@ export default function TakeoffCanvas() {
   const [imageAnchor, setImageAnchor] = useState(null);       // first marquee corner for the "image" screenshot tool, isolated like scheduleAnchor/symbolAnchor
   const [placingImageId, setPlacingImageId] = useState(null); // an image markup being (re)placed: it follows the cursor until the next click drops it (re-enterable from the panel, not just at capture)
   const placeGrabRef = useRef(null);                          // {key, dx, dy}: cursor→image-centre offset captured on the pointer's FIRST canvas contact during a place, so the image is grabbed where it sits (no teleport) and moves relative after
+  // Cross-sheet place flag: holds the markup id when beginPlace (below) armed
+  // placement for an image whose CURRENT sheet ISN'T the one now open. Carries
+  // that decision to onPointerMove's first-contact grab (~3686), which runs
+  // frames later — by then `sheet_id` may already have been rewritten to the
+  // panel it first touched, so re-reading it there is unreliable. Keyed on the
+  // markup id (not a bare boolean) so a second Place on a DIFFERENT markup can't
+  // inherit a stale flag. Cleared everywhere placeGrabRef is cleared.
+  const placeCrossSheetRef = useRef(null);
   const [imgThumbs, setImgThumbs] = useState({});             // markupId → tiny JPEG dataURL for the panel row — memory-only, built once per image, NEVER persisted (a 40px <img> of a full 1600px src would decode the whole bitmap and eat the byte budget)
   const thumbBuildingRef = useRef(new Set());                 // ids with a thumb build in flight (dedupe the async decode)
   const [sweep, setSweep] = useState(null);                   // the live review: matches / questions / seed, one sheet, dies on commit or discard
@@ -2191,6 +2208,52 @@ export default function TakeoffCanvas() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panelImgs, groupSig, status]);
 
+  // source-trace (◎) phase 2 — mirrors the fly-to phase-2 effect above, but
+  // pendingSourceRef has no markup id to re-validate against (there's no markup
+  // on the source sheet, only a synthetic {sheet_id, rect}), so it leans on
+  // pendingSourceOutcome's three guards instead: status==="error", the source
+  // sheet key no longer resolving to a real sheet (deleted file / bad key —
+  // same liveness test the sheetGroup-pruning effect uses), or a bounded
+  // attempt-budget cap. Every branch below either re-arms `attempts` or nulls
+  // the ref — it is NEVER left set past a terminal outcome (give-up or
+  // complete), which is the plan's central risk for this slice.
+  useEffect(() => {
+    const p = pendingSourceRef.current;
+    if (!p) return;
+    const sheetIsLive = isStitchKey(p.sheet_id)
+      ? !!stitchById[p.sheet_id] && stitchAlive(stitchById[p.sheet_id], new Set(sheets.map((s) => s.name)))
+      : sheets.some((s) => s.name === parseSheetKey(p.sheet_id).file);
+    const sp = panelKeySet.has(p.sheet_id) ? panels.find((pp) => pp.key === p.sheet_id) : null;
+    const outcome = pendingSourceOutcome(p, { status, sheetIsLive, panelReady: !!sp?.img?.w });
+    if (outcome.action === "give-up") { pendingSourceRef.current = null; return; }
+    if (outcome.action === "wait") { pendingSourceRef.current = { ...p, attempts: outcome.attempts }; return; }
+    // action === "complete": the rect was already validated (non-null midpoint)
+    // when traceSource armed this ref, but re-check rather than trust a ref that
+    // sat around — cheap, and keeps this path total on its own.
+    const mid = rectMidpoint(p.rect);
+    if (mid && centerOnPanelPoint(sp, mid[0], mid[1])) setSourceFlash({ sheet_id: p.sheet_id, rect: p.rect, token: p.token });
+    pendingSourceRef.current = null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelImgs, groupSig, status]);
+
+  // A flash belongs to whichever sheet it's currently drawn on (the render site
+  // keys it to `sourceFlash.sheet_id === p.key`, per-panel). Once that sheet
+  // leaves the open set — tab closed, group changed, navigated away — clear it
+  // rather than let it sit armed: the panel's <g> unmounts and remounts on
+  // return, and a CSS keyframes animation restarts on mount, so a stale
+  // sourceFlash would silently re-pulse on a LATER, unrelated visit to that
+  // sheet. MUST be a functional updater, not a closure read of `sourceFlash`:
+  // the pendingSourceRef effect above can, in the SAME batch that just changed
+  // groupSig, call setSourceFlash(newFlash) for the sheet that just finished
+  // opening — a closure-captured `sourceFlash` here would still be the OLD
+  // (now off-panel) value and null out the flash that was just set, in the
+  // same flush, before it ever painted. Reading `f` at apply time instead of
+  // closure time avoids that race.
+  useEffect(() => {
+    setSourceFlash((f) => (f && !panelKeySet.has(f.sheet_id) ? null : f));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupSig]);
+
   // ── autosave (debounced) ──────────────────────────────────────────────────
   // buildPayload is the single serializer — autosave and snapshots must write
   // identical records for the same state (byte-stability matters downstream).
@@ -2794,7 +2857,7 @@ export default function TakeoffCanvas() {
         // tool's points, on-screen or hidden
         else if (tool === "calibrate") { setCalib((c) => c.slice(0, -1)); }
         else if (tool === "check") { setCheck((c) => c.slice(0, -1)); }
-      } else if (e.key === "Escape") { if (agentOfferFnsRef.current?.pending()) { agentOfferFnsRef.current.dismiss(); } else if (ocSel) { setOcSel(null); } else if (selVert != null) { setSelVert(null); } else { clearPoly(); setCalib([]); setCheck([]); setCheckStated(""); setScaleGuide(null); selectShape(null); setMarkupDraft(null); setProposal(null); setArmedStamp(null); setScheduleAnchor(null); setSymbolAnchor(null); setImageAnchor(null); setPlacingImageId(null); placeGrabRef.current = null; setAlignPt(null); resetZone(); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; } }
+      } else if (e.key === "Escape") { if (agentOfferFnsRef.current?.pending()) { agentOfferFnsRef.current.dismiss(); } else if (ocSel) { setOcSel(null); } else if (selVert != null) { setSelVert(null); } else { clearPoly(); setCalib([]); setCheck([]); setCheckStated(""); setScaleGuide(null); selectShape(null); setMarkupDraft(null); setProposal(null); setArmedStamp(null); setScheduleAnchor(null); setSymbolAnchor(null); setImageAnchor(null); setPlacingImageId(null); placeGrabRef.current = null; placeCrossSheetRef.current = null; setAlignPt(null); resetZone(); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; } }
       // ⌘Z: the drawing context wins — mid-trace it still pops the last placed
       // point (with or without ⇧, matching the old behavior byte-for-byte);
       // only with no trace in progress does the command stack engage
@@ -2865,6 +2928,7 @@ export default function TakeoffCanvas() {
       const id = placingImageId;
       setPlacingImageId(null);
       placeGrabRef.current = null;
+      placeCrossSheetRef.current = null;
       // Commit boundary for the place gesture (onPointerMove's centre-follow at
       // :3676 is the live PREVIEW and must stay unstamped): stamp updated_at here
       // so a cross-sheet place isn't silently reverted by a 3-way sync tie
@@ -3685,9 +3749,19 @@ export default function TakeoffCanvas() {
       if (tp?.img?.w) {
         const cx = (q[0] - tp.xOffset) / tp.img.w, cy = q[1] / tp.img.h;
         if (!placeGrabRef.current || placeGrabRef.current.key !== tp.key) {
-          const m0 = markups.find((m) => m.id === placingImageId);
-          const ax = m0 && Array.isArray(m0.at) ? m0.at[0] : cx, ay = m0 && Array.isArray(m0.at) ? m0.at[1] : cy;
-          placeGrabRef.current = { key: tp.key, dx: ax - cx, dy: ay - cy };
+          // cross-sheet place (flagged at Place-button time in placeCrossSheetRef,
+          // not by re-reading the markup's sheet_id here — it may already have
+          // been rewritten to tp.key by an earlier contact this same gesture):
+          // the image's stored `at` is a position on the OTHER sheet and means
+          // nothing here, so zero the offset and let it center under the cursor
+          // instead of riding a bogus delta.
+          if (placeCrossSheetRef.current === placingImageId) {
+            placeGrabRef.current = { key: tp.key, dx: 0, dy: 0 };
+          } else {
+            const m0 = markups.find((m) => m.id === placingImageId);
+            const ax = m0 && Array.isArray(m0.at) ? m0.at[0] : cx, ay = m0 && Array.isArray(m0.at) ? m0.at[1] : cy;
+            placeGrabRef.current = { key: tp.key, dx: ax - cx, dy: ay - cy };
+          }
         }
         const g = placeGrabRef.current;
         setMarkups((ms) => ms.map((m) => (m.id === placingImageId ? { ...m, at: [cx + g.dx, cy + g.dy], sheet_id: tp.key } : m)));
@@ -5448,11 +5522,95 @@ export default function TakeoffCanvas() {
   }
   function flyToMarkup(m) {
     if (!m) return;
+    // a fly-to and a source-trace both end in setTfNow off the same deps
+    // ([panelImgs, groupSig, status]) — starting one must cancel a competing
+    // in-flight other, or whichever completes second silently yanks the view
+    // the user already stopped looking at.
+    pendingSourceRef.current = null;
     setShowMarkups(true);   // flying to a markup reveals the layer, so you never land on an invisible selection
     if (!panelKeySet.has(m.sheet_id)) { pendingFlyRef.current = m; openSheets([m.sheet_id], false); return; }
     // open already, but its bitmap may still be mid-render (img.w === 0) — if the
     // inline center can't run yet, hand off to the phase-2 effect below.
     if (!centerOnMarkup(m)) pendingFlyRef.current = m;
+  }
+  // Reposition an image markup — the row's Place button. Two cases, branched on
+  // whether the image's CURRENT sheet is already open (panelKeySet.has):
+  //  - same-sheet: unchanged foundation behavior — fly the view to it (centers
+  //    on its stored anchor) and the first-contact grab (onPointerMove ~3699)
+  //    preserves the cursor→image offset (no teleport).
+  //  - cross-sheet: the image's home sheet isn't open here, so flying there
+  //    would defeat placing it on THIS sheet — arm placement in place instead,
+  //    and flag placeCrossSheetRef so the first-contact grab zeroes the offset
+  //    (the image's stored `at` is a position on the OTHER sheet; centering it
+  //    under the cursor is the only sane drop point). See placeCrossSheetRef's
+  //    declaration for why the decision has to ride a ref instead of being
+  //    re-derived from m.sheet_id at grab time.
+  function beginPlace(m) {
+    placeGrabRef.current = null;
+    placeCrossSheetRef.current = null;
+    pendingSourceRef.current = null;   // starting a placement cancels any in-flight source trace — same setTfNow race as flyToMarkup above
+    if (panelKeySet.has(m.sheet_id)) {
+      flyToMarkup(m);
+      setPlacingImageId(m.id);
+      setCommitMsg("Placing image — the view centered on it; move the pointer and click to drop (Esc cancels).");
+    } else {
+      placeCrossSheetRef.current = m.id;
+      setPlacingImageId(m.id);
+      setCommitMsg("Placing image on this sheet — move the pointer and click to drop (Esc cancels).");
+    }
+  }
+  // Center the view on a normalized [nx,ny] point within panel `sp` —
+  // replicates centerOnMarkup's transform math above verbatim, but keyed off a
+  // raw point instead of resolving a markup's anchor. A source trace has no
+  // markup on the source sheet to resolve (only a synthetic {sheet_id, rect}),
+  // so centerOnMarkup/flyToMarkup can't express this — this is why traceSource
+  // doesn't reuse them.
+  function centerOnPanelPoint(sp, nx, ny) {
+    if (!sp?.img?.w) return false;
+    const el = containerRef.current;
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    const scale = tfRef.current.scale;
+    const sx = nx * sp.img.w + sp.xOffset, sy = ny * sp.img.h;
+    setTfNow({ x: r.width / 2 - sx * scale, y: r.height / 2 - sy * scale, scale });
+    return true;
+  }
+  // Trace a capture back to its ORIGIN sheet+region (◎, button wired by slice
+  // 4 — this function, its ref, and its effect are this slice's job). Captures
+  // only: m.source === "capture" && src_sheet_id && src_rect (a stitch source
+  // sheet works fine here — no suppression, unlike the caption's — openSheets/
+  // goToSheet already treat a stitch key as first-class).
+  function traceSource(m) {
+    if (!m || m.source !== "capture" || !m.src_sheet_id || !m.src_rect) return;
+    const mid = rectMidpoint(m.src_rect);
+    // a malformed rect arms nothing rather than a pendingSourceRef that can
+    // never complete and would burn its whole attempt budget finding that out
+    if (!mid) return;
+    // Mid-Place guard (plan-mandated): dropping into a trace while an image is
+    // still armed for placement must end that gesture FIRST — otherwise the
+    // riding image (onPointerMove is still centre-following the cursor) drops
+    // onto the SOURCE sheet on the very click that navigates us there.
+    if (placingImageId) {
+      setPlacingImageId(null);
+      placeGrabRef.current = null;
+      placeCrossSheetRef.current = null;
+    }
+    pendingFlyRef.current = null;   // a source trace supersedes any in-flight fly-to (same setTfNow race noted in flyToMarkup)
+    const src = m.src_sheet_id, rect = m.src_rect;
+    const token = ++sourceTraceSeqRef.current;   // fresh every trace, even a repeat of the same region — see sourceFlash's declaration on why
+    if (panelKeySet.has(src)) {
+      const sp = panels.find((p) => p.key === src);
+      if (sp?.img?.w && centerOnPanelPoint(sp, mid[0], mid[1])) {
+        setSourceFlash({ sheet_id: src, rect, token });   // no selectMarkup — there's no markup to select on the source sheet
+        return;
+      }
+      // open, but its bitmap hasn't finished rendering yet — the phase-2
+      // effect above completes this once panelImgs reports a real width.
+      pendingSourceRef.current = { sheet_id: src, rect, token, attempts: 0 };
+      return;
+    }
+    pendingSourceRef.current = { sheet_id: src, rect, token, attempts: 0 };
+    openSheets([src], false);
   }
 
   function finishShape() {
@@ -8019,7 +8177,7 @@ export default function TakeoffCanvas() {
                        ) : (
                          <span style={{ flex: 1, color: "var(--ink)" }}>{m.type === "svg" ? <em style={{ color: "var(--ink-muted)" }}>(vector symbol)</em> : ([m.type === "dimension" && Number(m.len_ft) > 0 ? dimLabel(m.len_ft) : "", m.text].filter(Boolean).join(" · ") || <em style={{ color: "var(--ink-muted)" }}>(no text)</em>)}</span>
                        )}
-                       {m.type === "image" && <button onClick={(e) => { e.stopPropagation(); placeGrabRef.current = null; flyToMarkup(m); setPlacingImageId(m.id); setCommitMsg("Placing image — the view centered on it; move the pointer and click to drop (Esc cancels)."); }} title="Reposition: centers the view on the image, then it follows the cursor — click the sheet to drop it" style={{ border: "1px solid var(--ink-faint)", background: placingImageId === m.id ? "var(--cobalt)" : "transparent", color: placingImageId === m.id ? "#fff" : "var(--cobalt)", cursor: "pointer", fontSize: 11, padding: "1px 7px" }}>Place</button>}
+                       {m.type === "image" && <button onClick={(e) => { e.stopPropagation(); beginPlace(m); }} title={panelKeySet.has(m.sheet_id) ? "Reposition: centers the view on the image, then it follows the cursor — click the sheet to drop it" : "Place this image on the current sheet — it follows the cursor until you click to drop it"} style={{ border: "1px solid var(--ink-faint)", background: placingImageId === m.id ? "var(--cobalt)" : "transparent", color: placingImageId === m.id ? "#fff" : "var(--cobalt)", cursor: "pointer", fontSize: 11, padding: "1px 7px" }}>Place</button>}
                        {m.type !== "svg" && <button onClick={(e) => { e.stopPropagation(); setPanelEditId((id) => (id === m.id ? null : m.id)); }} title="Edit text" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--ink-muted)" }}>✎</button>}
                        <button onClick={(e) => { e.stopPropagation(); deleteMarkup(m.id); }} title="Delete markup" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--c-danger)" }}>🗑</button>
                      </div>

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -5208,21 +5208,14 @@ export default function TakeoffCanvas() {
         };
       }).filter(Boolean);
       const sheetMeta = [...plainMeta, ...stitchMeta];
-      // Source-caption labels: resolve each capture's ORIGIN sheet to the same
-      // display name the tab/canvas shows (sheetBaseLabel — sheet number, rename,
-      // stitch name, or file-base fallback), keyed by src_sheet_id. markedset reads
-      // THIS map so the PDF caption matches the on-screen caption exactly, even when
-      // the origin sheet carries no markups of its own (so it isn't in sheetMeta).
-      const srcLabels = {};
-      for (const m of exportMarkups) {
-        if (m.type === "image" && m.source === "capture" && m.src_sheet_id != null) srcLabels[m.src_sheet_id] = sheetBaseLabel(m.src_sheet_id);
-      }
+      // (source-caption label rides on each capture as m.src_label, frozen at
+      // capture time — markedset reads it directly, no per-export resolution.)
       // branding mode decides the cover identity + wordmark + parent credit;
       // resolved per-project (folderId "" ⇒ the single browser-only setting)
       const brand = resolveBranding({ ...(await loadBrandingSelection(projectIdFromUrl())), profiles: loadProfiles().profiles });
       const { bytes, filename } = await buildMarkedSetPdf({
         projectName, clientInfo, company: brand.company, credit: brand.credit, coverTitle: brand.coverTitle,
-        dark: darkMode, units, sheets: sheetMeta, srcLabels, shapes, markups: exportMarkups, approvals, rfis, conditions,
+        dark: darkMode, units, sheets: sheetMeta, shapes, markups: exportMarkups, approvals, rfis, conditions,
         getPage: async (file, pageNum) => (await docFor(file)).getPage(pageNum),
         loadPdfData: (file) => store.loadPdfData(file),
       });
@@ -6691,16 +6684,21 @@ export default function TakeoffCanvas() {
     const { at, w, aspect } = captureRectToImageGeom({ x0, y0, x1, y1 }, panel.img.w, panel.img.h);
     if (!(w > 0)) return;
     // Capture-only provenance fields (uploads have no source, so addImageFromFile
-    // omits all three): src_sheet_id is the ORIGIN sheet (sheet_id tracks where
-    // the image currently lives and moves on a cross-sheet place — see
-    // imageProvenance below). src_rect reuses the ALREADY-CLAMPED x0..y1 above,
-    // NOT the raw marquee corners a/b (they carry xOffset and are unclamped) and
-    // NOT bw/bh (the 1600px capture raster size) — normalizing by those would
-    // silently drift the traced region off the real source box.
+    // omits them): src_sheet_id is the ORIGIN sheet (sheet_id tracks where the
+    // image currently lives and moves on a cross-sheet place — see imageProvenance
+    // below). src_rect reuses the ALREADY-CLAMPED x0..y1 above, NOT the raw marquee
+    // corners a/b (they carry xOffset and are unclamped) and NOT bw/bh (the 1600px
+    // capture raster size) — normalizing by those would silently drift the traced
+    // region off the real source box. src_label FREEZES the origin sheet's display
+    // name at capture time (panel.key is the active sheet here, so sheetBaseLabel
+    // resolves the real "AF101"): both the canvas caption and the marked-set PDF
+    // read this stored string, so they can never diverge on runtime label state
+    // (which sheetBaseLabel derives only for the currently-active file).
     addImageMarkup({
       at, w, aspect, src, source: "capture",
       src_sheet_id: panel.key,
       src_rect: [[x0 / panel.img.w, y0 / panel.img.h], [x1 / panel.img.w, y1 / panel.img.h]],
+      src_label: sheetBaseLabel(panel.key),
       source_label: false,
     }, panel.key);
   }
@@ -8853,15 +8851,14 @@ export default function TakeoffCanvas() {
                         // src must never make <image href> fetch remote content.
                         if (!(m.src && pickEmbedFormat(m.src) && Array.isArray(m.at) && bw > 0 && bh > 0)) return null;
                         const x0 = m.at[0] * p.img.w - bw / 2, y0 = m.at[1] * p.img.h - bh / 2;
-                        // Source caption (captures only) — the SHEET NAME of the origin,
-                        // via the live sheetBaseLabel closure (the same label the tab shows:
-                        // a detected sheet number "AF101", a user rename, a stitch name, or
-                        // a file-base fallback). The marked-set export reads the SAME label
-                        // through the srcLabels map built in exportMarkedSet from this very
-                        // closure, so screen and PDF stay byte-identical. "" (upload or no
-                        // src_sheet_id) means render nothing, not an empty chip.
+                        // Source caption (captures only) — the origin sheet NAME, read
+                        // from the frozen src_label (resolved at capture time; the
+                        // marked-set PDF reads the SAME stored string, so screen and PDF
+                        // can't diverge). Legacy captures without src_label fall back to
+                        // the live closure. A stitch origin has no page number, so drop the
+                        // "· p.N" for it. "" (upload or no src_sheet_id) ⇒ render nothing.
                         const capText = m.source === "capture" && m.source_label && m.src_sheet_id
-                          ? sourceCaption(sheetBaseLabel(m.src_sheet_id), parseSheetKey(m.src_sheet_id).page)
+                          ? sourceCaption(m.src_label ?? sheetBaseLabel(m.src_sheet_id), isStitchKey(m.src_sheet_id) ? 0 : parseSheetKey(m.src_sheet_id).page)
                           : "";
                         return (
                           <g key={m.id}>

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -7127,7 +7127,13 @@ export default function TakeoffCanvas() {
   const checkStatedFeet = parseLenInput(checkStated, units);
   const checkErrPct = checkFeet && checkStatedFeet > 0 ? ((checkFeet - checkStatedFeet) / checkStatedFeet) * 100 : null;
 
-  const markupCount = markups.filter((m) => panelKeySet.has(m.sheet_id)).length;
+  // Matches what the Markups tab actually renders post-Captures-split: the
+  // per-sheet non-image list (panel-filtered) plus the GLOBAL Captures list
+  // (every image markup, any sheet) — NOT the old panelKeySet-only count,
+  // which double-missed (never counted an other-sheet capture) and
+  // over-counted (still counted a THIS-sheet image, which no longer shows in
+  // the per-sheet body it was counted against).
+  const markupCount = markups.filter((m) => panelKeySet.has(m.sheet_id) && m.type !== "image").length + filterCaptures(markups, "").length;
   const selShape = selectedId ? visibleShapes.find((s) => s.id === selectedId) : null;
   // the input types in DISPLAY units (metres in metric); height_ft is stored feet
   const setShapeHeight = (raw) => {
@@ -8155,13 +8161,7 @@ export default function TakeoffCanvas() {
                      {/* the header line selects + flies to the markup (parity with the RFI
                          register's onFlyTo) — the inner controls stopPropagation so only the
                          label area triggers it, never edit/delete. */}
-                     <div onClick={() => flyToMarkup(m)} title={m.type === "image" ? imageProvenance(m) : "Select and center this markup"} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
-                       {m.type === "image" && (() => {
-                         const th = ensureThumb(m);
-                         return <span style={{ flex: "0 0 auto", width: 30, height: 30, border: "1px solid var(--ink-faint)", background: "var(--paper-bright)", display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden" }}>
-                           {th ? <img src={th} alt="" style={{ maxWidth: "100%", maxHeight: "100%", display: "block" }} /> : <span style={{ fontSize: 14 }}>🖼</span>}
-                         </span>;
-                       })()}
+                     <div onClick={() => flyToMarkup(m)} title="Select and center this markup" style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
                        <span style={{ fontSize: 10, fontWeight: 700, color: "var(--cobalt)", textTransform: "uppercase" }}>{m.type}</span>
                        {/* inline edit — the panel's fallback for the canvas overlay, since a
                            markup here may be off-screen or on another sheet (no click point).
@@ -8175,7 +8175,6 @@ export default function TakeoffCanvas() {
                        ) : (
                          <span style={{ flex: 1, color: "var(--ink)" }}>{m.type === "svg" ? <em style={{ color: "var(--ink-muted)" }}>(vector symbol)</em> : ([m.type === "dimension" && Number(m.len_ft) > 0 ? dimLabel(m.len_ft) : "", m.text].filter(Boolean).join(" · ") || <em style={{ color: "var(--ink-muted)" }}>(no text)</em>)}</span>
                        )}
-                       {m.type === "image" && <button onClick={(e) => { e.stopPropagation(); beginPlace(m); }} title={panelKeySet.has(m.sheet_id) ? "Reposition: centers the view on the image, then it follows the cursor — click the sheet to drop it" : "Place this image on the current sheet — it follows the cursor until you click to drop it"} style={{ border: "1px solid var(--ink-faint)", background: placingImageId === m.id ? "var(--cobalt)" : "transparent", color: placingImageId === m.id ? "#fff" : "var(--cobalt)", cursor: "pointer", fontSize: 11, padding: "1px 7px" }}>Place</button>}
                        {m.type !== "svg" && <button onClick={(e) => { e.stopPropagation(); setPanelEditId((id) => (id === m.id ? null : m.id)); }} title="Edit text" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--ink-muted)" }}>✎</button>}
                        <button onClick={(e) => { e.stopPropagation(); deleteMarkup(m.id); }} title="Delete markup" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--c-danger)" }}>🗑</button>
                      </div>
@@ -8290,8 +8289,12 @@ export default function TakeoffCanvas() {
                      {captureQuery && <button onClick={() => setCaptureQuery("")} title="Clear the filter" style={{ border: "none", background: "none", color: "var(--ink-muted)", cursor: "pointer", fontSize: 13, padding: 0 }}>×</button>}
                    </div>
                    {(() => {
+                     // one pass over `markups` for the image subset; the query
+                     // then narrows THAT (small) list instead of re-scanning
+                     // every markup a second time — filterCaptures's own
+                     // type==="image" filter is a no-op on an already-image-only input.
                      const allCaptures = filterCaptures(markups, "");
-                     const captures = filterCaptures(markups, captureQuery);
+                     const captures = filterCaptures(allCaptures, captureQuery);
                      if (allCaptures.length === 0) {
                        return <div style={{ padding: "4px 12px 14px", color: "var(--ink-muted)" }}>No captures yet. Marquee a region with 🖼 or use Upload image… above.</div>;
                      }

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -2855,6 +2855,12 @@ export default function TakeoffCanvas() {
       const id = placingImageId;
       setPlacingImageId(null);
       placeGrabRef.current = null;
+      // Commit boundary for the place gesture (onPointerMove's centre-follow at
+      // :3676 is the live PREVIEW and must stay unstamped): stamp updated_at here
+      // so a cross-sheet place isn't silently reverted by a 3-way sync tie
+      // (merge tiebreak is updated_at || created_at; equal created_at + no
+      // updated_at ⇒ ties → remote wins ⇒ the move vanishes).
+      updateMarkup(id, { updated_at: nowIso() });
       selectMarkup(id);
       setCommitMsg("Image placed.");
       return;
@@ -3134,7 +3140,7 @@ export default function TakeoffCanvas() {
           const brx = selMk.at[0] * sp.img.w + sp.xOffset + bw / 2, bry = selMk.at[1] * sp.img.h + bh / 2;
           if (Math.hypot(p[0] - brx, p[1] - bry) < thr * 1.5) {
             const tlx = selMk.at[0] * sp.img.w - bw / 2, tly = selMk.at[1] * sp.img.h - bh / 2;
-            dragRef.current = { kind: "markupResize", markupId: selMk.id, tl: { x: tlx, y: tly }, aspect: selMk.aspect, ox: sp.xOffset, imgW: sp.img.w, imgH: sp.img.h };
+            dragRef.current = { kind: "markupResize", markupId: selMk.id, tl: { x: tlx, y: tly }, aspect: selMk.aspect, ox: sp.xOffset, imgW: sp.img.w, imgH: sp.img.h, moved: false };
             e.currentTarget.setPointerCapture(e.pointerId); return;
           }
         }
@@ -3813,6 +3819,7 @@ export default function TakeoffCanvas() {
         const mp = toImage(e.clientX, e.clientY);
         const pointerLocalX = mp[0] - d.ox;
         const { w, at } = resizeImageFromCorner({ x: d.tl.x, y: d.tl.y }, { x: pointerLocalX, y: mp[1] }, d.aspect, d.imgW, d.imgH);
+        d.moved = true;   // a real resize tick occurred — onPointerUp's commit checks this
         setMarkups((ms) => ms.map((m) => (m.id === d.markupId ? { ...m, w, at } : m)));
       }
       return;
@@ -3874,6 +3881,17 @@ export default function TakeoffCanvas() {
           ...(d.lastComputed !== undefined ? { computed: d.lastComputed } : {}),
           prev: d.prev,
         });
+      } else if ((d.kind === "markupMove" || d.kind === "markupResize") && d.moved) {
+        // Same commit-boundary doctrine as the shape geom command above: the
+        // per-frame setMarkups calls in onPointerMove (:3799 body/handle drag,
+        // :3815 resize) are the live PREVIEW and stay unstamped; this is where
+        // the drag actually ends. `d.moved` gates out a plain select-click that
+        // arms the drag but never crosses the move threshold / never resizes —
+        // that's not an edit, so it gets no stamp (mirrors the shape branch's
+        // lastVerts-changed guard above). Without this, a cross-sheet move/resize
+        // that leaves created_at untouched is silently reverted on a 3-way sync
+        // tie (merge tiebreak: updated_at || created_at, ties → remote wins).
+        updateMarkup(d.markupId, { updated_at: nowIso() });
       }
       try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* gone */ }
       return;
@@ -6451,7 +6469,19 @@ export default function TakeoffCanvas() {
     } catch { setCommitMsg("Couldn't capture that region."); return; }
     const { at, w, aspect } = captureRectToImageGeom({ x0, y0, x1, y1 }, panel.img.w, panel.img.h);
     if (!(w > 0)) return;
-    addImageMarkup({ at, w, aspect, src, source: "capture" }, panel.key);
+    // Capture-only provenance fields (uploads have no source, so addImageFromFile
+    // omits all three): src_sheet_id is the ORIGIN sheet (sheet_id tracks where
+    // the image currently lives and moves on a cross-sheet place — see
+    // imageProvenance below). src_rect reuses the ALREADY-CLAMPED x0..y1 above,
+    // NOT the raw marquee corners a/b (they carry xOffset and are unclamped) and
+    // NOT bw/bh (the 1600px capture raster size) — normalizing by those would
+    // silently drift the traced region off the real source box.
+    addImageMarkup({
+      at, w, aspect, src, source: "capture",
+      src_sheet_id: panel.key,
+      src_rect: [[x0 / panel.img.w, y0 / panel.img.h], [x1 / panel.img.w, y1 / panel.img.h]],
+      source_label: false,
+    }, panel.key);
   }
 
   // The aggregate-budget gate shared by both entry points: refuse a new image when
@@ -6501,7 +6531,11 @@ export default function TakeoffCanvas() {
   // prominently). Degrades: drops the author when none is declared.
   function imageProvenance(m) {
     const verb = m.source === "upload" ? "Uploaded" : "Captured from";
-    const where = m.source === "upload" ? "" : ` ${sheetBaseLabel(m.sheet_id)}`;
+    // src_sheet_id is the ORIGIN sheet; sheet_id is wherever the image lives NOW
+    // and is rewritten on a cross-sheet place, so after a move reading sheet_id
+    // here would misreport where it was captured. Fall back to sheet_id for
+    // uploads (no src_sheet_id) and legacy records captured before this field.
+    const where = m.source === "upload" ? "" : ` ${sheetBaseLabel(m.src_sheet_id || m.sheet_id)}`;
     const when = m.created_at ? ` · ${String(m.created_at).slice(0, 10)}` : "";
     const who = m.author ? ` · ${m.author}` : "";
     return `${verb}${where}${when}${who}`;

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -6711,7 +6711,7 @@ export default function TakeoffCanvas() {
     // and the marked-set PDF read this stored string, so they can never diverge on
     // runtime label state (which sheetBaseLabel derives only for the active file).
     addImageMarkup({
-      at, w, aspect, src, source: "capture",
+      at, w, aspect, src, source: "capture", labelBase: srcLabel,
       src_sheet_id: panel.key,
       src_rect: [[x0 / panel.img.w, y0 / panel.img.h], [x1 / panel.img.w, y1 / panel.img.h]],
       src_label: srcLabel,
@@ -6734,9 +6734,13 @@ export default function TakeoffCanvas() {
     // sheet base + a per-sheet sequence ("AF101-01"). Uploads carry the file name.
     // Collisions after a delete are tolerated (a simple count, not a high-water
     // counter). Stamp the declared author (git-style; absent ⇒ omitted).
-    const { name: given, ...rest } = m;
+    // labelBase lets a caller pin the base to a resolved label (a capture passes its
+    // frozen src_label) so the row NAME and the source CAPTION agree even in the
+    // non-active-panel case sheetBaseLabel can't resolve here; absent ⇒ sheetBaseLabel.
+    const { name: given, labelBase, ...rest } = m;
     const seq = markups.filter((x) => x.type === "image" && x.sheet_id === key).length + 1;
-    const text = (typeof given === "string" && given.trim()) || `${sheetBaseLabel(key)}-${String(seq).padStart(2, "0")}`;
+    const base = (typeof labelBase === "string" && labelBase.trim()) ? labelBase : sheetBaseLabel(key);
+    const text = (typeof given === "string" && given.trim()) || `${base}-${String(seq).padStart(2, "0")}`;
     const by = authorName();
     addMarkup({ type: "image", ...rest, text, ...(by ? { author: by } : {}) }, key);
     setCommitMsg("Image placed.");

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -327,8 +327,11 @@ export default function TakeoffCanvas() {
   // src_rect shape, normalized 0..1), token } | null. `token` must change on
   // every trace, even a repeat of the SAME region, so the render can key a
   // fresh remount off it — see the render site for why. Slice 2 only defines
-  // and renders this; slice 3 SETS it and owns its staleness/clear lifecycle
-  // (no setTimeout here — that would collide with or be removed by slice 3).
+  // and renders this; slice 3 SETS it (via the `flashSource` helper, see
+  // traceSource below) and owns its staleness/clear lifecycle — both the
+  // panel-left clear effect below AND the one-shot auto-clear timer that
+  // `flashSource` arms so the CSS pulse (which holds its last frame forever
+  // once its single run finishes) doesn't end up as a permanent opaque box.
   const [sourceFlash, setSourceFlash] = useState(null);
   // Docked LEFT panel — one at a time, never overlapping: null | "markup" | "stamp" | "rfi".
   // The right-rail buttons switch tabs; the dock reflows the canvas (mirrors the
@@ -2233,7 +2236,7 @@ export default function TakeoffCanvas() {
     // when traceSource armed this ref, but re-check rather than trust a ref that
     // sat around — cheap, and keeps this path total on its own.
     const mid = rectMidpoint(p.rect);
-    if (mid && centerOnPanelPoint(sp, mid[0], mid[1])) setSourceFlash({ sheet_id: p.sheet_id, rect: p.rect, token: p.token });
+    if (mid && centerOnPanelPoint(sp, mid[0], mid[1])) flashSource(p.sheet_id, p.rect, p.token);
     pendingSourceRef.current = null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panelImgs, groupSig, status]);
@@ -2928,6 +2931,26 @@ export default function TakeoffCanvas() {
     // (onPointerMove has been centre-following the cursor). One click ends the mode.
     if (placingImageId) {
       const id = placingImageId;
+      // Zero-movement cross-sheet place guard: onPointerMove's first-contact
+      // grab (:3755) is the ONLY place that rewrites `sheet_id`/`at` onto the
+      // target panel, and it only runs on a pointermove. Click Place, then
+      // click the canvas again with NO intervening pointermove (cursor never
+      // left this spot) and that grab never fires — placeGrabRef.current is
+      // still null, so the image is still sitting on its ORIGIN sheet even
+      // though the message below is about to say "Image placed." Mirror the
+      // exact first-contact math here, keyed off THIS click's own position
+      // (which — since nothing moved — is the same position onPointerMove
+      // would have used), so a click-without-move still lands the image on
+      // the sheet under the cursor. Same-sheet reposition never sets
+      // placeCrossSheetRef, so this block is a no-op for that path.
+      if (placeCrossSheetRef.current === id) {
+        const q = toImage(e.clientX, e.clientY);
+        const tp = panelAt(q[0]);
+        if (tp?.img?.w && (!placeGrabRef.current || placeGrabRef.current.key !== tp.key)) {
+          const cx = (q[0] - tp.xOffset) / tp.img.w, cy = q[1] / tp.img.h;
+          setMarkups((ms) => ms.map((m) => (m.id === id ? { ...m, at: [cx, cy], sheet_id: tp.key } : m)));
+        }
+      }
       setPlacingImageId(null);
       placeGrabRef.current = null;
       placeCrossSheetRef.current = null;
@@ -5579,6 +5602,23 @@ export default function TakeoffCanvas() {
     setTfNow({ x: r.width / 2 - sx * scale, y: r.height / 2 - sy * scale, scale });
     return true;
   }
+  // Sets the source-trace flash AND arms its one-shot auto-clear — the pulse
+  // (app.css `@keyframes pulse`) runs once and then holds its last frame
+  // forever unless something nulls the state back out, so without this the
+  // flash rect sits as a permanent opaque box. Keyed on `token`, not
+  // `sheet_id`: a repeat trace of the same region bumps sourceTraceSeqRef and
+  // gets a fresh token, so an older timer's closure (capturing the OLD token)
+  // is a no-op against the newer flash it would otherwise stomp — no need to
+  // track/cancel the previous timeout explicitly. Both call sites (the
+  // inline-ready path in traceSource and the pending-completion effect above)
+  // go through this one helper so the timer can't drift between them.
+  const SOURCE_FLASH_MS = 2600; // matches app.css pulse's ~2.55s animation length, plus a hair
+  function flashSource(sheet_id, rect, token) {
+    setSourceFlash({ sheet_id, rect, token });
+    setTimeout(() => {
+      setSourceFlash((f) => (f && f.token === token ? null : f));
+    }, SOURCE_FLASH_MS);
+  }
   // Trace a capture back to its ORIGIN sheet+region (◎, button wired by slice
   // 4 — this function, its ref, and its effect are this slice's job). Captures
   // only: m.source === "capture" && src_sheet_id && src_rect (a stitch source
@@ -5605,7 +5645,7 @@ export default function TakeoffCanvas() {
     if (panelKeySet.has(src)) {
       const sp = panels.find((p) => p.key === src);
       if (sp?.img?.w && centerOnPanelPoint(sp, mid[0], mid[1])) {
-        setSourceFlash({ sheet_id: src, rect, token });   // no selectMarkup — there's no markup to select on the source sheet
+        flashSource(src, rect, token);   // no selectMarkup — there's no markup to select on the source sheet
         return;
       }
       // open, but its bitmap hasn't finished rendering yet — the phase-2
@@ -9088,7 +9128,7 @@ export default function TakeoffCanvas() {
                         <rect key={sourceFlash.token}
                           x={fx0} y={fy0} width={fx1 - fx0} height={fy1 - fy0}
                           fill="rgba(31,63,199,.14)" stroke="#1f3fc7" strokeWidth={3 / tf.scale}
-                          style={{ pointerEvents: "none", animation: "pulse .85s ease-in-out 3" }} />
+                          style={{ pointerEvents: "none", animation: "sourceFlashPulse .85s ease-in-out 3 forwards" }} />
                       );
                     })()}
                   </g>

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -25,7 +25,7 @@ import { getFocusMode, toggleFocusMode, onFocusModeChange } from "../lib/focusMo
 import { seedStampLibrary, instantiateStamp, markupToStampElement } from "../lib/stamps.js";
 import { extractSvgPrimitives, svgToStamp } from "../lib/svgImport.js";
 import { transformPath, svgPlacedBox } from "../lib/svgpath.js";
-import { imagePlacedBox, captureRectToImageGeom, resizeImageFromCorner, aspectFromDims, pickEmbedFormat } from "../lib/markupImage";
+import { imagePlacedBox, captureRectToImageGeom, resizeImageFromCorner, aspectFromDims, pickEmbedFormat, sourceCaption } from "../lib/markupImage";
 import { ingestFiles } from "../lib/ingest.js";
 import { parseTakeoffImport, mergeTakeoffImport } from "../lib/importTakeoff.js";
 import { buildProjectArchive, parseProjectArchive, isProjectArchive, downloadArchive } from "../lib/projectArchive.js";
@@ -38,7 +38,7 @@ import UserGuide from "../components/UserGuide.jsx";
 import TakeoffsPanel, { clampPanelW, CONDITION_DND_MIME, ConditionAppearanceEditor } from "../components/TakeoffsPanel.jsx";
 import { HATCHES, PALETTE, NO_FILL, HatchPattern, HatchSwatch } from "../components/hatches.jsx";
 import { Icon } from "../brand/icons.jsx";
-import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, compareSheetKeys, extractSheetNumber, detectScale, extractRegionText, extractTextMarks, extractDimTexts } from "../lib/sheets";
+import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, compareSheetKeys, extractSheetNumber, detectScale, extractRegionText, extractTextMarks, extractDimTexts, sheetBaseLabelFromKey } from "../lib/sheets";
 import { normalizeLoadedGroups } from "../lib/sheetGroups";
 import { isStitchKey, mintStitchId, sanitizeStitches, autoButt, stitchExtent, alignMembers, seamClips, mergePoints, mergeSegs, stitchAlive, stitchLayoutSig } from "../lib/stitches";
 import { isCanvasBusy } from "../lib/canvasBusy";
@@ -318,6 +318,16 @@ export default function TakeoffCanvas() {
   const [markups, setMarkups] = useState([]);                // cloud/callout/text annotations (separate from measurement shapes)
   const [approvals, setApprovals] = useState([]);            // approval seals — estimator APPROVED ink + agent AGENT marks (lib/approvals.js; its own family, not markups)
   const [markupDraft, setMarkupDraft] = useState(null);      // in-progress markup first point (cloud/callout/highlight)
+  // Source-trace flash (◎, wired by slice 3) — a transient highlight on a
+  // capture's ORIGIN region, rendered inside the SOURCE panel's own <g> (so it
+  // inherits that panel's xOffset like everything else there). Its OWN state —
+  // NEVER written onto a markup: { sheet_id, rect: [[nx0,ny0],[nx1,ny1]] (the
+  // src_rect shape, normalized 0..1), token } | null. `token` must change on
+  // every trace, even a repeat of the SAME region, so the render can key a
+  // fresh remount off it — see the render site for why. Slice 2 only defines
+  // and renders this; slice 3 SETS it and owns its staleness/clear lifecycle
+  // (no setTimeout here — that would collide with or be removed by slice 3).
+  const [sourceFlash, setSourceFlash] = useState(null);
   // Docked LEFT panel — one at a time, never overlapping: null | "markup" | "stamp" | "rfi".
   // The right-rail buttons switch tabs; the dock reflows the canvas (mirrors the
   // docked Takeoffs panel on the right).
@@ -8482,6 +8492,15 @@ export default function TakeoffCanvas() {
                         // src must never make <image href> fetch remote content.
                         if (!(m.src && pickEmbedFormat(m.src) && Array.isArray(m.at) && bw > 0 && bh > 0)) return null;
                         const x0 = m.at[0] * p.img.w - bw / 2, y0 = m.at[1] * p.img.h - bh / 2;
+                        // Source caption (captures only; dormant until slice 4 flips
+                        // source_label true) — derived the SAME way as the marked-set
+                        // export (sheetBaseLabelFromKey + sourceCaption) so screen and
+                        // PDF read byte-identical text. "" (upload, no src_sheet_id, or
+                        // a stitch source — sheetBaseLabelFromKey suppresses those)
+                        // means render nothing, not an empty chip.
+                        const capText = m.source === "capture" && m.source_label && m.src_sheet_id
+                          ? sourceCaption(sheetBaseLabelFromKey(m.src_sheet_id), parseSheetKey(m.src_sheet_id).page)
+                          : "";
                         return (
                           <g key={m.id}>
                             {halo(x0, y0, x0 + bw, y0 + bh)}
@@ -8492,6 +8511,26 @@ export default function TakeoffCanvas() {
                             <rect x={x0} y={y0} width={bw} height={bh} fill="none" stroke="#fff" strokeWidth={2.5 / z} style={{ pointerEvents: "none" }} />
                             <rect x={x0} y={y0} width={bw} height={bh} fill="none" stroke="#2a3550" strokeWidth={1 / z} style={{ pointerEvents: "none" }} />
                             {selM && <rect x={x0 + bw - 4 / z} y={y0 + bh - 4 / z} width={8 / z} height={8 / z} fill="#1f3fc7" stroke="#fff" strokeWidth={1.5 / z} style={{ pointerEvents: "none" }} />}
+                            {capText && (() => {
+                              // Frame-hugging chip on the TOP edge, centered on the box
+                              // width so it never collides with the top-LEFT link badge
+                              // (badge(x0, y0-9/z) is centered ON x0). Explicit light
+                              // fill + dark ink — NOT theme tokens (the image render
+                              // never dark-mode-inverts, so a chip that flipped with the
+                              // app theme would read backwards against it). Fixed screen
+                              // size (every dimension /z): on a very small capture it can
+                              // overrun the frame width, which is fine — it stays on the
+                              // top edge, clear of the bottom-right resize handle.
+                              const capCx = x0 + bw / 2, capCy = y0 - 9 / z;
+                              const capH = 15 / z, capW = (capText.length * 5.6 + 14) / z;
+                              return (
+                                <g style={{ pointerEvents: "none" }}>
+                                  <rect x={capCx - capW / 2} y={capCy - capH / 2} width={capW} height={capH} rx={3 / z}
+                                    fill="rgba(255,247,237,.95)" stroke="#0e1a2e" strokeWidth={1 / z} />
+                                  <text x={capCx} y={capCy} fill="#0e1a2e" fontSize={10 / z} fontWeight="600" textAnchor="middle" dominantBaseline="central">{capText}</text>
+                                </g>
+                              );
+                            })()}
                             {badge(x0, y0 - 9 / z)}
                           </g>
                         );
@@ -8719,6 +8758,27 @@ export default function TakeoffCanvas() {
                         </g>
                       );
                     })}
+                    {/* Source-trace flash (◎, wired by slice 3) — a transient highlight
+                        drawn in the SOURCE panel's own <g>, so it inherits xOffset like
+                        every other overlay here. `key={sourceFlash.token}` is load-bearing:
+                        a CSS keyframes animation only (re)starts on mount, so without a
+                        key tied to the token a repeat trace of the SAME region would find
+                        the <rect> already mounted and silently no-op the pulse — no JS
+                        tick, per the plan's no-live-tick rule. The guard on `rect` shape
+                        matches the try-wrap the export side uses: a malformed value from a
+                        future caller must not take the canvas down. */}
+                    {sourceFlash && sourceFlash.sheet_id === p.key
+                      && Array.isArray(sourceFlash.rect) && sourceFlash.rect.length === 2 && (() => {
+                      const [[fnx0, fny0], [fnx1, fny1]] = sourceFlash.rect;
+                      const fx0 = Math.min(fnx0, fnx1) * p.img.w, fy0 = Math.min(fny0, fny1) * p.img.h;
+                      const fx1 = Math.max(fnx0, fnx1) * p.img.w, fy1 = Math.max(fny0, fny1) * p.img.h;
+                      return (
+                        <rect key={sourceFlash.token}
+                          x={fx0} y={fy0} width={fx1 - fx0} height={fy1 - fy0}
+                          fill="rgba(31,63,199,.14)" stroke="#1f3fc7" strokeWidth={3 / tf.scale}
+                          style={{ pointerEvents: "none", animation: "pulse .85s ease-in-out 3" }} />
+                      );
+                    })()}
                   </g>
                 );
               })}

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -40,7 +40,7 @@ import UserGuide from "../components/UserGuide.jsx";
 import TakeoffsPanel, { clampPanelW, CONDITION_DND_MIME, ConditionAppearanceEditor } from "../components/TakeoffsPanel.jsx";
 import { HATCHES, PALETTE, NO_FILL, HatchPattern, HatchSwatch } from "../components/hatches.jsx";
 import { Icon } from "../brand/icons.jsx";
-import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, compareSheetKeys, extractSheetNumber, detectScale, extractRegionText, extractTextMarks, extractDimTexts, sheetBaseLabelFromKey } from "../lib/sheets";
+import { RENDER_SCALE, MAX_GROUP, STANDARD_SCALES, parseSheetKey, compareSheetKeys, extractSheetNumber, detectScale, extractRegionText, extractTextMarks, extractDimTexts } from "../lib/sheets";
 import { normalizeLoadedGroups } from "../lib/sheetGroups";
 import { isStitchKey, mintStitchId, sanitizeStitches, autoButt, stitchExtent, alignMembers, seamClips, mergePoints, mergeSegs, stitchAlive, stitchLayoutSig } from "../lib/stitches";
 import { isCanvasBusy } from "../lib/canvasBusy";
@@ -5208,12 +5208,21 @@ export default function TakeoffCanvas() {
         };
       }).filter(Boolean);
       const sheetMeta = [...plainMeta, ...stitchMeta];
+      // Source-caption labels: resolve each capture's ORIGIN sheet to the same
+      // display name the tab/canvas shows (sheetBaseLabel — sheet number, rename,
+      // stitch name, or file-base fallback), keyed by src_sheet_id. markedset reads
+      // THIS map so the PDF caption matches the on-screen caption exactly, even when
+      // the origin sheet carries no markups of its own (so it isn't in sheetMeta).
+      const srcLabels = {};
+      for (const m of exportMarkups) {
+        if (m.type === "image" && m.source === "capture" && m.src_sheet_id != null) srcLabels[m.src_sheet_id] = sheetBaseLabel(m.src_sheet_id);
+      }
       // branding mode decides the cover identity + wordmark + parent credit;
       // resolved per-project (folderId "" ⇒ the single browser-only setting)
       const brand = resolveBranding({ ...(await loadBrandingSelection(projectIdFromUrl())), profiles: loadProfiles().profiles });
       const { bytes, filename } = await buildMarkedSetPdf({
         projectName, clientInfo, company: brand.company, credit: brand.credit, coverTitle: brand.coverTitle,
-        dark: darkMode, units, sheets: sheetMeta, shapes, markups: exportMarkups, approvals, rfis, conditions,
+        dark: darkMode, units, sheets: sheetMeta, srcLabels, shapes, markups: exportMarkups, approvals, rfis, conditions,
         getPage: async (file, pageNum) => (await docFor(file)).getPage(pageNum),
         loadPdfData: (file) => store.loadPdfData(file),
       });
@@ -8844,14 +8853,15 @@ export default function TakeoffCanvas() {
                         // src must never make <image href> fetch remote content.
                         if (!(m.src && pickEmbedFormat(m.src) && Array.isArray(m.at) && bw > 0 && bh > 0)) return null;
                         const x0 = m.at[0] * p.img.w - bw / 2, y0 = m.at[1] * p.img.h - bh / 2;
-                        // Source caption (captures only; dormant until slice 4 flips
-                        // source_label true) — derived the SAME way as the marked-set
-                        // export (sheetBaseLabelFromKey + sourceCaption) so screen and
-                        // PDF read byte-identical text. "" (upload, no src_sheet_id, or
-                        // a stitch source — sheetBaseLabelFromKey suppresses those)
-                        // means render nothing, not an empty chip.
+                        // Source caption (captures only) — the SHEET NAME of the origin,
+                        // via the live sheetBaseLabel closure (the same label the tab shows:
+                        // a detected sheet number "AF101", a user rename, a stitch name, or
+                        // a file-base fallback). The marked-set export reads the SAME label
+                        // through the srcLabels map built in exportMarkedSet from this very
+                        // closure, so screen and PDF stay byte-identical. "" (upload or no
+                        // src_sheet_id) means render nothing, not an empty chip.
                         const capText = m.source === "capture" && m.source_label && m.src_sheet_id
-                          ? sourceCaption(sheetBaseLabelFromKey(m.src_sheet_id), parseSheetKey(m.src_sheet_id).page)
+                          ? sourceCaption(sheetBaseLabel(m.src_sheet_id), parseSheetKey(m.src_sheet_id).page)
                           : "";
                         return (
                           <g key={m.id}>

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -157,7 +157,7 @@ import { requiredDensity as tileRequiredDensity } from "../lib/tiles";
 // setShapes (the label-vocabulary renames, live drag PREVIEW frames, the
 // hydrate-time sanitizers, per-shape height/thickness re-pricing).
 // nowIso stays imported for the non-shape records (markups, RFIs, conditions).
-import { nowIso, mintUuid, setAuthorName } from "../lib/provenance.js";
+import { nowIso, mintUuid, setAuthorName, authorName } from "../lib/provenance.js";
 import { applyShapeCommand, geomSnapshot, vertsEqual, recordCommand } from "../lib/shapeCommands.js";
 import { applyApprovalCommand, sanitizeApprovals, approvalInk, APPROVAL_R } from "../lib/approvals.js";
 import { findCutoutParent, subtractCutout, recomposeCutouts, cutRunsAcross } from "../lib/cutout.js";
@@ -702,6 +702,10 @@ export default function TakeoffCanvas() {
   // ── the Symbol tool (#264) — same two-click marquee idiom as schedule ─────
   const [symbolAnchor, setSymbolAnchor] = useState(null);     // first marquee corner, isolated like scheduleAnchor
   const [imageAnchor, setImageAnchor] = useState(null);       // first marquee corner for the "image" screenshot tool, isolated like scheduleAnchor/symbolAnchor
+  const [placingImageId, setPlacingImageId] = useState(null); // an image markup being (re)placed: it follows the cursor until the next click drops it (re-enterable from the panel, not just at capture)
+  const placeGrabRef = useRef(null);                          // {key, dx, dy}: cursor→image-centre offset captured on the pointer's FIRST canvas contact during a place, so the image is grabbed where it sits (no teleport) and moves relative after
+  const [imgThumbs, setImgThumbs] = useState({});             // markupId → tiny JPEG dataURL for the panel row — memory-only, built once per image, NEVER persisted (a 40px <img> of a full 1600px src would decode the whole bitmap and eat the byte budget)
+  const thumbBuildingRef = useRef(new Set());                 // ids with a thumb build in flight (dedupe the async decode)
   const [sweep, setSweep] = useState(null);                   // the live review: matches / questions / seed, one sheet, dies on commit or discard
   const sweepRef = useRef(null);
   useEffect(() => { sweepRef.current = sweep; }, [sweep]);
@@ -990,6 +994,18 @@ export default function TakeoffCanvas() {
     if (t.file === active && pageLabels[t.page]) return lvl + pageLabels[t.page];
     const base = t.file.replace(/\.pdf$/i, "");
     return lvl + (t.page > 1 ? `${base} · ${t.page}` : base);
+  };
+  // A sheet's bare identifier for auto-naming an image markup (e.g. "AF101") —
+  // tabLabel WITHOUT the mutable "Level 1 · " prefix and with a hyphen so a page-2
+  // sheet reads "PLAN-2", not the compound "Level 1 · PLAN · 2" that would nest
+  // badly inside an image name like "…-01".
+  const sheetBaseLabel = (k) => {
+    if (isStitchKey(k)) return stitchById[k]?.name || "Stitched";
+    if (galleryLabels[k]) return galleryLabels[k];
+    const t = parseSheetKey(k);
+    if (t.file === active && pageLabels[t.page]) return pageLabels[t.page];
+    const base = t.file.replace(/\.pdf$/i, "");
+    return t.page > 1 ? `${base}-${t.page}` : base;
   };
 
   // ── panels: the ONE rendering model — single-sheet mode is a group of one ──
@@ -2768,7 +2784,7 @@ export default function TakeoffCanvas() {
         // tool's points, on-screen or hidden
         else if (tool === "calibrate") { setCalib((c) => c.slice(0, -1)); }
         else if (tool === "check") { setCheck((c) => c.slice(0, -1)); }
-      } else if (e.key === "Escape") { if (agentOfferFnsRef.current?.pending()) { agentOfferFnsRef.current.dismiss(); } else if (ocSel) { setOcSel(null); } else if (selVert != null) { setSelVert(null); } else { clearPoly(); setCalib([]); setCheck([]); setCheckStated(""); setScaleGuide(null); selectShape(null); setMarkupDraft(null); setProposal(null); setArmedStamp(null); setScheduleAnchor(null); setSymbolAnchor(null); setImageAnchor(null); setAlignPt(null); resetZone(); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; } }
+      } else if (e.key === "Escape") { if (agentOfferFnsRef.current?.pending()) { agentOfferFnsRef.current.dismiss(); } else if (ocSel) { setOcSel(null); } else if (selVert != null) { setSelVert(null); } else { clearPoly(); setCalib([]); setCheck([]); setCheckStated(""); setScaleGuide(null); selectShape(null); setMarkupDraft(null); setProposal(null); setArmedStamp(null); setScheduleAnchor(null); setSymbolAnchor(null); setImageAnchor(null); setPlacingImageId(null); placeGrabRef.current = null; setAlignPt(null); resetZone(); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; } }
       // ⌘Z: the drawing context wins — mid-trace it still pops the last placed
       // point (with or without ⇧, matching the old behavior byte-for-byte);
       // only with no trace in progress does the command stack engage
@@ -2833,6 +2849,16 @@ export default function TakeoffCanvas() {
       return;
     }
     if (e.button !== 0) return;   // only left-click places points
+    // an image (re)placement is armed → this left-click drops it where it now sits
+    // (onPointerMove has been centre-following the cursor). One click ends the mode.
+    if (placingImageId) {
+      const id = placingImageId;
+      setPlacingImageId(null);
+      placeGrabRef.current = null;
+      selectMarkup(id);
+      setCommitMsg("Image placed.");
+      return;
+    }
     // snapRef/angleRef are drawing-tool aids maintained by moveCrosshair, which
     // bails for the Select tool (:1577) — so in Select they'd be STALE. Select
     // does its own endpoint snap (ocSnap) on drop, so it always uses the raw
@@ -3632,6 +3658,26 @@ export default function TakeoffCanvas() {
   function onPointerMove(e) {
     lastPtrRef.current = [e.clientX, e.clientY];   // paste targets the sheet under the cursor
     aimSeqRef.current++;                           // deixis freshness tick — see getAimSeed
+    // (re)placing an image markup: it rides the cursor until the next click drops
+    // it. On the pointer's FIRST canvas contact (or when it crosses to a new sheet)
+    // we grab the image WHERE IT SITS — recording the cursor→centre offset so it
+    // doesn't teleport under the cursor — then move it by the cursor delta after.
+    // Live setMarkups mirrors the move-drag; committed on pointerdown below.
+    if (placingImageId) {
+      const q = toImage(e.clientX, e.clientY);
+      const tp = panelAt(q[0]);
+      if (tp?.img?.w) {
+        const cx = (q[0] - tp.xOffset) / tp.img.w, cy = q[1] / tp.img.h;
+        if (!placeGrabRef.current || placeGrabRef.current.key !== tp.key) {
+          const m0 = markups.find((m) => m.id === placingImageId);
+          const ax = m0 && Array.isArray(m0.at) ? m0.at[0] : cx, ay = m0 && Array.isArray(m0.at) ? m0.at[1] : cy;
+          placeGrabRef.current = { key: tp.key, dx: ax - cx, dy: ay - cy };
+        }
+        const g = placeGrabRef.current;
+        setMarkups((ms) => ms.map((m) => (m.id === placingImageId ? { ...m, at: [cx + g.dx, cy + g.dy], sheet_id: tp.key } : m)));
+      }
+      return;
+    }
     // status-bar coords — direct DOM (instrument readout; no React render per move).
     // Sheet feet when the hovered panel has a scale, raw image px otherwise.
     if (statusCoordRef.current) {
@@ -6419,8 +6465,46 @@ export default function TakeoffCanvas() {
   function addImageMarkup(m, key) {
     const used = markups.reduce((n, x) => n + (x.type === "image" && typeof x.src === "string" ? x.src.length : 0), 0);
     if (used + m.src.length > MAX_IMAGE_MARKUP_BYTES) { setCommitMsg("Too many/large images on this project — delete some before adding more."); return; }
-    addMarkup({ type: "image", ...m }, key);
+    // Auto-name (stored in `text`, which the panel renders and the ✎ edits): the
+    // sheet base + a per-sheet sequence ("AF101-01"). Uploads carry the file name.
+    // Collisions after a delete are tolerated (a simple count, not a high-water
+    // counter). Stamp the declared author (git-style; absent ⇒ omitted).
+    const { name: given, ...rest } = m;
+    const seq = markups.filter((x) => x.type === "image" && x.sheet_id === key).length + 1;
+    const text = (typeof given === "string" && given.trim()) || `${sheetBaseLabel(key)}-${String(seq).padStart(2, "0")}`;
+    const by = authorName();
+    addMarkup({ type: "image", ...rest, text, ...(by ? { author: by } : {}) }, key);
     setCommitMsg("Image placed.");
+  }
+
+  // Lazy, memory-only panel thumbnail: decode the src ONCE, downscale to a ~48px
+  // JPEG, cache by markup id. Returns null while building (the row shows a
+  // placeholder) or on a bad src; the build's setImgThumbs re-renders the row.
+  function ensureThumb(m) {
+    if (imgThumbs[m.id]) return imgThumbs[m.id];
+    if (!thumbBuildingRef.current.has(m.id) && m.src && pickEmbedFormat(m.src)) {
+      thumbBuildingRef.current.add(m.id);
+      const img = new Image();
+      img.onload = () => {
+        const s = 48 / Math.max(img.width, img.height, 1);
+        const w = Math.max(1, Math.round(img.width * s)), h = Math.max(1, Math.round(img.height * s));
+        const c = document.createElement("canvas"); c.width = w; c.height = h;
+        c.getContext("2d").drawImage(img, 0, 0, w, h);
+        setImgThumbs((t) => ({ ...t, [m.id]: c.toDataURL("image/jpeg", 0.7) }));
+      };
+      img.onerror = () => { thumbBuildingRef.current.delete(m.id); };
+      img.src = m.src;
+    }
+    return null;
+  }
+  // Provenance one-liner for the panel row's title tooltip (Kevin: not shown
+  // prominently). Degrades: drops the author when none is declared.
+  function imageProvenance(m) {
+    const verb = m.source === "upload" ? "Uploaded" : "Captured from";
+    const where = m.source === "upload" ? "" : ` ${sheetBaseLabel(m.sheet_id)}`;
+    const when = m.created_at ? ` · ${String(m.created_at).slice(0, 10)}` : "";
+    const who = m.author ? ` · ${m.author}` : "";
+    return `${verb}${where}${when}${who}`;
   }
 
   // Upload: decode a raster file (EXIF-oriented), downscale to 1600px longest side,
@@ -6478,7 +6562,7 @@ export default function TakeoffCanvas() {
         const c = toImage(r.left + r.width / 2, r.top + r.height / 2);
         at = [cl01((c[0] - focusPanel.xOffset) / focusPanel.img.w), cl01(c[1] / focusPanel.img.h)];
       }
-      addImageMarkup({ at, w: 0.2, aspect, src, source: "upload" }, focusPanel.key);
+      addImageMarkup({ at, w: 0.2, aspect, src, source: "upload", name: (file?.name || "").replace(/\.[^.]+$/, "") }, focusPanel.key);
     } catch { setCommitMsg("Couldn't read that image."); }
   }
 
@@ -7867,22 +7951,33 @@ export default function TakeoffCanvas() {
                    <div style={{ padding: "4px 12px 14px", color: "var(--ink-muted)" }}>No markups {groupKeys.length > 1 ? "on these sheets" : "on this sheet"} yet.</div>
                  )}
                  {markups.filter((m) => panelKeySet.has(m.sheet_id)).map((m) => (
-                   <div key={m.id} style={{ padding: "10px 12px", borderTop: "1px solid var(--ink-faint)" }}>
-                     <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+                   <div key={m.id} style={{ padding: "10px 12px", borderTop: "1px solid var(--ink-faint)", background: selectedMarkupId === m.id ? "var(--surface-pop)" : "transparent" }}>
+                     {/* the header line selects + flies to the markup (parity with the RFI
+                         register's onFlyTo) — the inner controls stopPropagation so only the
+                         label area triggers it, never edit/delete. */}
+                     <div onClick={() => flyToMarkup(m)} title={m.type === "image" ? imageProvenance(m) : "Select and center this markup"} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
+                       {m.type === "image" && (() => {
+                         const th = ensureThumb(m);
+                         return <span style={{ flex: "0 0 auto", width: 30, height: 30, border: "1px solid var(--ink-faint)", background: "var(--paper-bright)", display: "flex", alignItems: "center", justifyContent: "center", overflow: "hidden" }}>
+                           {th ? <img src={th} alt="" style={{ maxWidth: "100%", maxHeight: "100%", display: "block" }} /> : <span style={{ fontSize: 14 }}>🖼</span>}
+                         </span>;
+                       })()}
                        <span style={{ fontSize: 10, fontWeight: 700, color: "var(--cobalt)", textTransform: "uppercase" }}>{m.type}</span>
                        {/* inline edit — the panel's fallback for the canvas overlay, since a
                            markup here may be off-screen or on another sheet (no click point).
                            Enter/blur commit, Esc cancels; INPUT is guarded from the global keys. */}
                        {panelEditId === m.id ? (
                          <input name="markup-text" autoComplete="off" autoFocus defaultValue={m.text || ""}
+                           onClick={(e) => e.stopPropagation()}
                            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); updateMarkup(m.id, { text: e.currentTarget.value.trim() }); setPanelEditId(null); } else if (e.key === "Escape") { e.preventDefault(); e.currentTarget.value = m.text || ""; setPanelEditId(null); } }}
                            onBlur={(e) => { updateMarkup(m.id, { text: e.currentTarget.value.trim() }); setPanelEditId(null); }}
                            style={{ flex: 1, minWidth: 0, fontSize: 12.5, padding: "1px 4px", border: "1px solid var(--cobalt)", borderRadius: 0, outline: "none" }} />
                        ) : (
                          <span style={{ flex: 1, color: "var(--ink)" }}>{m.type === "svg" ? <em style={{ color: "var(--ink-muted)" }}>(vector symbol)</em> : ([m.type === "dimension" && Number(m.len_ft) > 0 ? dimLabel(m.len_ft) : "", m.text].filter(Boolean).join(" · ") || <em style={{ color: "var(--ink-muted)" }}>(no text)</em>)}</span>
                        )}
-                       {m.type !== "svg" && <button onClick={() => setPanelEditId((id) => (id === m.id ? null : m.id))} title="Edit text" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--ink-muted)" }}>✎</button>}
-                       <button onClick={() => deleteMarkup(m.id)} title="Delete markup" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--c-danger)" }}>🗑</button>
+                       {m.type === "image" && <button onClick={(e) => { e.stopPropagation(); placeGrabRef.current = null; flyToMarkup(m); setPlacingImageId(m.id); setCommitMsg("Placing image — the view centered on it; move the pointer and click to drop (Esc cancels)."); }} title="Reposition: centers the view on the image, then it follows the cursor — click the sheet to drop it" style={{ border: "1px solid var(--ink-faint)", background: placingImageId === m.id ? "var(--cobalt)" : "transparent", color: placingImageId === m.id ? "#fff" : "var(--cobalt)", cursor: "pointer", fontSize: 11, padding: "1px 7px" }}>Place</button>}
+                       {m.type !== "svg" && <button onClick={(e) => { e.stopPropagation(); setPanelEditId((id) => (id === m.id ? null : m.id)); }} title="Edit text" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--ink-muted)" }}>✎</button>}
+                       <button onClick={(e) => { e.stopPropagation(); deleteMarkup(m.id); }} title="Delete markup" style={{ border: "none", background: "none", cursor: "pointer", color: "var(--c-danger)" }}>🗑</button>
                      </div>
                      {/* appearance — per-markup color (reuse PALETTE) + line style; both
                          additive: unset color falls back to the cobalt(linked)/amber default,
@@ -8357,6 +8452,11 @@ export default function TakeoffCanvas() {
                           <g key={m.id}>
                             {halo(x0, y0, x0 + bw, y0 + bh)}
                             <image href={m.src} x={x0} y={y0} width={bw} height={bh} preserveAspectRatio="none" style={{ pointerEvents: "none" }} />
+                            {/* PERMANENT frame — a placed screenshot overlays its own source and is
+                                invisible without it; the halo is selection-only. White + slate double
+                                stroke reads on both canvas themes (the image itself is never inverted). */}
+                            <rect x={x0} y={y0} width={bw} height={bh} fill="none" stroke="#fff" strokeWidth={2.5 / z} style={{ pointerEvents: "none" }} />
+                            <rect x={x0} y={y0} width={bw} height={bh} fill="none" stroke="#2a3550" strokeWidth={1 / z} style={{ pointerEvents: "none" }} />
                             {selM && <rect x={x0 + bw - 4 / z} y={y0 + bh - 4 / z} width={8 / z} height={8 / z} fill="#1f3fc7" stroke="#fff" strokeWidth={1.5 / z} style={{ pointerEvents: "none" }} />}
                             {badge(x0, y0 - 9 / z)}
                           </g>

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -18,13 +18,14 @@ import { flushSync } from "react-dom";
 import { Link, useNavigate } from "react-router";
 import * as pdfjsLib from "pdfjs-dist";
 import workerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
-import { store, isStaleTabError, STALE_TAB_MESSAGE, projectIdFromUrl, ANN_SCHEMA, emptyAnnotations, metaGet, metaPut } from "../lib/store.js";
+import { store, isStaleTabError, STALE_TAB_MESSAGE, friendlyStoreError, projectIdFromUrl, ANN_SCHEMA, emptyAnnotations, metaGet, metaPut } from "../lib/store.js";
 import { forgetThumbs, releaseThumbs } from "../lib/thumbs.js";
 import { Z } from "../lib/ui.js";
 import { getFocusMode, toggleFocusMode, onFocusModeChange } from "../lib/focusMode.js";
 import { seedStampLibrary, instantiateStamp, markupToStampElement } from "../lib/stamps.js";
 import { extractSvgPrimitives, svgToStamp } from "../lib/svgImport.js";
 import { transformPath, svgPlacedBox } from "../lib/svgpath.js";
+import { imagePlacedBox, captureRectToImageGeom, resizeImageFromCorner, aspectFromDims, pickEmbedFormat } from "../lib/markupImage";
 import { ingestFiles } from "../lib/ingest.js";
 import { parseTakeoffImport, mergeTakeoffImport } from "../lib/importTakeoff.js";
 import { buildProjectArchive, parseProjectArchive, isProjectArchive, downloadArchive } from "../lib/projectArchive.js";
@@ -137,6 +138,7 @@ import { getTheme, toggleTheme, onThemeChange } from "../lib/theme.js";
 import {
   PANEL_GAP, DETAIL_ENGAGE, DETAIL_MARGIN, MAX_CANVAS_DIM, MAX_CANVAS_AREA, SYNC_MS, GESTURE_MS, SNAP_CELL,
   MEASURE_TOOLS, CUT_TOOLS, MARKUP_TOOLS, MARKUP_IDS, HL_INKS, HL_SIZES,
+  MARKUP_IMG_MAX, MAX_IMAGE_MARKUP_BYTES, MARKUP_UPLOAD_MAX_BYTES, MARKUP_DECODE_MAX_AREA,
 } from "../lib/canvasConstants.js";
 import { uid, clamp, isDangerMsg, instantiateTemplate, seedConditions } from "../lib/canvasUtil.js";
 // Tile-pyramid rendering (#86) — pure math in lib/tiles.ts (tested), worker
@@ -699,6 +701,7 @@ export default function TakeoffCanvas() {
   const [scheduleAnchor, setScheduleAnchor] = useState(null); // first marquee corner for the "schedule" tool — ISOLATED from poly so it can never leak into a measure shape
   // ── the Symbol tool (#264) — same two-click marquee idiom as schedule ─────
   const [symbolAnchor, setSymbolAnchor] = useState(null);     // first marquee corner, isolated like scheduleAnchor
+  const [imageAnchor, setImageAnchor] = useState(null);       // first marquee corner for the "image" screenshot tool, isolated like scheduleAnchor/symbolAnchor
   const [sweep, setSweep] = useState(null);                   // the live review: matches / questions / seed, one sheet, dies on commit or discard
   const sweepRef = useRef(null);
   useEffect(() => { sweepRef.current = sweep; }, [sweep]);
@@ -707,6 +710,7 @@ export default function TakeoffCanvas() {
   const fileInputRef = useRef(null);                    // hidden <input type=file> for "Open PDF"
   const importInputRef = useRef(null);                  // hidden <input type=file> for "Import takeoff…" (the agent-JSON handoff)
   const profileInputRef = useRef(null);                 // hidden <input type=file> for "Import profile…" (#299)
+  const imageInputRef = useRef(null);                   // hidden <input type=file> for the Markups-dock "Upload image…" button
 
   const containerRef = useRef(null);
   const stageRef = useRef(null);
@@ -1673,6 +1677,7 @@ export default function TakeoffCanvas() {
   // leaving the stamp tool disarms the pending stamp — a stray click under a
   // measure/select tool must never drop a stamp
   useEffect(() => { if (tool !== "stamp") setArmedStamp(null); }, [tool]);
+  useEffect(() => { if (tool !== "image") setImageAnchor(null); }, [tool]);   // leaving the image marquee drops a half-set anchor (mirrors scheduleAnchor/symbolAnchor reset)
   // A One-Click proposal is only actionable while One-Click is armed (Enter
   // already requires it) — discard it on tool switch, like the stamp above.
   // Also keeps Create out of the ACTION slot while Finish occupies it, so the
@@ -2390,7 +2395,12 @@ export default function TakeoffCanvas() {
       // can drain and re-hydrate. Closes the last pre-scheduled-save loss window.
       if (remotePendingRender.current) { setSaveState("idle"); return; }
       store.saveAnnotations(payload).then(() => setSaveState("saved")).catch((e) => {
-        if (isStaleTabError(e)) setCommitMsg(STALE_TAB_MESSAGE);
+        // surface the failure rather than dropping to a silent "idle" — with inline
+        // image markups a QuotaExceededError is a realistic failure mode, and a
+        // silent one loses the WHOLE payload (shapes, quantities, everything) with
+        // no signal. Stale-tab keeps its sticky lockout copy; anything else (quota,
+        // disk) shows the actionable friendlyStoreError text.
+        setCommitMsg(isStaleTabError(e) ? STALE_TAB_MESSAGE : friendlyStoreError(e));
         setSaveState("idle");
       });
     }, 700);
@@ -2758,7 +2768,7 @@ export default function TakeoffCanvas() {
         // tool's points, on-screen or hidden
         else if (tool === "calibrate") { setCalib((c) => c.slice(0, -1)); }
         else if (tool === "check") { setCheck((c) => c.slice(0, -1)); }
-      } else if (e.key === "Escape") { if (agentOfferFnsRef.current?.pending()) { agentOfferFnsRef.current.dismiss(); } else if (ocSel) { setOcSel(null); } else if (selVert != null) { setSelVert(null); } else { clearPoly(); setCalib([]); setCheck([]); setCheckStated(""); setScaleGuide(null); selectShape(null); setMarkupDraft(null); setProposal(null); setArmedStamp(null); setScheduleAnchor(null); setSymbolAnchor(null); setAlignPt(null); resetZone(); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; } }
+      } else if (e.key === "Escape") { if (agentOfferFnsRef.current?.pending()) { agentOfferFnsRef.current.dismiss(); } else if (ocSel) { setOcSel(null); } else if (selVert != null) { setSelVert(null); } else { clearPoly(); setCalib([]); setCheck([]); setCheckStated(""); setScaleGuide(null); selectShape(null); setMarkupDraft(null); setProposal(null); setArmedStamp(null); setScheduleAnchor(null); setSymbolAnchor(null); setImageAnchor(null); setAlignPt(null); resetZone(); hlRef.current = null; if (hlPathRef.current) hlPathRef.current.style.display = "none"; } }
       // ⌘Z: the drawing context wins — mid-trace it still pops the last placed
       // point (with or without ⇧, matching the old behavior byte-for-byte);
       // only with no trace in progress does the command stack engage
@@ -2891,6 +2901,12 @@ export default function TakeoffCanvas() {
       if (!symbolAnchor) setSymbolAnchor(p);
       else { runSymbolSweep(symbolAnchor, p); setSymbolAnchor(null); }
     }
+    else if (tool === "image") {
+      // two-click marquee, isolated state like schedule/symbol — routes ONLY here,
+      // never through placeMarkup (which has no image case and would no-op)
+      if (!imageAnchor) setImageAnchor(p);
+      else { captureRegionMarkup(imageAnchor, p); setImageAnchor(null); setTool("select"); }
+    }
     else if (tool === "cloud" || tool === "callout" || tool === "text" || tool === "highlight" || tool === "dimension") placeMarkup(p);
     else if (tool === "stamp") placeStamp(p);
     else if (tool === "approve") placeApproval(p);
@@ -2992,6 +3008,14 @@ export default function TakeoffCanvas() {
       const cx = m.at[0] * W + ox, cy = m.at[1] * H;
       return X >= cx - bw / 2 - thr && X <= cx + bw / 2 + thr && Y >= cy - bh / 2 - thr && Y <= cy + bh / 2 + thr;
     }
+    if (m.type === "image" && Array.isArray(m.at) && Number(m.w) > 0 && pickEmbedFormat(m.src)) {
+      // a raster image — hit its placed box (width-anchored, same box the renderer
+      // draws). Gate on a PNG/JPEG DATA url (pickEmbedFormat) so an imported record
+      // with a non-data src (e.g. http(s)://) is neither rendered nor selectable.
+      const { bw, bh } = imagePlacedBox(m.w, m.aspect, W);
+      const cx = m.at[0] * W + ox, cy = m.at[1] * H;
+      return X >= cx - bw / 2 - thr && X <= cx + bw / 2 + thr && Y >= cy - bh / 2 - thr && Y <= cy + bh / 2 + thr;
+    }
     return false;
   }
   // Select tool: pick a shape (or a vertex of the selected one) and start dragging
@@ -3068,6 +3092,28 @@ export default function TakeoffCanvas() {
         e.currentTarget.setPointerCapture(e.pointerId); return;
       }
     }
+    // 1b. a selected image's bottom-right RESIZE handle wins next (screen-constant,
+    //     /z). Gated on the resolved markup being type "image" so this never fires
+    //     on another selected markup. Fixed top-left; onPointerMove drives the live
+    //     resize via resizeImageFromCorner.
+    if (showMarkups && selectedMarkupId) {
+      const selMk = markups.find((mm) => mm.id === selectedMarkupId);
+      // require the image to be on a VISIBLE panel — panelByKey falls back to
+      // panels[0] for an off-group sheet, which would arm the resize against the
+      // wrong panel's dims and corrupt an off-view image's w/at.
+      if (selMk && selMk.type === "image" && selMk.at && panelKeySet.has(selMk.sheet_id)) {
+        const sp = panelByKey(selMk.sheet_id);
+        if (sp && sp.img.w) {
+          const { bw, bh } = imagePlacedBox(selMk.w, selMk.aspect, sp.img.w);
+          const brx = selMk.at[0] * sp.img.w + sp.xOffset + bw / 2, bry = selMk.at[1] * sp.img.h + bh / 2;
+          if (Math.hypot(p[0] - brx, p[1] - bry) < thr * 1.5) {
+            const tlx = selMk.at[0] * sp.img.w - bw / 2, tly = selMk.at[1] * sp.img.h - bh / 2;
+            dragRef.current = { kind: "markupResize", markupId: selMk.id, tl: { x: tlx, y: tly }, aspect: selMk.aspect, ox: sp.xOffset, imgW: sp.img.w, imgH: sp.img.h };
+            e.currentTarget.setPointerCapture(e.pointerId); return;
+          }
+        }
+      }
+    }
     // 2. markups render ON TOP of shapes (:2137 > :2093), so a markup hit wins over a
     //    plain shape click — but NOT over the selected shape's handles above.
     //    When the markup layer is hidden (showMarkups false), skip the search
@@ -3077,8 +3123,12 @@ export default function TakeoffCanvas() {
       // a NON-highlight markup hit beats a highlight at the same point (test
       // highlights last), so a linked cloud/callout under a highlight stays
       // clickable; a highlight still wins over a plain shape (it shields it).
-      const mHit = rev.find((m) => m.type !== "highlight" && hitMarkup(m, p, thr))
-                || rev.find((m) => m.type === "highlight" && hitMarkup(m, p, thr));
+      // three tiers: plain markups first, then highlight, then image LAST — so a
+      // large image never shadows another markup from selection (an image shields
+      // shapes beneath it like a highlight box does; move it to reach what's under).
+      const mHit = rev.find((m) => m.type !== "highlight" && m.type !== "image" && hitMarkup(m, p, thr))
+                || rev.find((m) => m.type === "highlight" && hitMarkup(m, p, thr))
+                || rev.find((m) => m.type === "image" && hitMarkup(m, p, thr));
       if (mHit) {
         selectMarkup(mHit.id);
         // arm a move drag — snapshot the markup's current normalized coords (all four
@@ -3449,8 +3499,9 @@ export default function TakeoffCanvas() {
     if (rectRef.current) {
       const schedDraw = tool === "schedule" && scheduleAnchor;
       const symDraw = tool === "symbol" && symbolAnchor;
-      if (!panRef.current && ((tool === "rect" || tool === "deduct-rect") && poly.length === 1 || schedDraw || symDraw)) {
-        const a = symDraw ? symbolAnchor : schedDraw ? scheduleAnchor : poly[0];
+      const imgDraw = tool === "image" && imageAnchor;
+      if (!panRef.current && ((tool === "rect" || tool === "deduct-rect") && poly.length === 1 || schedDraw || symDraw || imgDraw)) {
+        const a = imgDraw ? imageAnchor : symDraw ? symbolAnchor : schedDraw ? scheduleAnchor : poly[0];
         rectRef.current.setAttribute("x", Math.min(a[0], cur[0])); rectRef.current.setAttribute("y", Math.min(a[1], cur[1]));
         rectRef.current.setAttribute("width", Math.abs(cur[0] - a[0])); rectRef.current.setAttribute("height", Math.abs(cur[1] - a[1]));
         rectRef.current.style.display = "block";
@@ -3708,6 +3759,15 @@ export default function TakeoffCanvas() {
           if (o.from) return { ...m, from: [o.from[0] + dx, o.from[1] + dy], to: [o.to[0] + dx, o.to[1] + dy] };
           return { ...m, at: [o.at[0] + dx, o.at[1] + dy] };   // text + bubble
         }));
+      } else if (d.kind === "markupResize") {
+        // drag the BR corner while the top-left stays fixed — resizeImageFromCorner
+        // clamps width first, then derives the new center so the top-left is
+        // invariant even at the clamp rails. Live setMarkups (not commit-on-release);
+        // onPointerUp sees a non-shape kind and just releases capture.
+        const mp = toImage(e.clientX, e.clientY);
+        const pointerLocalX = mp[0] - d.ox;
+        const { w, at } = resizeImageFromCorner({ x: d.tl.x, y: d.tl.y }, { x: pointerLocalX, y: mp[1] }, d.aspect, d.imgW, d.imgH);
+        setMarkups((ms) => ms.map((m) => (m.id === d.markupId ? { ...m, w, at } : m)));
       }
       return;
     }
@@ -5044,12 +5104,13 @@ export default function TakeoffCanvas() {
     const p = toImage(e.clientX, e.clientY);
     const thr = 8 / tfRef.current.scale;
     const rev = [...visibleMarkups].reverse();
-    const m = rev.find((mm) => mm.type !== "highlight" && hitMarkup(mm, p, thr))
-      || rev.find((mm) => mm.type === "highlight" && hitMarkup(mm, p, thr));
+    const m = rev.find((mm) => mm.type !== "highlight" && mm.type !== "image" && hitMarkup(mm, p, thr))
+      || rev.find((mm) => mm.type === "highlight" && hitMarkup(mm, p, thr))
+      || rev.find((mm) => mm.type === "image" && hitMarkup(mm, p, thr));
     if (!m) return;
     // an svg symbol carries no text — select it, but don't open a dead-end editor;
     // a highlighter stroke is pure ink (no text either), same rule
-    if (m.type === "svg" || (m.type === "highlight" && Array.isArray(m.pts))) { selectMarkup(m.id); return; }
+    if (m.type === "svg" || m.type === "image" || (m.type === "highlight" && Array.isArray(m.pts))) { selectMarkup(m.id); return; }
     const anchor = markupAnchorStage(m);
     if (!anchor) return;
     selectMarkup(m.id);
@@ -6302,6 +6363,123 @@ export default function TakeoffCanvas() {
     }).promise;
     const dataUrl = canvas.toDataURL("image/png");
     return { b64: dataUrl.split(",")[1] || "", width: bw, height: bh };
+  }
+
+  // ── image markup (#…) — two entry points, one record type ────────────────
+  // Marquee screenshot: a,b are the two marquee corners in stage px. Render the
+  // boxed region of the plan offscreen (the rasterizeRegion idiom, but with its
+  // OWN 1600px downscale factor — NOT scanRasterScale's 4096 cap) and store it as
+  // a floating `image` markup anchored at the box center. Guards mirror
+  // importScheduleFromRect: sheet ready, both corners in one panel, a real source
+  // page (refuse a stitched composite), a non-degenerate box.
+  async function captureRegionMarkup(a, b) {
+    if (status !== "ready") { setCommitMsg("Sheet still loading — try again in a moment."); return; }
+    const panel = panelAt(a[0]);
+    if (panelAt(b[0]).key !== panel.key) { setCommitMsg("Draw the box within a single sheet."); return; }
+    const pageObj = pageObjsRef.current.get(panel.key);
+    if (!pageObj) { setCommitMsg("Capture a region on a single sheet (not a stitched view)."); return; }
+    const rs = renderScalesRef.current.get(panel.key) || RENDER_SCALE;
+    // rect in image (rs-viewport) px, clamped to the panel bounds so an over-drag
+    // past the sheet edge never parks the geometry off-sheet
+    const cl = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+    const x0 = cl(Math.min(a[0], b[0]) - panel.xOffset, 0, panel.img.w);
+    const x1 = cl(Math.max(a[0], b[0]) - panel.xOffset, 0, panel.img.w);
+    const y0 = cl(Math.min(a[1], b[1]), 0, panel.img.h);
+    const y1 = cl(Math.max(a[1], b[1]), 0, panel.img.h);
+    const regW = x1 - x0, regH = y1 - y0;
+    if (!(regW >= 4 && regH >= 4)) { setCommitMsg("Drag a larger box to capture."); return; }
+    // own downscale factor: 1600px longest side (never scanRasterScale's 4096)
+    const factor = Math.min(1, MARKUP_IMG_MAX / regW, MARKUP_IMG_MAX / regH);
+    const bw = Math.max(1, Math.round(regW * factor)), bh = Math.max(1, Math.round(regH * factor));
+    let src;
+    try {
+      const vp = pageObj.getViewport({ scale: rs * factor });
+      const canvas = document.createElement("canvas");
+      canvas.width = bw; canvas.height = bh;
+      await pageObj.render({
+        canvasContext: canvas.getContext("2d"),
+        viewport: vp,
+        transform: [1, 0, 0, 1, -x0 * factor, -y0 * factor],
+      }).promise;
+      src = canvas.toDataURL("image/png");
+    } catch { setCommitMsg("Couldn't capture that region."); return; }
+    const { at, w, aspect } = captureRectToImageGeom({ x0, y0, x1, y1 }, panel.img.w, panel.img.h);
+    if (!(w > 0)) return;
+    addImageMarkup({ at, w, aspect, src, source: "capture" }, panel.key);
+  }
+
+  // The aggregate-budget gate shared by both entry points: refuse a new image when
+  // the project's total image-markup bytes would exceed the cap (N capped images
+  // otherwise defeat the per-image cap and push the annotations blob past quota).
+  // This is a SOFT guard read from the render-closure `markups`; two back-to-back
+  // async adds could momentarily race it, but the per-image 1600px cap already
+  // bounds each one, so the worst case is a single image slipping just over the
+  // budget — not a correctness or safety issue, and the quota surfacing in the
+  // autosave catch is the real backstop.
+  function addImageMarkup(m, key) {
+    const used = markups.reduce((n, x) => n + (x.type === "image" && typeof x.src === "string" ? x.src.length : 0), 0);
+    if (used + m.src.length > MAX_IMAGE_MARKUP_BYTES) { setCommitMsg("Too many/large images on this project — delete some before adding more."); return; }
+    addMarkup({ type: "image", ...m }, key);
+    setCommitMsg("Image placed.");
+  }
+
+  // Upload: decode a raster file (EXIF-oriented), downscale to 1600px longest side,
+  // ALWAYS re-encode through a canvas (pixels only — SSRF/script-safe; guarantees a
+  // PNG/JPEG data URL), and drop it centered in the current view of the focus sheet.
+  async function addImageFromFile(file) {
+    // don't trust accept="image/*": accept ONLY PNG/JPEG — matching the UI copy,
+    // the docs, and pickEmbedFormat (the marked-set gate), and keeping the decode
+    // surface small. By MIME OR by extension, because some platforms/drag-drop hand
+    // over an empty file.type for a good PNG/JPEG (the StampPanel import checks the
+    // extension for the same reason). Everything else — webp/gif/bmp, and SVG — is
+    // refused here (uploads are still re-encoded to PNG/JPEG regardless).
+    const name = file?.name || "";
+    const isPngJpeg = !!file && (/^image\/(png|jpeg)$/.test(file.type) || /\.(png|jpe?g)$/i.test(name));
+    if (!isPngJpeg) {
+      setCommitMsg("Pick a PNG or JPEG image."); return;
+    }
+    // cheap pre-decode gate: bail on a huge FILE before createImageBitmap allocates
+    // anything (a small-file / huge-dims pixel bomb is caught by the area guard below).
+    if (file.size > MARKUP_UPLOAD_MAX_BYTES) { setCommitMsg(`That image file is too large (max ${Math.round(MARKUP_UPLOAD_MAX_BYTES / (1024 * 1024))} MB).`); return; }
+    try {
+      // sniff intrinsic dimensions via an <img> FIRST — reading naturalWidth/Height
+      // only needs the header, so a pixel bomb (small file, enormous declared dims)
+      // is refused BEFORE createImageBitmap forces a full-size RGBA decode that could
+      // OOM the tab. createImageBitmap then only runs on an already-bounded image.
+      const url = URL.createObjectURL(file);
+      try {
+        const dims = await new Promise((res, rej) => {
+          const im = new Image();
+          im.onload = () => res({ w: im.naturalWidth, h: im.naturalHeight });
+          im.onerror = () => rej(new Error("decode"));
+          im.src = url;
+        });
+        if (dims.w * dims.h > MARKUP_DECODE_MAX_AREA) { setCommitMsg("That image is too large (too many pixels)."); return; }
+      } finally { URL.revokeObjectURL(url); }
+      const bmp = await createImageBitmap(file, { imageOrientation: "from-image" });
+      // defense-in-depth: the oriented bitmap's own area, in case the sniff and the
+      // decoder disagree (a markup-appropriate cap, NOT the 241M render-canvas cap).
+      if (bmp.width * bmp.height > MARKUP_DECODE_MAX_AREA) { bmp.close?.(); setCommitMsg("That image is too large (too many pixels)."); return; }
+      const f = Math.min(1, MARKUP_IMG_MAX / Math.max(bmp.width, bmp.height));
+      const bw = Math.max(1, Math.round(bmp.width * f)), bh = Math.max(1, Math.round(bmp.height * f));
+      const canvas = document.createElement("canvas");
+      canvas.width = bw; canvas.height = bh;
+      canvas.getContext("2d").drawImage(bmp, 0, 0, bw, bh);
+      bmp.close?.();
+      const isJpeg = file.type === "image/jpeg";
+      const src = canvas.toDataURL(isJpeg ? "image/jpeg" : "image/png", isJpeg ? 0.85 : undefined);
+      const aspect = aspectFromDims(bw, bh);
+      // center of the current view, normalized to the focus panel (falls back to
+      // the panel center if the view geometry isn't available)
+      const cl01 = (v) => Math.min(1, Math.max(0, v));
+      let at = [0.5, 0.5];
+      const r = containerRef.current?.getBoundingClientRect();
+      if (r) {
+        const c = toImage(r.left + r.width / 2, r.top + r.height / 2);
+        at = [cl01((c[0] - focusPanel.xOffset) / focusPanel.img.w), cl01(c[1] / focusPanel.img.h)];
+      }
+      addImageMarkup({ at, w: 0.2, aspect, src, source: "upload" }, focusPanel.key);
+    } catch { setCommitMsg("Couldn't read that image."); }
   }
 
   // Approved rows → conditions. Category drives color/hatch/waste (rowToSeed);
@@ -7665,7 +7843,16 @@ export default function TakeoffCanvas() {
                  {/* layer show/hide — hides the on-canvas markup layer AND its hit-testing
                      (can't select/delete/fly-to an invisible markup); orthogonal to the
                      marked-set export, which still includes markups. */}
-                 <div style={{ display: "flex", justifyContent: "flex-end", padding: "6px 10px", borderBottom: "1px solid var(--ink-faint)" }}>
+                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "6px 10px", borderBottom: "1px solid var(--ink-faint)" }}>
+                   {/* hidden input reused by the Upload button — re-encoded through addImageFromFile */}
+                   <input name="markup-image-file" ref={imageInputRef} type="file" accept="image/*" style={{ display: "none" }}
+                     onChange={(e) => { const f = e.target.files?.[0]; if (f) addImageFromFile(f); e.target.value = ""; }} />
+                   <button
+                     onClick={() => imageInputRef.current?.click()}
+                     title="Upload a raster image (PNG or JPEG) as a floating annotation on the current sheet"
+                     style={{ background: "transparent", border: "1px solid var(--ink-faint)", color: "var(--ink)", fontSize: 11, cursor: "pointer", padding: "2px 7px" }}>
+                     Upload image…
+                   </button>
                    <button
                      onClick={() => { const nv = !showMarkups; setShowMarkups(nv); if (!nv) setSelectedMarkupId(null); }}
                      title={showMarkups ? "Hide the markup layer on the canvas" : "Show the markup layer on the canvas"}
@@ -7674,7 +7861,7 @@ export default function TakeoffCanvas() {
                    </button>
                  </div>
                  <div style={{ padding: "8px 10px", color: "var(--ink-muted)" }}>
-                   Pick <b>☁ Cloud</b>, <b>▨ Highlight</b>, <b>💬 Callout</b>, <b>T Text</b>, or <b>⟷ Dimension</b> above, then click the plan to annotate it.
+                   Pick <b>☁ Cloud</b>, <b>▨ Highlight</b>, <b>💬 Callout</b>, <b>T Text</b>, or <b>⟷ Dimension</b> above, then click the plan to annotate it. <b>🖼 Image</b> marquees a region (two clicks) — or use <b>Upload image…</b> above.
                  </div>
                  {markups.filter((m) => panelKeySet.has(m.sheet_id)).length === 0 && (
                    <div style={{ padding: "4px 12px 14px", color: "var(--ink-muted)" }}>No markups {groupKeys.length > 1 ? "on these sheets" : "on this sheet"} yet.</div>
@@ -7985,7 +8172,13 @@ export default function TakeoffCanvas() {
                         FILL (dark-boosted on the dark canvas); RFI linkage is an unconditional
                         ⬢/number badge, independent of the note text. Layer hides via showMarkups. */}
                     {showMarkups && visibleMarkups.filter((m) => m.sheet_id === p.key)
-                      .slice().sort((a, b) => (a.type === "highlight" ? 0 : 1) - (b.type === "highlight" ? 0 : 1))
+                      // three draw tiers that MATCH the three hit tiers (selectAt),
+                      // so on-screen z-order never contradicts selection priority:
+                      // image at the back (0), highlight (1), everything else on top
+                      // (2). Painting is document order, so tier 0 draws first/behind
+                      // and tier 2 last/on top; hit-test ranks them in reverse, so the
+                      // topmost-drawn markup is the one a click selects.
+                      .slice().sort((a, b) => (a.type === "image" ? 0 : a.type === "highlight" ? 1 : 2) - (b.type === "image" ? 0 : b.type === "highlight" ? 1 : 2))
                       .map((m) => {
                       const z = tf.scale;
                       // Colour precedence: an explicit per-markup colour always
@@ -8145,6 +8338,27 @@ export default function TakeoffCanvas() {
                             <circle cx={cx} cy={cy} r={rad} fill={darkMode ? "rgba(12,15,20,.85)" : "rgba(255,255,255,.85)"} stroke={mk} strokeWidth={(2 * w) / z} strokeDasharray={dash} />
                             {m.text && <text x={cx} y={cy} fill={mk} fontSize={Math.min(13, rad * z * 0.9) / z} fontWeight="700" textAnchor="middle" dominantBaseline="central" style={{ pointerEvents: "none" }}>{m.text}</text>}
                             {badge(cx + rad, cy - rad - 4 / z)}
+                          </g>
+                        );
+                      }
+                      if (m.type === "image") {
+                        // a raster image markup (screenshot capture or upload). Width-anchored
+                        // like svg but off `m.w` alone (imagePlacedBox), rendered as-is (no
+                        // dark-mode invert — a screenshot is captured from the light PDF).
+                        // Self-contained: a guard-fail returns null, never falling through to
+                        // the text renderer below (which would paint a phantom note box).
+                        const { bw, bh } = imagePlacedBox(m.w, m.aspect, p.img.w);
+                        // only a PNG/JPEG DATA url renders (matches the marked-set
+                        // export invariant) — an imported record with an http(s)://
+                        // src must never make <image href> fetch remote content.
+                        if (!(m.src && pickEmbedFormat(m.src) && Array.isArray(m.at) && bw > 0 && bh > 0)) return null;
+                        const x0 = m.at[0] * p.img.w - bw / 2, y0 = m.at[1] * p.img.h - bh / 2;
+                        return (
+                          <g key={m.id}>
+                            {halo(x0, y0, x0 + bw, y0 + bh)}
+                            <image href={m.src} x={x0} y={y0} width={bw} height={bh} preserveAspectRatio="none" style={{ pointerEvents: "none" }} />
+                            {selM && <rect x={x0 + bw - 4 / z} y={y0 + bh - 4 / z} width={8 / z} height={8 / z} fill="#1f3fc7" stroke="#fff" strokeWidth={1.5 / z} style={{ pointerEvents: "none" }} />}
+                            {badge(x0, y0 - 9 / z)}
                           </g>
                         );
                       }

--- a/web/src/pages/TakeoffCanvas.jsx
+++ b/web/src/pages/TakeoffCanvas.jsx
@@ -5554,6 +5554,8 @@ export default function TakeoffCanvas() {
       setPlacingImageId(m.id);
       setCommitMsg("Placing image — the view centered on it; move the pointer and click to drop (Esc cancels).");
     } else {
+      pendingFlyRef.current = null;   // an outstanding fly-to (unrelated markup, sheet still opening) must not complete later and recenter the view mid cross-sheet placement — same race class as flyToMarkup clearing pendingSourceRef
+      setShowMarkups(true);           // the cross-sheet branch skips flyToMarkup (which sets this for the same-sheet case) — without it, a hidden markup layer means the drag preview is invisible until commit
       placeCrossSheetRef.current = m.id;
       setPlacingImageId(m.id);
       setCommitMsg("Placing image on this sheet — move the pointer and click to drop (Esc cancels).");

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -160,6 +160,26 @@ input, textarea { font-family: var(--f-body); }
   0%, 100% { opacity: 1; }
   50%      { opacity: .35; }
 }
+/* Source-trace flash (◎, TakeoffCanvas's `flashSource`) — a BOUNDED pulse (3
+   iterations of .85s, ~2.55s total, matched by flashSource's own one-shot
+   auto-clear timer) that settles dim on its last cycle instead of holding a
+   solid highlight. Deliberately its own keyframes rather than a reuse of
+   `pulse` above: pulse also drives the INFINITE `.status-dot.is-live` loop,
+   and giving pulse asymmetric endpoints would put a visible snap back to
+   full opacity in that dot's loop every cycle. Paired with
+   `animation-fill-mode: forwards` at the call site so the brief window
+   between the animation finishing and flashSource's timer clearing the state
+   holds this dim frame, not an opaque one. The end value is a middling .5,
+   not near-zero: under `prefers-reduced-motion` (below), the animation
+   duration collapses to ~0 and `forwards` snaps straight to the 100% frame
+   for the full ~2.6s until the timer clears it — a near-invisible end value
+   would leave reduced-motion users with no visible highlight at all, which
+   defeats the feature. .5 stays legible for both motion preferences. */
+@keyframes sourceFlashPulse {
+  0%   { opacity: 1; }
+  50%  { opacity: .35; }
+  100% { opacity: .5; }
+}
 
 /* honor the user's motion preference */
 @media (prefers-reduced-motion: reduce) {

--- a/web/test/markedset.image.test.ts
+++ b/web/test/markedset.image.test.ts
@@ -188,32 +188,60 @@ test("marked set: a capture image with a caption on a ROTATED source page still 
   assert.ok(text.includes("Source: "), "the source caption text is present on the rotated sheet's page");
 });
 
-// The caption shows the ORIGIN sheet's on-screen NAME, supplied by the caller as
-// srcLabels[src_sheet_id] (exportMarkedSet resolves it via the sheetBaseLabel
-// closure so the PDF matches the canvas). Prove the passed label — not the
-// file-base fallback — is what lands in the caption text.
-test("marked set: the source caption uses srcLabels (the sheet name), not the file-base fallback", async () => {
+// The caption shows the ORIGIN sheet's on-screen NAME, FROZEN on the markup as
+// m.src_label at capture time (the canvas stamps sheetBaseLabel there, and the PDF
+// reads the same stored string, so screen and PDF can't diverge). Prove the frozen
+// label — not the file-base fallback — is what lands in the caption text.
+test("marked set: the source caption uses the frozen m.src_label (sheet name), not the file-base fallback", async () => {
   const srcBytes = await makeSourcePdf();
   const sheets = [{ key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" }];
   const markups = [{
     id: "mk1", type: "image", sheet_id: "S1", at: [0.5, 0.5], w: 0.3, aspect: 1, src: PNG,
-    source: "capture", source_label: true, src_sheet_id: "plan.pdf#1",
+    source: "capture", source_label: true, src_sheet_id: "plan.pdf#1", src_label: "AF101",
     src_rect: [[0.1, 0.1], [0.4, 0.4]],
   }];
   const pages: Record<number, ReturnType<typeof mockPage>> = { 1: mockPage(612, 792, 0) };
   const { bytes } = await buildMarkedSetPdf({
     projectName: "Test", dark: false, units: "imperial",
-    sheets, srcLabels: { "plan.pdf#1": "AF101" }, shapes: [], markups, approvals: [], rfis: [], conditions: [], company: undefined, clientInfo: undefined,
+    sheets, shapes: [], markups, approvals: [], rfis: [], conditions: [], company: undefined, clientInfo: undefined,
     getPage: async (_file: string, pageNum: number) => pages[pageNum],
     loadPdfData: async () => srcBytes,
   });
   const text = await pageText(bytes, 1);
   assert.ok(text.includes("Sheet 1"), "pageText decoded real text off this page (sheet footer label)");
-  assert.ok(text.includes("Source: AF101"), "the caption shows the srcLabels sheet name (AF101), not the file base 'plan'");
-  assert.ok(!text.includes("Source: plan"), "the file-base fallback is NOT used when a srcLabels entry exists");
+  assert.ok(text.includes("Source: AF101"), "the caption shows the frozen src_label sheet name (AF101), not the file base 'plan'");
+  assert.ok(!text.includes("Source: plan"), "the file-base fallback is NOT used when src_label is present");
 });
 
-test("marked set: a capture image whose src_sheet_id is a STITCH key exports with the caption suppressed, no crash", async () => {
+// A stitch-origin capture carries the stitch NAME in src_label and has no page
+// number — the caption reads "Source: <name>" with NO "· p.N".
+test("marked set: a STITCH-origin capture shows its name with no page, no crash", async () => {
+  const srcBytes = await makeSourcePdf();
+  const sheets = [{ key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" }];
+  const markups = [{
+    id: "mk1", type: "image", sheet_id: "S1", at: [0.5, 0.5], w: 0.3, aspect: 1, src: PNG,
+    source: "capture", source_label: true, src_sheet_id: "stitch:abc", src_label: "West Wing (stitched)",
+    src_rect: [[0.1, 0.1], [0.4, 0.4]],
+  }];
+  const pages: Record<number, ReturnType<typeof mockPage>> = { 1: mockPage(612, 792, 0) };
+  const { bytes } = await buildMarkedSetPdf({
+    projectName: "Test", dark: false, units: "imperial",
+    sheets, shapes: [], markups, approvals: [], rfis: [], conditions: [], company: undefined, clientInfo: undefined,
+    getPage: async (_file: string, pageNum: number) => pages[pageNum],
+    loadPdfData: async () => srcBytes,
+  });
+  const perPage = await imageXObjectsPerPage(bytes);
+  assert.equal(perPage.length, 2, "cover + the one marked sheet");
+  assert.equal(perPage[1], 1, "the image still exports alongside the stitch-origin caption");
+  const text = await pageText(bytes, 1);
+  assert.ok(text.includes("Sheet 1"), "pageText decoded real text off this page (sheet footer label)");
+  assert.ok(text.includes("Source: West Wing (stitched)"), "the stitch name is shown");
+  assert.ok(!/West Wing \(stitched\)\s*·\s*p\./.test(text), "no fabricated '· p.N' is appended for a stitch origin");
+});
+
+// A legacy capture with NO src_label (made before the freeze) degrades to the pure
+// file/page fallback — and a stitch key with no src_label still suppresses cleanly.
+test("marked set: a legacy capture without src_label falls back (stitch key ⇒ suppressed, no crash)", async () => {
   const srcBytes = await makeSourcePdf();
   const sheets = [{ key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" }];
   const markups = [{
@@ -229,12 +257,8 @@ test("marked set: a capture image whose src_sheet_id is a STITCH key exports wit
     loadPdfData: async () => srcBytes,
   });
   const perPage = await imageXObjectsPerPage(bytes);
-  assert.equal(perPage.length, 2, "cover + the one marked sheet");
-  assert.equal(perPage[1], 1, "the image still exports even though sheetBaseLabelFromKey suppresses a stitch-key caption");
+  assert.equal(perPage[1], 1, "the image still exports even though the fallback suppresses a stitch-key caption");
   const text = await pageText(bytes, 1);
-  // Positive anchor FIRST (see the ROTATED test above for why): without it, a
-  // pageText that silently returned "" would make the negative assertion
-  // below pass for the wrong reason.
   assert.ok(text.includes("Sheet 1"), "pageText decoded real text off this page (sheet footer label)");
-  assert.ok(!text.includes("Source: "), "no caption text is drawn for a stitch-key source");
+  assert.ok(!text.includes("Source: "), "no caption for a legacy stitch-key source (fallback returns '')");
 });

--- a/web/test/markedset.image.test.ts
+++ b/web/test/markedset.image.test.ts
@@ -188,6 +188,31 @@ test("marked set: a capture image with a caption on a ROTATED source page still 
   assert.ok(text.includes("Source: "), "the source caption text is present on the rotated sheet's page");
 });
 
+// The caption shows the ORIGIN sheet's on-screen NAME, supplied by the caller as
+// srcLabels[src_sheet_id] (exportMarkedSet resolves it via the sheetBaseLabel
+// closure so the PDF matches the canvas). Prove the passed label — not the
+// file-base fallback — is what lands in the caption text.
+test("marked set: the source caption uses srcLabels (the sheet name), not the file-base fallback", async () => {
+  const srcBytes = await makeSourcePdf();
+  const sheets = [{ key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" }];
+  const markups = [{
+    id: "mk1", type: "image", sheet_id: "S1", at: [0.5, 0.5], w: 0.3, aspect: 1, src: PNG,
+    source: "capture", source_label: true, src_sheet_id: "plan.pdf#1",
+    src_rect: [[0.1, 0.1], [0.4, 0.4]],
+  }];
+  const pages: Record<number, ReturnType<typeof mockPage>> = { 1: mockPage(612, 792, 0) };
+  const { bytes } = await buildMarkedSetPdf({
+    projectName: "Test", dark: false, units: "imperial",
+    sheets, srcLabels: { "plan.pdf#1": "AF101" }, shapes: [], markups, approvals: [], rfis: [], conditions: [], company: undefined, clientInfo: undefined,
+    getPage: async (_file: string, pageNum: number) => pages[pageNum],
+    loadPdfData: async () => srcBytes,
+  });
+  const text = await pageText(bytes, 1);
+  assert.ok(text.includes("Sheet 1"), "pageText decoded real text off this page (sheet footer label)");
+  assert.ok(text.includes("Source: AF101"), "the caption shows the srcLabels sheet name (AF101), not the file base 'plan'");
+  assert.ok(!text.includes("Source: plan"), "the file-base fallback is NOT used when a srcLabels entry exists");
+});
+
 test("marked set: a capture image whose src_sheet_id is a STITCH key exports with the caption suppressed, no crash", async () => {
   const srcBytes = await makeSourcePdf();
   const sheets = [{ key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" }];

--- a/web/test/markedset.image.test.ts
+++ b/web/test/markedset.image.test.ts
@@ -33,6 +33,36 @@ async function makeSourcePdf() {
   return src.save();
 }
 
+// Decodes a page's content stream(s) back to a plain-text search string, so a
+// test can assert a caption STRING actually landed on the page rather than
+// only checking the image XObject count (which a throwing caption draw would
+// never affect — the caption code runs strictly after pg.drawImage, inside
+// the same try/catch as the image embed). pdf-lib's StandardFontEmbedder
+// encodes every drawn string as a PDFHexString (WinAnsi code points, which
+// are byte-identical to Latin-1/ASCII for the caption's character set), so
+// decoding each `<...>Tj` operand and concatenating in stream order recovers
+// the drawn text well enough for a substring check.
+async function pageText(bytes: Uint8Array, pageIndex: number): Promise<string> {
+  const { PDFDocument, PDFName } = await import("pdf-lib");
+  const zlib = await import("node:zlib");
+  const out = await PDFDocument.load(bytes);
+  const page: any = out.getPages()[pageIndex];
+  const contentsRef: any = page.node.Contents();
+  const refs = contentsRef && typeof contentsRef.asArray === "function" ? contentsRef.asArray() : [contentsRef];
+  let text = "";
+  for (const ref of refs) {
+    const stream: any = out.context.lookup(ref);
+    if (!stream) continue;
+    const filter = stream.dict && stream.dict.lookup(PDFName.of("Filter"));
+    let data: Uint8Array = stream.contents;
+    if (filter && String(filter) === "/FlateDecode") data = zlib.inflateSync(Buffer.from(data));
+    const raw = Buffer.from(data).toString("latin1");
+    const hexTokens = raw.match(/<[0-9A-Fa-f]+>/g) || [];
+    text += hexTokens.map((h) => Buffer.from(h.slice(1, -1), "hex").toString("latin1")).join("");
+  }
+  return text;
+}
+
 async function imageXObjectsPerPage(bytes: Uint8Array): Promise<number[]> {
   // pdf-lib's low-level dict classes have protected constructors, so this walks
   // the resources with `any` casts rather than fighting the type-guards.
@@ -141,6 +171,21 @@ test("marked set: a capture image with a caption on a ROTATED source page still 
   const perPage = await imageXObjectsPerPage(bytes);
   assert.equal(perPage.length, 2, "cover + the one marked sheet (S2)");
   assert.equal(perPage[1], 1, "the image still embeds even though the caption chip also draws on this rotated page");
+  // The caption draws AFTER pg.drawImage and the whole block shares one
+  // try/catch — a throwing caption would still leave the image embedded and
+  // the error swallowed, so the XObject count alone can't catch a broken
+  // caption. Assert the caption text actually landed in the page's content
+  // stream (sheetBaseLabelFromKey("plan.pdf#1") → "plan", page 1 → hasPage
+  // is true, so the full text is "Source: plan · p.1"; checking the
+  // "Source: " prefix is enough to prove the caption drew at all).
+  const text = await pageText(bytes, 1);
+  // Positive anchor FIRST: prove pageText actually decoded this page's
+  // content stream at all (every sheet page carries its own footer text,
+  // "<label> · marked set", independent of any caption) — otherwise a
+  // silently-empty extraction would make the caption assertion below
+  // meaningless rather than a real check.
+  assert.ok(text.includes("Sheet 2"), "pageText decoded real text off this page (sheet footer label)");
+  assert.ok(text.includes("Source: "), "the source caption text is present on the rotated sheet's page");
 });
 
 test("marked set: a capture image whose src_sheet_id is a STITCH key exports with the caption suppressed, no crash", async () => {
@@ -161,4 +206,10 @@ test("marked set: a capture image whose src_sheet_id is a STITCH key exports wit
   const perPage = await imageXObjectsPerPage(bytes);
   assert.equal(perPage.length, 2, "cover + the one marked sheet");
   assert.equal(perPage[1], 1, "the image still exports even though sheetBaseLabelFromKey suppresses a stitch-key caption");
+  const text = await pageText(bytes, 1);
+  // Positive anchor FIRST (see the ROTATED test above for why): without it, a
+  // pageText that silently returned "" would make the negative assertion
+  // below pass for the wrong reason.
+  assert.ok(text.includes("Sheet 1"), "pageText decoded real text off this page (sheet footer label)");
+  assert.ok(!text.includes("Source: "), "no caption text is drawn for a stitch-key source");
 });

--- a/web/test/markedset.image.test.ts
+++ b/web/test/markedset.image.test.ts
@@ -1,0 +1,105 @@
+// Multi-sheet image-markup export — a deterministic node integration test of the
+// real buildMarkedSetPdf (no browser: mock pdf.js pages + a real source PDF). It
+// proves image markups export to their OWN sheet's page across a multi-page set,
+// that none is dropped, and that a rotated source page still gets its image (the
+// rotated-sheet placement math itself is proven in markupImage.test.ts).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildMarkedSetPdf } from "../src/lib/markedset.js";
+
+const RS = 2.0; // RENDER_SCALE (web/src/lib/sheets.ts)
+// a 1×1 PNG — enough for embedPng to produce a real image XObject
+const PNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+// pdf.js-style viewport transform: rotate 0 → [s,0,0,-s,0,H·s]; a 90°-rotated page
+// gets a swap-form transform so toPage carries rotation (exact pdf.js values don't
+// matter here — only that the map is a valid, non-axis-aligned similarity).
+function mockPage(wPt: number, hPt: number, rotate: number) {
+  return {
+    rotate,
+    getViewport({ scale }: { scale: number }) {
+      if (rotate === 90) return { width: hPt * scale, height: wPt * scale, transform: [0, scale, scale, 0, 0, 0] };
+      return { width: wPt * scale, height: hPt * scale, transform: [scale, 0, 0, -scale, 0, hPt * scale] };
+    },
+  };
+}
+
+async function makeSourcePdf() {
+  const { PDFDocument, degrees } = await import("pdf-lib");
+  const src = await PDFDocument.create();
+  src.addPage([612, 792]);                      // page 1 — upright
+  const p2 = src.addPage([612, 792]);           // page 2 — rotated 90°
+  p2.setRotation(degrees(90));
+  return src.save();
+}
+
+async function imageXObjectsPerPage(bytes: Uint8Array): Promise<number[]> {
+  // pdf-lib's low-level dict classes have protected constructors, so this walks
+  // the resources with `any` casts rather than fighting the type-guards.
+  const { PDFDocument, PDFName } = await import("pdf-lib");
+  const out = await PDFDocument.load(bytes);
+  const imageName = String(PDFName.of("Image")); // "/Image"
+  return out.getPages().map((page) => {
+    const res: any = (page as any).node.Resources();
+    const xobj: any = res && res.lookup(PDFName.of("XObject"));
+    if (!xobj || typeof xobj.entries !== "function") return 0;
+    let n = 0;
+    for (const [, ref] of xobj.entries()) {
+      const stream: any = out.context.lookup(ref);
+      const sub = stream && stream.dict && stream.dict.lookup(PDFName.of("Subtype"));
+      if (sub && String(sub) === imageName) n++;
+    }
+    return n;
+  });
+}
+
+test("marked set: an image markup on each of two sheets exports to its own page (rotated included)", async () => {
+  const srcBytes = await makeSourcePdf();
+  const sheets = [
+    { key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" },
+    { key: "S2", file: "plan.pdf", page: 2, label: "Sheet 2 (rot 90)" },
+  ];
+  const markups = [
+    { id: "mk1", type: "image", sheet_id: "S1", at: [0.5, 0.5], w: 0.3, aspect: 1, src: PNG },
+    { id: "mk2", type: "image", sheet_id: "S2", at: [0.4, 0.6], w: 0.25, aspect: 1, src: PNG },
+  ];
+  const pages: Record<number, ReturnType<typeof mockPage>> = {
+    1: mockPage(612, 792, 0),
+    2: mockPage(612, 792, 90),
+  };
+  const { bytes } = await buildMarkedSetPdf({
+    projectName: "Test", dark: false, units: "imperial",
+    sheets, shapes: [], markups, approvals: [], rfis: [], conditions: [], company: undefined, clientInfo: undefined,
+    getPage: async (_file: string, pageNum: number) => pages[pageNum],
+    loadPdfData: async () => srcBytes,
+  });
+
+  const perPage = await imageXObjectsPerPage(bytes);
+  // pages: [cover, sheet 1, sheet 2]
+  assert.equal(perPage.length, 3, "cover + 2 sheet pages");
+  assert.equal(perPage[0], 0, "cover carries no image markup");
+  assert.equal(perPage[1], 1, "sheet 1 carries exactly its one image");
+  assert.equal(perPage[2], 1, "sheet 2 (rotated) still carries its one image");
+  assert.equal(perPage[1] + perPage[2], 2, "both images exported, none dropped or doubled");
+});
+
+test("marked set: an image on ONLY sheet 2 does not bleed onto sheet 1's page", async () => {
+  const srcBytes = await makeSourcePdf();
+  const sheets = [
+    { key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" },
+    { key: "S2", file: "plan.pdf", page: 2, label: "Sheet 2" },
+  ];
+  const markups = [{ id: "mk2", type: "image", sheet_id: "S2", at: [0.5, 0.5], w: 0.3, aspect: 1, src: PNG }];
+  const pages: Record<number, ReturnType<typeof mockPage>> = { 1: mockPage(612, 792, 0), 2: mockPage(612, 792, 0) };
+  const { bytes } = await buildMarkedSetPdf({
+    projectName: "Test", dark: false, units: "imperial",
+    sheets, shapes: [], markups, approvals: [], rfis: [], conditions: [], company: undefined, clientInfo: undefined,
+    getPage: async (_file: string, pageNum: number) => pages[pageNum],
+    loadPdfData: async () => srcBytes,
+  });
+  const perPage = await imageXObjectsPerPage(bytes);
+  // only S2 has a markup, so S1 is not a "marked" sheet → pages: [cover, sheet 2]
+  assert.equal(perPage.length, 2, "cover + only the one marked sheet");
+  assert.equal(perPage[0], 0, "cover has no image");
+  assert.equal(perPage[1], 1, "the single image lands on sheet 2's page only");
+});

--- a/web/test/markedset.image.test.ts
+++ b/web/test/markedset.image.test.ts
@@ -103,3 +103,62 @@ test("marked set: an image on ONLY sheet 2 does not bleed onto sheet 1's page", 
   assert.equal(perPage[0], 0, "cover has no image");
   assert.equal(perPage[1], 1, "the single image lands on sheet 2's page only");
 });
+
+// ── source caption (task 2) ───────────────────────────────────────────────────
+// The caption chip's on-screen POSITION has no node-test surface (SVG/React) —
+// that's the named slice-5 live-verify check (a rotated-page marked-set export
+// must show the caption glued to the image). What IS node-testable here, on
+// this same real-buildMarkedSetPdf harness, is that the new caption code path
+// (parseSheetKey/sheetBaseLabelFromKey/sourceCaption + the imageDrawParams-built
+// rotated chip) runs to completion without throwing and without disturbing the
+// image export — on the hardest case (a rotated source page) and on the
+// suppression case (a stitch-key source).
+test("marked set: a capture image with a caption on a ROTATED source page still exports its image", async () => {
+  const srcBytes = await makeSourcePdf();
+  const sheets = [
+    { key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" },
+    { key: "S2", file: "plan.pdf", page: 2, label: "Sheet 2 (rot 90)" },
+  ];
+  const markups = [
+    // captured FROM sheet 1, PLACED on sheet 2 (the rotated page) — exercises
+    // the rotated imageDrawParams path for both the image and its caption box.
+    {
+      id: "mk1", type: "image", sheet_id: "S2", at: [0.5, 0.5], w: 0.3, aspect: 1, src: PNG,
+      source: "capture", source_label: true, src_sheet_id: "plan.pdf#1",
+      src_rect: [[0.1, 0.1], [0.4, 0.4]],
+    },
+  ];
+  const pages: Record<number, ReturnType<typeof mockPage>> = {
+    1: mockPage(612, 792, 0),
+    2: mockPage(612, 792, 90),
+  };
+  const { bytes } = await buildMarkedSetPdf({
+    projectName: "Test", dark: false, units: "imperial",
+    sheets, shapes: [], markups, approvals: [], rfis: [], conditions: [], company: undefined, clientInfo: undefined,
+    getPage: async (_file: string, pageNum: number) => pages[pageNum],
+    loadPdfData: async () => srcBytes,
+  });
+  const perPage = await imageXObjectsPerPage(bytes);
+  assert.equal(perPage.length, 2, "cover + the one marked sheet (S2)");
+  assert.equal(perPage[1], 1, "the image still embeds even though the caption chip also draws on this rotated page");
+});
+
+test("marked set: a capture image whose src_sheet_id is a STITCH key exports with the caption suppressed, no crash", async () => {
+  const srcBytes = await makeSourcePdf();
+  const sheets = [{ key: "S1", file: "plan.pdf", page: 1, label: "Sheet 1" }];
+  const markups = [{
+    id: "mk1", type: "image", sheet_id: "S1", at: [0.5, 0.5], w: 0.3, aspect: 1, src: PNG,
+    source: "capture", source_label: true, src_sheet_id: "stitch:abc",
+    src_rect: [[0.1, 0.1], [0.4, 0.4]],
+  }];
+  const pages: Record<number, ReturnType<typeof mockPage>> = { 1: mockPage(612, 792, 0) };
+  const { bytes } = await buildMarkedSetPdf({
+    projectName: "Test", dark: false, units: "imperial",
+    sheets, shapes: [], markups, approvals: [], rfis: [], conditions: [], company: undefined, clientInfo: undefined,
+    getPage: async (_file: string, pageNum: number) => pages[pageNum],
+    loadPdfData: async () => srcBytes,
+  });
+  const perPage = await imageXObjectsPerPage(bytes);
+  assert.equal(perPage.length, 2, "cover + the one marked sheet");
+  assert.equal(perPage[1], 1, "the image still exports even though sheetBaseLabelFromKey suppresses a stitch-key caption");
+});

--- a/web/test/markupImage.test.ts
+++ b/web/test/markupImage.test.ts
@@ -11,6 +11,7 @@ import {
   pickEmbedFormat,
   imageDrawParams,
   sourceCaption,
+  filterCaptures,
 } from "../src/lib/markupImage.ts";
 
 // ── imagePlacedBox ──────────────────────────────────────────────────────────
@@ -224,4 +225,39 @@ test("pickEmbedFormat: jpeg→jpg, png→png, else null", () => {
   assert.equal(pickEmbedFormat("data:image/jpeg2000;base64,x"), null);
   assert.equal(pickEmbedFormat("data:image/png-evil;base64,x"), null);
   assert.equal(pickEmbedFormat("data:image/png,rawdata"), "png");   // `,` payload form
+});
+
+// ── filterCaptures — the Captures panel's GLOBAL list + name search ────────
+const M = (type: string, text: string) => ({ type, text });
+
+test("filterCaptures: keeps only image markups, project-wide (not sheet-filtered)", () => {
+  const markups = [M("image", "AF101-01"), M("cloud", "not an image"), M("image", "AF102-01")];
+  assert.deepEqual(filterCaptures(markups, ""), [markups[0], markups[2]]);
+});
+
+test("filterCaptures: empty/whitespace query returns every capture, unfiltered", () => {
+  const markups = [M("image", "AF101-01"), M("image", "AF102-01")];
+  assert.deepEqual(filterCaptures(markups, ""), markups);
+  assert.deepEqual(filterCaptures(markups, "   "), markups);
+});
+
+test("filterCaptures: name search is case-insensitive substring over text", () => {
+  const markups = [M("image", "AF101-01"), M("image", "Roof Detail")];
+  assert.deepEqual(filterCaptures(markups, "roof"), [markups[1]]);
+  assert.deepEqual(filterCaptures(markups, "AF101"), [markups[0]]);
+});
+
+test("filterCaptures: a query matching nothing → []", () => {
+  const markups = [M("image", "AF101-01")];
+  assert.deepEqual(filterCaptures(markups, "zzz"), []);
+});
+
+test("filterCaptures: no image markups at all → [] regardless of query", () => {
+  assert.deepEqual(filterCaptures([M("cloud", "x")], ""), []);
+});
+
+test("filterCaptures: a capture with no text never matches a non-empty query, but always survives the unfiltered pass", () => {
+  const markups = [{ type: "image" }];
+  assert.deepEqual(filterCaptures(markups, ""), markups);
+  assert.deepEqual(filterCaptures(markups, "anything"), []);
 });

--- a/web/test/markupImage.test.ts
+++ b/web/test/markupImage.test.ts
@@ -1,0 +1,205 @@
+// Pure image-markup geometry tests — markupImage.ts is DOM-free, so it runs
+// straight under node (same precedent as geometry.test.ts / svgpath). Run: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  imagePlacedBox,
+  captureRectToImageGeom,
+  resizeImageFromCorner,
+  clampImageWidth,
+  aspectFromDims,
+  pickEmbedFormat,
+  imageDrawParams,
+} from "../src/lib/markupImage.ts";
+
+// ── imagePlacedBox ──────────────────────────────────────────────────────────
+test("imagePlacedBox: width-anchored box (bw=w*sheetW, bh=bw*aspect)", () => {
+  assert.deepEqual(imagePlacedBox(0.5, 0.5, 1000), { bw: 500, bh: 250 });
+});
+
+test("imagePlacedBox: tall aspect grows height past width (width-anchor divergence from svgPlacedBox)", () => {
+  assert.deepEqual(imagePlacedBox(0.25, 2, 800), { bw: 200, bh: 400 });
+});
+
+test("imagePlacedBox: degenerate/non-finite inputs → {0,0}", () => {
+  assert.deepEqual(imagePlacedBox(0, 0.5, 1000), { bw: 0, bh: 0 });
+  assert.deepEqual(imagePlacedBox(-1, 0.5, 1000), { bw: 0, bh: 0 });
+  assert.deepEqual(imagePlacedBox(0.5, 0, 1000), { bw: 0, bh: 0 });
+  assert.deepEqual(imagePlacedBox(0.5, -1, 1000), { bw: 0, bh: 0 });
+  assert.deepEqual(imagePlacedBox(0.5, 0.5, Infinity), { bw: 0, bh: 0 });
+  assert.deepEqual(imagePlacedBox(0.5, 0.5, NaN), { bw: 0, bh: 0 });
+  // non-finite w / aspect must be guarded too (not just > 0) — else Infinity bw/bh
+  assert.deepEqual(imagePlacedBox(Infinity, 0.5, 1000), { bw: 0, bh: 0 });
+  assert.deepEqual(imagePlacedBox(0.5, Infinity, 1000), { bw: 0, bh: 0 });
+});
+
+test("imagePlacedBox: w is clamped to the [0.02, 2] rails (an imported extreme w can't mint a giant box)", () => {
+  assert.deepEqual(imagePlacedBox(50, 1, 1000), { bw: 2000, bh: 2000 });     // w clamped 50 → 2
+  assert.deepEqual(imagePlacedBox(0.001, 1, 1000), { bw: 20, bh: 20 });      // w clamped 0.001 → 0.02
+});
+
+// ── captureRectToImageGeom ──────────────────────────────────────────────────
+test("captureRectToImageGeom: rect → {at,w,aspect}", () => {
+  const g = captureRectToImageGeom({ x0: 100, y0: 50, x1: 300, y1: 150 }, 1000, 800);
+  assert.equal(g.w, 0.2);
+  assert.equal(g.aspect, 0.5);
+  assert.deepEqual(g.at, [0.2, 0.125]);
+});
+
+test("captureRectToImageGeom: corner-order independent (swapped corners → same box)", () => {
+  const a = captureRectToImageGeom({ x0: 100, y0: 50, x1: 300, y1: 150 }, 1000, 800);
+  const b = captureRectToImageGeom({ x0: 300, y0: 150, x1: 100, y1: 50 }, 1000, 800);
+  assert.deepEqual(a, b);
+});
+
+test("captureRectToImageGeom: degenerate x0==x1 → {w:0, aspect:0}, no NaN/Infinity", () => {
+  const g = captureRectToImageGeom({ x0: 200, y0: 50, x1: 200, y1: 150 }, 1000, 800);
+  assert.equal(g.w, 0);
+  assert.equal(g.aspect, 0);
+  assert.ok(Number.isFinite(g.at[0]) && Number.isFinite(g.at[1]));
+});
+
+test("captureRectToImageGeom: sheetW=0 / non-finite guarded (no Infinity)", () => {
+  const z = captureRectToImageGeom({ x0: 100, y0: 50, x1: 300, y1: 150 }, 0, 800);
+  assert.equal(z.w, 0);
+  assert.equal(z.aspect, 0);
+  assert.ok(Number.isFinite(z.at[0]) && Number.isFinite(z.at[1]));
+  const nf = captureRectToImageGeom({ x0: 100, y0: 50, x1: 300, y1: 150 }, Infinity, 800);
+  assert.equal(nf.w, 0);
+  assert.ok(Number.isFinite(nf.at[0]) && Number.isFinite(nf.at[1]));
+});
+
+test("captureRectToImageGeom: at clamped into [0,1] when rect exceeds bounds", () => {
+  const g = captureRectToImageGeom({ x0: -500, y0: -400, x1: 3000, y1: 2400 }, 1000, 800);
+  assert.ok(g.at[0] >= 0 && g.at[0] <= 1);
+  assert.ok(g.at[1] >= 0 && g.at[1] <= 1);
+});
+
+// ── resizeImageFromCorner ───────────────────────────────────────────────────
+// Recompute the placed box from {w, at} exactly as the renderer does and return
+// its top-left corner (at is center; box is width-anchored).
+function topLeftOf(w: number, at: [number, number], aspect: number, sheetW: number, sheetH: number) {
+  const { bw, bh } = imagePlacedBox(w, aspect, sheetW);
+  return { x: at[0] * sheetW - bw / 2, y: at[1] * sheetH - bh / 2 };
+}
+
+test("resizeImageFromCorner: top-left invariant on a normal drag", () => {
+  const fixedTL = { x: 100, y: 120 };
+  const r = resizeImageFromCorner(fixedTL, { x: 300, y: 500 }, 0.5, 1000, 800);
+  const tl = topLeftOf(r.w, r.at, 0.5, 1000, 800);
+  assert.ok(Math.abs(tl.x - fixedTL.x) < 1e-9);
+  assert.ok(Math.abs(tl.y - fixedTL.y) < 1e-9);
+});
+
+test("resizeImageFromCorner: top-left STILL invariant at the max clamp rail (drag far past max)", () => {
+  const fixedTL = { x: 100, y: 120 };
+  const r = resizeImageFromCorner(fixedTL, { x: 100000, y: 500 }, 0.5, 1000, 800);
+  assert.equal(r.w, 2); // clamped to max
+  const tl = topLeftOf(r.w, r.at, 0.5, 1000, 800);
+  assert.ok(Math.abs(tl.x - fixedTL.x) < 1e-9);
+  assert.ok(Math.abs(tl.y - fixedTL.y) < 1e-9);
+});
+
+test("resizeImageFromCorner: top-left STILL invariant at the min clamp rail (drag below min)", () => {
+  const fixedTL = { x: 100, y: 120 };
+  const r = resizeImageFromCorner(fixedTL, { x: 105, y: 500 }, 0.5, 1000, 800);
+  assert.equal(r.w, 0.02); // clamped to min
+  const tl = topLeftOf(r.w, r.at, 0.5, 1000, 800);
+  assert.ok(Math.abs(tl.x - fixedTL.x) < 1e-9);
+  assert.ok(Math.abs(tl.y - fixedTL.y) < 1e-9);
+});
+
+test("resizeImageFromCorner: aspect preserved (bh/bw == aspect)", () => {
+  const r = resizeImageFromCorner({ x: 100, y: 120 }, { x: 400, y: 500 }, 0.75, 1000, 800);
+  const { bw, bh } = imagePlacedBox(r.w, 0.75, 1000);
+  assert.ok(Math.abs(bh / bw - 0.75) < 1e-9);
+});
+
+test("resizeImageFromCorner: non-square sheet (sheetW≠sheetH) — catches width/height normalization swap", () => {
+  const fixedTL = { x: 100, y: 100 };
+  const r = resizeImageFromCorner(fixedTL, { x: 300, y: 400 }, 0.5, 1000, 500);
+  // bw=200 → w=0.2, bh=100 → at=[(100+100)/1000,(100+50)/500]=[0.2,0.3]
+  assert.equal(r.w, 0.2);
+  assert.deepEqual(r.at, [0.2, 0.3]);
+  const tl = topLeftOf(r.w, r.at, 0.5, 1000, 500);
+  assert.ok(Math.abs(tl.x - fixedTL.x) < 1e-9);
+  assert.ok(Math.abs(tl.y - fixedTL.y) < 1e-9);
+});
+
+test("resizeImageFromCorner: degenerate sheet dims / aspect → finite at, no NaN/Infinity", () => {
+  for (const [sw, sh, asp] of [[0, 800, 0.5], [1000, 0, 0.5], [1000, 800, 0], [1000, 800, Infinity], [NaN, 800, 0.5]]) {
+    const r = resizeImageFromCorner({ x: 100, y: 120 }, { x: 300, y: 500 }, asp, sw, sh);
+    assert.ok(Number.isFinite(r.w), `w finite for ${sw},${sh},${asp}`);
+    assert.ok(Number.isFinite(r.at[0]) && Number.isFinite(r.at[1]), `at finite for ${sw},${sh},${asp}`);
+  }
+});
+
+// ── imageDrawParams (rotated-page marked-set placement) ─────────────────────
+// Reconstruct where pdf-lib's drawImage would put the three box corners from the
+// returned {x,y,width,height,rotateDeg} and assert they land exactly on
+// toPage(corner) — proving the placement is correct AND un-mirrored on rotated
+// pages. pdf-lib: anchor = bottom-left; height axis is +90° from the width axis.
+function drawImageCorners(p: { x: number; y: number; width: number; height: number; rotateDeg: number }) {
+  const t = (p.rotateDeg * Math.PI) / 180, c = Math.cos(t), s = Math.sin(t);
+  return {
+    bl: [p.x, p.y],
+    br: [p.x + p.width * c, p.y + p.width * s],
+    tl: [p.x - p.height * s, p.y + p.height * c],
+  };
+}
+const near = (a: number[], b: number[]) => Math.abs(a[0] - b[0]) < 1e-9 && Math.abs(a[1] - b[1]) < 1e-9;
+
+test("imageDrawParams: box corners land on toPage(corner) for plain / 90° / 180° page maps", () => {
+  const x0 = 100, y0 = 50, bw = 200, bh = 100;
+  const maps: Array<(x: number, y: number) => [number, number]> = [
+    (x, y) => [x * 2, 1000 - y * 2],   // plain page: y-flip + uniform scale (rotateDeg 0)
+    (x, y) => [y * 2 + 10, x * 2 + 20], // 90°-rotated source page (similarity, orientation-reversing)
+    (x, y) => [-x * 2 + 500, y * 2],    // 180°-rotated source page
+  ];
+  for (const toPage of maps) {
+    const p = imageDrawParams(toPage, x0, y0, bw, bh);
+    const got = drawImageCorners(p);
+    assert.ok(near(got.bl, toPage(x0, y0 + bh)), "bottom-left");
+    assert.ok(near(got.br, toPage(x0 + bw, y0 + bh)), "bottom-right");
+    assert.ok(near(got.tl, toPage(x0, y0)), "top-left");
+  }
+});
+
+test("imageDrawParams: plain page is axis-aligned (rotateDeg 0, side lengths = px × scale)", () => {
+  const p = imageDrawParams((x, y) => [x * 2, 1000 - y * 2], 100, 50, 200, 100);
+  assert.equal(p.rotateDeg, 0);
+  assert.equal(p.width, 400);
+  assert.equal(p.height, 200);
+  assert.deepEqual([p.x, p.y], [200, 700]);
+});
+
+// ── clampImageWidth ─────────────────────────────────────────────────────────
+test("clampImageWidth: rails + interior + NaN", () => {
+  assert.equal(clampImageWidth(0.019), 0.02);
+  assert.equal(clampImageWidth(2.001), 2);
+  assert.equal(clampImageWidth(0.5), 0.5);
+  assert.equal(clampImageWidth(NaN), 0.02);
+});
+
+// ── aspectFromDims ──────────────────────────────────────────────────────────
+test("aspectFromDims: h/w with guard", () => {
+  assert.equal(aspectFromDims(200, 100), 0.5);
+  assert.equal(aspectFromDims(0, 100), 1);
+  assert.equal(aspectFromDims(-5, 100), 1);
+  assert.equal(aspectFromDims(Infinity, 100), 1);
+  assert.equal(aspectFromDims(NaN, 100), 1);
+});
+
+// ── pickEmbedFormat ─────────────────────────────────────────────────────────
+test("pickEmbedFormat: jpeg→jpg, png→png, else null", () => {
+  assert.equal(pickEmbedFormat("data:image/jpeg;base64,x"), "jpg");
+  assert.equal(pickEmbedFormat("data:image/png;base64,x"), "png");
+  assert.equal(pickEmbedFormat("data:image/webp;base64,x"), null);
+  assert.equal(pickEmbedFormat("data:image/gif;base64,x"), null);
+  assert.equal(pickEmbedFormat(""), null);
+  assert.equal(pickEmbedFormat("data:image/svg+xml;base64,x"), null);
+  // exact media type only — a prefix collision must not read as png/jpeg
+  assert.equal(pickEmbedFormat("data:image/jpeg2000;base64,x"), null);
+  assert.equal(pickEmbedFormat("data:image/png-evil;base64,x"), null);
+  assert.equal(pickEmbedFormat("data:image/png,rawdata"), "png");   // `,` payload form
+});

--- a/web/test/markupImage.test.ts
+++ b/web/test/markupImage.test.ts
@@ -10,6 +10,7 @@ import {
   aspectFromDims,
   pickEmbedFormat,
   imageDrawParams,
+  sourceCaption,
 } from "../src/lib/markupImage.ts";
 
 // ── imagePlacedBox ──────────────────────────────────────────────────────────
@@ -188,6 +189,27 @@ test("aspectFromDims: h/w with guard", () => {
   assert.equal(aspectFromDims(-5, 100), 1);
   assert.equal(aspectFromDims(Infinity, 100), 1);
   assert.equal(aspectFromDims(NaN, 100), 1);
+});
+
+// ── sourceCaption ────────────────────────────────────────────────────────────
+test("sourceCaption: label + page → 'Source: <label> · p.<page>'", () => {
+  assert.equal(sourceCaption("AF101", 3), "Source: AF101 · p.3");
+});
+
+test("sourceCaption: page not a positive finite integer → page part omitted", () => {
+  assert.equal(sourceCaption("AF101", 0), "Source: AF101");
+  assert.equal(sourceCaption("AF101", -1), "Source: AF101");
+  assert.equal(sourceCaption("AF101", 1.5), "Source: AF101");
+  assert.equal(sourceCaption("AF101", NaN), "Source: AF101");
+  assert.equal(sourceCaption("AF101", Infinity), "Source: AF101");
+  assert.equal(sourceCaption("AF101", undefined as any), "Source: AF101");
+});
+
+test("sourceCaption: empty/non-string label → ''", () => {
+  assert.equal(sourceCaption("", 3), "");
+  assert.equal(sourceCaption(null as any, 3), "");
+  assert.equal(sourceCaption(undefined as any, 3), "");
+  assert.equal(sourceCaption(42 as any, 3), "");
 });
 
 // ── pickEmbedFormat ─────────────────────────────────────────────────────────

--- a/web/test/reltime.test.ts
+++ b/web/test/reltime.test.ts
@@ -1,0 +1,86 @@
+// reltime.ts — compact relative-age + explicit-UTC-timestamp helpers for the
+// Captures panel row. Both take their "now" (or read Date.parse of `iso`)
+// deterministically, so every test pins a fixed epoch — no real-clock flake.
+// Run: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { relativeAge, absoluteUtc } from "../src/lib/reltime.ts";
+
+// Fixed "now" used across every relativeAge case: 2026-08-25T19:58:00Z — the
+// same instant the brief's absoluteUtc example ("Aug 25, 2026, 7:58 PM (UTC)")
+// is built from, so a passing absoluteUtc test on this exact instant doubles
+// as a sanity check that the two helpers agree.
+const NOW = Date.UTC(2026, 7, 25, 19, 58, 0);
+const SEC = 1000, MIN = 60 * SEC, HOUR = 60 * MIN, DAY = 24 * HOUR;
+const isoAt = (ms: number) => new Date(ms).toISOString();
+
+// ── relativeAge: bucket boundaries ──────────────────────────────────────────
+test("relativeAge: < 45s → just now (interior + right at the 44s edge)", () => {
+  assert.equal(relativeAge(isoAt(NOW - 30 * SEC), NOW), "just now");
+  assert.equal(relativeAge(isoAt(NOW - 44 * SEC), NOW), "just now");
+});
+
+test("relativeAge: 45s boundary flips just-now → minutes (rounds up to 1m, the 'min 1' floor)", () => {
+  assert.equal(relativeAge(isoAt(NOW - 45 * SEC), NOW), "1m ago");
+});
+
+test("relativeAge: minutes bucket, interior + just-under-60m edge", () => {
+  assert.equal(relativeAge(isoAt(NOW - 5 * MIN), NOW), "5m ago");
+  assert.equal(relativeAge(isoAt(NOW - 59 * MIN), NOW), "59m ago");
+});
+
+test("relativeAge: 60m boundary flips minutes → hours", () => {
+  assert.equal(relativeAge(isoAt(NOW - 60 * MIN), NOW), "1h ago");
+});
+
+test("relativeAge: hours bucket, interior + just-under-24h edge", () => {
+  assert.equal(relativeAge(isoAt(NOW - 5 * HOUR), NOW), "5h ago");
+  assert.equal(relativeAge(isoAt(NOW - 23 * HOUR), NOW), "23h ago");
+});
+
+test("relativeAge: 24h boundary flips hours → yesterday", () => {
+  assert.equal(relativeAge(isoAt(NOW - 24 * HOUR), NOW), "yesterday");
+});
+
+test("relativeAge: yesterday bucket holds through the 47h edge", () => {
+  assert.equal(relativeAge(isoAt(NOW - 47 * HOUR), NOW), "yesterday");
+});
+
+test("relativeAge: 48h boundary flips yesterday → days", () => {
+  assert.equal(relativeAge(isoAt(NOW - 48 * HOUR), NOW), "2d ago");
+});
+
+test("relativeAge: days bucket, interior + just-under-7d edge", () => {
+  assert.equal(relativeAge(isoAt(NOW - 3 * DAY), NOW), "3d ago");
+  assert.equal(relativeAge(isoAt(NOW - 6 * DAY), NOW), "6d ago");
+});
+
+test("relativeAge: 7d boundary flips days → a plain UTC date", () => {
+  // NOW - 7d = 2026-08-18T19:58:00Z
+  assert.equal(relativeAge(isoAt(NOW - 7 * DAY), NOW), "Aug 18, 2026");
+});
+
+test("relativeAge: older date is formatted in UTC regardless of local wall-clock", () => {
+  assert.equal(relativeAge("2020-01-01T00:00:00Z", NOW), "Jan 1, 2020");
+});
+
+// ── relativeAge: guards ─────────────────────────────────────────────────────
+test("relativeAge: non-finite / unparseable iso → '' (never throw)", () => {
+  assert.equal(relativeAge("", NOW), "");
+  assert.equal(relativeAge("not-a-date", NOW), "");
+  // deliberately wrong runtime type (a caller could pass one) — guard must not throw
+  assert.equal(relativeAge(undefined as any, NOW), "");
+  assert.equal(relativeAge(null as any, NOW), "");
+});
+
+// ── absoluteUtc ──────────────────────────────────────────────────────────────
+test("absoluteUtc: explicit human timestamp, zone spelled out, formatted in UTC", () => {
+  assert.equal(absoluteUtc("2026-08-25T19:58:00Z"), "Aug 25, 2026, 7:58 PM (UTC)");
+  assert.equal(absoluteUtc("2026-01-05T00:05:00Z"), "Jan 5, 2026, 12:05 AM (UTC)");
+});
+
+test("absoluteUtc: unparseable → '' (never throw)", () => {
+  assert.equal(absoluteUtc(""), "");
+  assert.equal(absoluteUtc("garbage"), "");
+  assert.equal(absoluteUtc(undefined as any), "");
+});

--- a/web/test/sheetBaseLabel.test.ts
+++ b/web/test/sheetBaseLabel.test.ts
@@ -1,0 +1,34 @@
+// sheetBaseLabelFromKey — the pure fallback branch of the canvas's
+// sheetBaseLabel closure (TakeoffCanvas.jsx), extracted so the source-caption
+// text can be computed identically on the canvas AND inside markedset.js.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sheetBaseLabelFromKey } from "../src/lib/sheets.js";
+
+test("sheetBaseLabelFromKey: page 1 → bare file name (no #1 suffix)", () => {
+  assert.equal(sheetBaseLabelFromKey("foo.pdf#1"), "foo");
+  assert.equal(sheetBaseLabelFromKey("foo.pdf"), "foo"); // no # at all — page defaults to 1
+});
+
+test("sheetBaseLabelFromKey: page > 1 → '<base>-<page>'", () => {
+  assert.equal(sheetBaseLabelFromKey("foo.pdf#3"), "foo-3");
+});
+
+test("sheetBaseLabelFromKey: strips a trailing .pdf case-insensitively", () => {
+  assert.equal(sheetBaseLabelFromKey("Plan.PDF#2"), "Plan-2");
+});
+
+test("sheetBaseLabelFromKey: stitch key → '' (STITCH-KEY GUARD)", () => {
+  // A stitch key ("stitch:<uid>") has no '#', so parseSheetKey would otherwise
+  // read the whole thing as a garbage file name ("Source: stitch:abc · p.1").
+  // The canvas resolves a stitch's name via runtime state (stitchById) this
+  // pure module can't see, so it must suppress instead of guessing.
+  assert.equal(sheetBaseLabelFromKey("stitch:abc"), "");
+});
+
+test("sheetBaseLabelFromKey: missing/empty/non-string key → '' (never throws)", () => {
+  assert.equal(sheetBaseLabelFromKey(""), "");
+  assert.equal(sheetBaseLabelFromKey(undefined as unknown as string), "");
+  assert.equal(sheetBaseLabelFromKey(null as unknown as string), "");
+  assert.equal(sheetBaseLabelFromKey(42 as unknown as string), "");
+});

--- a/web/test/sourceTrace.test.ts
+++ b/web/test/sourceTrace.test.ts
@@ -1,0 +1,101 @@
+// sourceTrace.ts — pure helpers behind the ◎ source-trace mechanism
+// (Captures slice 3): rectMidpoint (the trace's centering anchor) and
+// pendingSourceOutcome (the pendingSourceRef staleness guard — the plan's
+// "riskiest mechanism", since pendingSourceRef carries no markup id to
+// re-validate against). Run: npm test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rectMidpoint, pendingSourceOutcome, MAX_SOURCE_TRACE_ATTEMPTS } from "../src/lib/sourceTrace.ts";
+
+// ── rectMidpoint ─────────────────────────────────────────────────────────────
+test("rectMidpoint: normal rect → average of the two corners", () => {
+  assert.deepEqual(rectMidpoint([[0.2, 0.3], [0.6, 0.7]]), [0.4, 0.5]);
+});
+
+test("rectMidpoint: order-independent — swapped corners give the same midpoint", () => {
+  const a = rectMidpoint([[0.2, 0.3], [0.6, 0.7]]);
+  const b = rectMidpoint([[0.6, 0.7], [0.2, 0.3]]);
+  assert.deepEqual(a, b);
+});
+
+test("rectMidpoint: a degenerate rect (both corners equal) → that point", () => {
+  assert.deepEqual(rectMidpoint([[0.5, 0.5], [0.5, 0.5]]), [0.5, 0.5]);
+});
+
+test("rectMidpoint: malformed shapes → null, never throw", () => {
+  assert.equal(rectMidpoint(null), null);
+  assert.equal(rectMidpoint(undefined), null);
+  assert.equal(rectMidpoint([]), null);
+  assert.equal(rectMidpoint([[0, 0]]), null);                 // only one corner
+  assert.equal(rectMidpoint([[0, 0], [1, 1], [2, 2]]), null); // three corners
+  assert.equal(rectMidpoint([[0, 0], [1]]), null);            // short corner
+  assert.equal(rectMidpoint(["a", "b"]), null);                // corners aren't arrays
+  assert.equal(rectMidpoint([[0, 0], [1, "x"]]), null);        // non-numeric coordinate
+  assert.equal(rectMidpoint([[0, 0], [1, Infinity]]), null);   // non-finite coordinate
+  assert.equal(rectMidpoint([[NaN, 0], [1, 1]]), null);        // NaN coordinate
+});
+
+// ── pendingSourceOutcome ─────────────────────────────────────────────────────
+const ref = (attempts: number) => ({ sheet_id: "A.pdf", rect: [[0, 0], [1, 1]] as [[number, number], [number, number]], token: 1, attempts });
+
+test("pendingSourceOutcome: null ref → null (nothing to decide)", () => {
+  assert.equal(pendingSourceOutcome(null, { status: "ready", sheetIsLive: true, panelReady: true }), null);
+});
+
+test("pendingSourceOutcome: status===\"error\" → give-up, even if the panel looks ready", () => {
+  assert.deepEqual(
+    pendingSourceOutcome(ref(0), { status: "error", sheetIsLive: true, panelReady: true }),
+    { action: "give-up" },
+  );
+});
+
+test("pendingSourceOutcome: sheet no longer resolves to a real sheet → give-up, even mid-ready", () => {
+  assert.deepEqual(
+    pendingSourceOutcome(ref(0), { status: "ready", sheetIsLive: false, panelReady: true }),
+    { action: "give-up" },
+  );
+});
+
+test("pendingSourceOutcome: ready + panel bitmap present → complete", () => {
+  assert.deepEqual(
+    pendingSourceOutcome(ref(3), { status: "ready", sheetIsLive: true, panelReady: true }),
+    { action: "complete" },
+  );
+});
+
+test("pendingSourceOutcome: still loading (not ready, or ready but no bitmap yet) → wait, attempts increments", () => {
+  assert.deepEqual(
+    pendingSourceOutcome(ref(0), { status: "loading", sheetIsLive: true, panelReady: false }),
+    { action: "wait", attempts: 1 },
+  );
+  assert.deepEqual(
+    pendingSourceOutcome(ref(4), { status: "ready", sheetIsLive: true, panelReady: false }),
+    { action: "wait", attempts: 5 },
+  );
+});
+
+test("pendingSourceOutcome: attempt budget — one below the cap still waits, reaching the cap gives up", () => {
+  assert.deepEqual(
+    pendingSourceOutcome(ref(MAX_SOURCE_TRACE_ATTEMPTS - 2), { status: "loading", sheetIsLive: true, panelReady: false }),
+    { action: "wait", attempts: MAX_SOURCE_TRACE_ATTEMPTS - 1 },
+  );
+  assert.deepEqual(
+    pendingSourceOutcome(ref(MAX_SOURCE_TRACE_ATTEMPTS - 1), { status: "loading", sheetIsLive: true, panelReady: false }),
+    { action: "give-up" },
+  );
+});
+
+test("pendingSourceOutcome: never left pending on a terminal status — every non-wait outcome is either give-up or complete", () => {
+  const statuses = ["loading", "ready", "error"];
+  for (const status of statuses) {
+    for (const sheetIsLive of [true, false]) {
+      for (const panelReady of [true, false]) {
+        const out = pendingSourceOutcome(ref(0), { status, sheetIsLive, panelReady });
+        assert.ok(out !== null, "a non-null ref must always produce a decision");
+        assert.ok(out.action === "give-up" || out.action === "wait" || out.action === "complete");
+        // the terminal cases (give-up/complete) must never carry stale wait bookkeeping
+        if (out.action !== "wait") assert.equal("attempts" in out, false);
+      }
+    }
+  }
+});

--- a/web/test/sourceTrace.test.ts
+++ b/web/test/sourceTrace.test.ts
@@ -5,7 +5,7 @@
 // re-validate against). Run: npm test
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { rectMidpoint, pendingSourceOutcome, MAX_SOURCE_TRACE_ATTEMPTS } from "../src/lib/sourceTrace.ts";
+import { rectMidpoint, pendingSourceOutcome, MAX_SOURCE_TRACE_ATTEMPTS, isTraceable, traceLabel } from "../src/lib/sourceTrace.ts";
 
 // ── rectMidpoint ─────────────────────────────────────────────────────────────
 test("rectMidpoint: normal rect → average of the two corners", () => {
@@ -98,4 +98,35 @@ test("pendingSourceOutcome: never left pending on a terminal status — every no
       }
     }
   }
+});
+
+// ── isTraceable — the ◎ button + caption toggle's shared gate (slice 4) ────
+test("isTraceable: a capture with a known origin → true", () => {
+  assert.equal(isTraceable({ source: "capture", src_sheet_id: "AF101.pdf::1" }), true);
+});
+
+test("isTraceable: an upload → false (source !== 'capture', regardless of src_sheet_id)", () => {
+  assert.equal(isTraceable({ source: "upload" }), false);
+  assert.equal(isTraceable({ source: "upload", src_sheet_id: "AF101.pdf::1" }), false);
+});
+
+test("isTraceable: a legacy pre-slice-1 capture with no src_sheet_id → false", () => {
+  assert.equal(isTraceable({ source: "capture" }), false);
+  assert.equal(isTraceable({ source: "capture", src_sheet_id: "" }), false);
+  assert.equal(isTraceable({ source: "capture", src_sheet_id: null }), false);
+});
+
+test("isTraceable: missing/undefined markup → false, never throw", () => {
+  assert.equal(isTraceable(undefined), false);
+  assert.equal(isTraceable(null), false);
+  assert.equal(isTraceable({}), false);
+});
+
+// ── traceLabel — the ◎ button's text ────────────────────────────────────────
+test("traceLabel: capture has moved off its origin sheet → 'from <origin>'", () => {
+  assert.equal(traceLabel("AF101.pdf::1", "AF102.pdf::1", "AF101"), "◎ from AF101");
+});
+
+test("traceLabel: capture still sits on its origin sheet → terse 'Source'", () => {
+  assert.equal(traceLabel("AF101.pdf::1", "AF101.pdf::1", "AF101"), "◎ Source");
 });


### PR DESCRIPTION
## What & why

Adds a raster image annotation to the plan canvas, and a cross-sheet library to manage placed images. There is no image annotation on the canvas today. Implements #345.

- Arm the Image tool and marquee a region of a sheet with two clicks to screenshot it, or choose **Upload image…** for a PNG or JPEG. Both downscale to 1600 px on the longest side; a project's images share a 16 MB cap. The image lands framed and carries the author name.
- A **Captures** section in the Markups tab lists every image across all sheets. Each row: a thumbnail, an editable name, the sheet it's on now, its age, plus **Place**, a source trace, a caption toggle, the condition and RFI links, and delete. **Upload image…** sits in the section header; a name filter above the list.
- **Place** drops the image on the current sheet — center-and-reposition on the sheet it already lives on, ride-the-cursor drop on another.
- The source trace reads **◎ Source**, or **◎ from &lt;sheet&gt;** once the image has moved; it opens the origin sheet and flashes the captured region.
- The caption toggle draws a **Source: &lt;sheet&gt; · p.&lt;page&gt;** chip on the image (off by default), and it exports with the marked-set PDF, aligned with the page on rotated sheets.

**On size — this is a large PR, and we can split it.** We debated submitting it as two stacked PRs: the base image annotation (capture, upload, placement, marked-set export), then the Captures library on top. The base tip is self-contained and builds and tests green on its own, so the split is clean. We kept it as one for a cohesive review, but we're glad to split it into two if you'd prefer.

## How it was verified

- [x] `npm run build` is green
- [x] Exercised the changed flow against the bundled sample plan — screenshots and a short screen recording below
- [x] Docs updated (`README.md`, `docs/USER_GUIDE.md`, `CHANGELOG.md`)

`npm run typecheck` and `npm test` are also green (image-annotation and Captures helpers are node-tested; the panel and canvas render are covered by the hands-on pass).

### Screenshots

_Adding via the web UI — a short screen recording of the whole flow, plus a still of each surface:_

- _[recording](https://github.com/user-attachments/assets/94395675-bfa5-4176-961a-00d6e081b617)_ — the whole flow: capture → caption → cross-sheet Place → source trace → name filter
- _<img width="1382" height="925" alt="pr-01-captures-empty" src="https://github.com/user-attachments/assets/ed20b12c-e235-45a0-a497-4b691f2f5aa7" />_ — the Captures section empty, and the per-sheet list pointing to it
- _<img width="1382" height="925" alt="pr-02-image-tool" src="https://github.com/user-attachments/assets/71c7c368-37f5-4b9e-816f-3998a2d93a43" />_ — the Image tool in the markup menu
- _<img width="1382" height="925" alt="pr-03-capture-row-caption" src="https://github.com/user-attachments/assets/61c61ece-8889-40f6-b265-a0faa204e717" />_ — a capture, its row, and the on-image source caption
- _<img width="1382" height="925" alt="pr-04-crosssheet-place" src="https://github.com/user-attachments/assets/b7f91d35-12a5-4cde-a1e4-fc232a15cf1a" />_ — Place on another sheet: the image rides the cursor
- _<img width="1382" height="925" alt="pr-05-trace-flash" src="https://github.com/user-attachments/assets/0bb93f64-82e9-42b4-b51a-8fbfda3bf2c9" />_ — the source trace back to the origin sheet
- _<img width="1382" height="925" alt="pr-06-name-filter" src="https://github.com/user-attachments/assets/2b69b94a-466c-42c1-baec-a95ba67ed23c" />_ — the name filter
- _<img width="4620" height="3300" alt="pr-07-markedset-pdf" src="https://github.com/user-attachments/assets/c2cf76cb-5d17-453c-8c32-1c1755e4307b" />_ — the caption in the exported marked-set PDF

## Notes for the reviewer

- **Coordinate spaces.** `src_rect` is normalized against the clamped panel-local capture box. The marked-set caption is drawn through the same rotated-page path as the image itself (`imageDrawParams` + the page rotation), so it stays glued on rotated sheets rather than detaching.
- **Screen and PDF agree.** The source-caption label is frozen on the capture at creation time, so the canvas caption and the PDF caption read the same string regardless of which file is active at export. When a sheet's number isn't cached (a non-active panel of a multi-file side-by-side), the title block is read at capture time, falling back to the file name if it can't be read.
- **Limits are deliberate.** Only PNG or JPEG data renders — an imported record with a remote source is never fetched. A stitched-composite source shows the stitch's name; an unreadable origin keeps the file name. There's no this-sheet / all-sheets scope filter — the per-row sheet badge and the name filter cover it. Images stay in the browser and are excluded from the contribute payload.
