### PR TITLE
docs: move image-annotation design docs to docs/design/

### DIFF
--- a/docs/design/IMAGE_ANNOTATION.md
+++ b/docs/design/IMAGE_ANNOTATION.md
@@ -1,4 +1,4 @@
-# Plan — Image annotation markup (upload + marquee screenshot)
+# Image annotation markup (upload + marquee screenshot)
 
 > Revised after four parallel adversarial plan reviews (correctness, regression,
 > test-design, security/edge). Every finding is folded into the body below; the
@@ -81,7 +81,12 @@ so a too-big blob silently fails to persist *the entire takeoff*. Fix: on a
 non-stale error, `setCommitMsg(friendlyStoreError(e))` (the quota copy already
 exists, `store.js:139-141`) and set an explicit error save-state, not `"idle"`.
 
-Migration to a dedicated blob store stays **out of scope**.
+Migration to a dedicated blob store stays **out of scope** — and note it is a
+trade, not a free win. It would buy back the per-edit re-serialization above
+(image bytes keyed by markup id out-of-band, so the debounced `annotations` save
+carries only the small record, not the base64 payload) at the cost of the
+separate sync channel the "Cloud sync is free" reason weighs against: that
+channel must carry the bytes itself or images vanish across devices.
 
 ### Coordinate frame (verified)
 
@@ -243,7 +248,7 @@ the `text` fallthrough), inside the async `for (const m of marksHere)` (sequenti
 **New**
 - `web/src/lib/markupImage.ts` — the pure helpers above.
 - `web/test/markupImage.test.ts` — node:test over every helper.
-- `docs/plans/image-annotation-plan.md` — this file.
+- `docs/design/IMAGE_ANNOTATION.md` — this file.
 
 **Edited**
 - `web/src/lib/canvasConstants.js` — add the `image` tool to `MARKUP_TOOLS`; add

--- a/docs/design/IMAGE_CAPTURES.md
+++ b/docs/design/IMAGE_CAPTURES.md
@@ -1,4 +1,4 @@
-# Plan — "Captures": a cross-sheet image library in the sidebar
+# "Captures": a cross-sheet image library in the sidebar
 
 Reshapes image markups on `feat/206-image-annotation` from per-sheet annotations
 into a portable **Captures** library. Verified against the branch (file:line refs

--- a/docs/design/IMAGE_MARKUP_PROVENANCE.md
+++ b/docs/design/IMAGE_MARKUP_PROVENANCE.md
@@ -1,4 +1,4 @@
-# Plan — image-markup provenance, naming, thumbnails, placement & audit
+# Image-markup provenance, naming, thumbnails, placement & audit
 
 Enhancements to the image-markup feature on `feat/206-image-annotation` (PR #206).
 Verified against the branch rebased on `main` (2026-08-25); file:line refs are


### PR DESCRIPTION
Follow-up to the two non-blocking notes on #346.

- Moves the three image-annotation / Captures / provenance docs from `docs/plans/` to `docs/design/`, beside the drawing-styles and readout-tally design docs. `docs/plans/` held only these three, so it is now empty. Renamed to the UPPERCASE convention and dropped the `Plan —` H1 prefix; the one self-reference is repointed. The other two are pure renames.
- Adds the storage note you asked for to the `Storage decision` section: what a future dedicated blob store would trade — it buys back the per-edit re-serialization of the inline base64 image bytes on the debounced save, at the cost of the separate sync channel that section's own "Cloud sync is free" reason weighs against.