### PR TITLE
fix(transitions): measure partial shared runs to their true endpoints

### DIFF
--- a/mcp/test/transitions.test.ts
+++ b/mcp/test/transitions.test.ts
@@ -120,3 +120,33 @@ test("degenerate rings are ignored rather than throwing", () => {
   assert.deepEqual(sharedRuns([[0, 0], [1, 1]] as Pt[], rect(0, 0, 10, 10), OPTS), []);
   assert.deepEqual(sharedRuns(rect(0, 0, 10, 10), [] as Pt[], OPTS), []);
 });
+
+test("ENDPOINT REFINEMENT: a partial joint whose ends fall between samples measures full length", () => {
+  // A 100 px joint from y=107 to y=207 on A's right edge, sampled every 25 px:
+  // only y=125..200 pass the alongside test, so the samples alone measure
+  // 75 px — and a 100 px min_len gate silently drops a real transition.
+  // Refinement bisects each open end toward its rejected neighbour and finds
+  // the true endpoints at y=107 and y=207.
+  const a = rect(0, 0, 100, 400);
+  const b = rect(100, 107, 200, 207);
+  const runs = sharedRuns(a, b, { step_px: 25, touch_px: 1, max_gap_px: 12, min_len_px: 99 });
+  assert.equal(runs.length, 1, "the partial joint survives");
+  assert.equal(runs[0].kind, "butt");
+  assert.ok(Math.abs(runs[0].length_px - 100) < 0.01,
+    `run length ${runs[0].length_px} ≈ 100 (samples alone measured 75)`);
+  // the refined endpoints bound the true interval
+  const ys = runs[0].path.map((p) => p[1]);
+  assert.ok(Math.abs(Math.min(...ys) - 107) < 0.01, `head refined to y=107, got ${Math.min(...ys)}`);
+  assert.ok(Math.abs(Math.max(...ys) - 207) < 0.01, `tail refined to y=207, got ${Math.max(...ys)}`);
+});
+
+test("ENDPOINT REFINEMENT: an aligned joint is unchanged — refinement adds no phantom length", () => {
+  // B's edge endpoints land exactly on A's samples; the bisection converges to
+  // the samples themselves and the path gains nothing.
+  const a = rect(0, 0, 100, 400);
+  const b = rect(100, 100, 200, 200);
+  const runs = sharedRuns(a, b, { step_px: 25, touch_px: 1, max_gap_px: 12, min_len_px: 50 });
+  assert.equal(runs.length, 1);
+  assert.ok(Math.abs(runs[0].length_px - 100) < 0.01,
+    `aligned run stays ${runs[0].length_px} ≈ 100`);
+});

--- a/web/src/lib/transitions.ts
+++ b/web/src/lib/transitions.ts
@@ -197,11 +197,60 @@ export function sharedRuns(ringA: Pt[], ringB: Pt[], opts: SharedRunOpts): Share
     }
   }
 
+  // ── endpoint refinement ────────────────────────────────────────────────────
+  // A run's first and last samples are merely the outermost samples that PASSED
+  // the alongside test — the true boundary endpoint lies somewhere between each
+  // of them and its rejected neighbour, up to a full step away. Summing only
+  // the samples therefore undercuts every partial joint by as much as
+  // 2 x step_px, and a real joint sitting just over min_len_px measures under
+  // it and vanishes. (A 100 px joint from y=107 to y=207 sampled every 25 px
+  // keeps y=125..200: 75 px, gone at a 100 px gate.)
+  //
+  // sampleRing samples every segment's own start, so consecutive samples always
+  // lie on ONE ring segment — the chord between a boundary sample and its
+  // rejected neighbour IS the perimeter, and the flip point can be bisected on
+  // it exactly. The predicate mirrors the sampling one, with the tangent taken
+  // from the chord itself (on a straight edge that IS the central-difference
+  // tangent; at a corner the run ends at the corner sample anyway).
+  const alongsideAt = (p: Pt, tangent: Pt): boolean => {
+    const hit = nearestOnRing(p, ringB);
+    if (hit.d > max_gap_px) return false;
+    const dx = hit.at[0] - p[0], dy = hit.at[1] - p[1];
+    const dl = Math.hypot(dx, dy);
+    if (dl < COINCIDENT_PX) return true;
+    const tl = Math.hypot(tangent[0], tangent[1]);
+    if (tl === 0) return false;
+    return Math.abs((tangent[0] * dx + tangent[1] * dy) / (tl * dl)) <= 0.5;
+  };
+  // Bisect the chord from the passing sample toward the rejected neighbour and
+  // return the outermost point that still passes (the conservative side of the
+  // flip). Identical endpoints (an aligned joint) refine to the sample itself.
+  const refineEnd = (inside: Pt, outside: Pt): Pt => {
+    const tangent: Pt = [outside[0] - inside[0], outside[1] - inside[1]];
+    let lo = 0, hi = 1;   // t along inside->outside; lo passes, hi fails
+    for (let iter = 0; iter < 24; iter++) {
+      const mid = (lo + hi) / 2;
+      const p: Pt = [inside[0] + tangent[0] * mid, inside[1] + tangent[1] * mid];
+      if (alongsideAt(p, tangent)) lo = mid; else hi = mid;
+    }
+    return [inside[0] + tangent[0] * lo, inside[1] + tangent[1] * lo];
+  };
+
   const runs: SharedRun[] = [];
   for (const r of raw) {
     const idx: number[] = [];
     for (let i = r.from; i <= r.to; i++) idx.push(i % samples.length);
     const path = idx.map((i) => samples[i]);
+    // Open ends only: a run covering every sample wraps the whole ring and has
+    // no rejected neighbour to refine toward.
+    if (idx.length < samples.length) {
+      const before = samples[(((r.from - 1) % samples.length) + samples.length) % samples.length];
+      const after = samples[(r.to + 1) % samples.length];
+      const head = refineEnd(path[0], before);
+      const tail = refineEnd(path[path.length - 1], after);
+      if (Math.hypot(head[0] - path[0][0], head[1] - path[0][1]) > 1e-6) path.unshift(head);
+      if (Math.hypot(tail[0] - path[path.length - 1][0], tail[1] - path[path.length - 1][1]) > 1e-6) path.push(tail);
+    }
     let length_px = 0;
     for (let i = 1; i < path.length; i++) {
       length_px += Math.hypot(path[i][0] - path[i - 1][0], path[i][1] - path[i - 1][1]);


### PR DESCRIPTION
## The bug

`sharedRuns` sums `length_px` over the samples that passed the alongside test. When a run's true endpoints fall **between** samples, each open end loses up to one `step_px` — a systematic undercount on every partial joint, and worse: a real joint sitting just over `min_len_px` measures under it and **silently vanishes** from the takeoff.

Concrete case: a 100 px butt joint from `y=107` to `y=207` on a straight edge, sampled every 25 px, keeps only the samples at `y=125..200` — 75 px. At a 100 px minimum-run gate the transition is dropped entirely, which is the wrong-in-either-direction failure the module's own header warns about ("butt read as wall → the transition is silently missing from the bid" — here it's not even read as wall, it's just gone).

## The fix

`sampleRing` samples every segment's own start, so consecutive samples always lie on **one** ring segment — the chord between a run's boundary sample and its rejected neighbour *is* the perimeter. Each open end is refined by bisecting that chord on the same alongside predicate (nearest point on B within `max_gap_px`, the perpendicularity rule, `COINCIDENT_PX` handling), keeping the outermost point that still passes. The refined endpoints join both `path` and `length_px`, so the committed geometry and the committed LF stay consistent.

Deliberately conservative:
- a run covering every sample wraps the whole ring and has no rejected neighbour — left alone;
- aligned joints (endpoints on samples) refine to the samples themselves and gain nothing (epsilon-guarded, no duplicate vertices);
- `gap_px` stays the median of the *sample* distances, unchanged.

## Tests

Two regression cases in `mcp/test/transitions.test.ts`:
- the non-aligned `107..207` case now measures ~100 px with the path's refined endpoints at the true boundary (was 75 px, dropped);
- an aligned joint is byte-for-byte unchanged in length.

`web` typecheck + build green; `mcp` suite 184/184; `web` suite green apart from 4 pre-existing localStorage/node-env failures that fail identically on a clean checkout of `main`.

Found by review on a downstream port of this module.