### PR TITLE
fix(transitions): sampleRing refuses a non-positive step instead of hanging

### DIFF
--- a/mcp/test/transitions.test.ts
+++ b/mcp/test/transitions.test.ts
@@ -120,3 +120,16 @@ test("degenerate rings are ignored rather than throwing", () => {
   assert.deepEqual(sharedRuns([[0, 0], [1, 1]] as Pt[], rect(0, 0, 10, 10), OPTS), []);
   assert.deepEqual(sharedRuns(rect(0, 0, 10, 10), [] as Pt[], OPTS), []);
 });
+
+test("sampleRing refuses a non-positive step instead of spinning forever", () => {
+  // step=0 made n = Infinity and the per-segment loop never terminated.
+  const r = rect(0, 0, 100, 100);
+  assert.deepEqual(sampleRing(r, 0), []);
+  assert.deepEqual(sampleRing(r, -5), []);
+  assert.deepEqual(sampleRing(r, NaN), []);
+  // and sharedRuns degrades to "no runs" rather than hanging the caller
+  assert.deepEqual(
+    sharedRuns(r, rect(100, 0, 200, 100), { step_px: 0, touch_px: 1, max_gap_px: 12, min_len_px: 10 }),
+    []
+  );
+});

--- a/web/src/lib/transitions.ts
+++ b/web/src/lib/transitions.ts
@@ -100,6 +100,10 @@ export function distToRing(p: Pt, ring: Pt[]): number {
 
 /** Walk a closed ring at a fixed step, returning the sample points in order. */
 export function sampleRing(ring: Pt[], step: number): Pt[] {
+  // A non-positive (or NaN) step is not a finer walk, it is n = Infinity — the
+  // per-segment loop below never terminates and the tab hangs. Both in-tree
+  // callers clamp their step, but this is exported API: refuse, don't spin.
+  if (!(step > 0)) return [];
   const out: Pt[] = [];
   for (const [a, b] of segments(ring)) {
     const len = Math.hypot(b[0] - a[0], b[1] - a[1]);


### PR DESCRIPTION
## The bug

`sampleRing(ring, 0)` computes `n = Math.max(1, Math.ceil(len / 0)) = Infinity` and the per-segment sampling loop never terminates — the caller hangs (in the web app, that is the tab; over MCP, the tool call).

Both in-tree callers are safe today (`deriveTransitionRuns` clamps `step_px` to `>= 1`), but `sampleRing` and `sharedRuns` are exported API and one unclamped `opts` pass-through away from spinning forever.

## The fix

A single guard at the top of `sampleRing`: `if (!(step > 0)) return [];` — catches `0`, negatives, and `NaN` (`NaN > 0` is `false`). `sharedRuns` already degrades cleanly on an empty sample list (`samples.length < 2` → `[]`), so a bad step now means "no runs", never a hang.

## Tests

One regression test covering `0`, `-5`, and `NaN` directly on `sampleRing`, plus the `sharedRuns` pass-through with `step_px: 0`.

`mcp` suite 183/183; `web` typecheck green.

Companion to #350 (both from review findings on a downstream port of this module); independent — either merges cleanly without the other.