### PR TITLE
harden(transitions): bound sampleRing's sample count, not just the step

### DIFF
--- a/mcp/test/transitions.test.ts
+++ b/mcp/test/transitions.test.ts
@@ -157,6 +157,11 @@ test("sampleRing refuses a non-positive step instead of spinning forever", () =>
   assert.deepEqual(sampleRing(r, 0), []);
   assert.deepEqual(sampleRing(r, -5), []);
   assert.deepEqual(sampleRing(r, NaN), []);
+  // a subnormal step passes `> 0` but len / step still overflows to Infinity
+  assert.deepEqual(sampleRing(r, Number.MIN_VALUE), []);
+  // a segment whose length overflows Math.hypot is skipped, not walked
+  const huge = rect(0, 0, 1e308, 1e308);
+  assert.deepEqual(sampleRing(huge, 25), []);
   // and sharedRuns degrades to "no runs" rather than hanging the caller
   assert.deepEqual(
     sharedRuns(r, rect(100, 0, 200, 100), { step_px: 0, touch_px: 1, max_gap_px: 12, min_len_px: 10 }),

--- a/web/src/lib/transitions.ts
+++ b/web/src/lib/transitions.ts
@@ -98,6 +98,9 @@ export function distToRing(p: Pt, ring: Pt[]): number {
   return nearestOnRing(p, ring).d;
 }
 
+/** More samples than any real ring walk could want — the refuse-don't-spin cap. */
+const SAMPLE_BUDGET = 1_000_000;
+
 /** Walk a closed ring at a fixed step, returning the sample points in order. */
 export function sampleRing(ring: Pt[], step: number): Pt[] {
   // A non-positive (or NaN) step is not a finer walk, it is n = Infinity — the
@@ -110,6 +113,12 @@ export function sampleRing(ring: Pt[], step: number): Pt[] {
     if (!(len > 0)) continue;
     // every segment contributes its own start, so a corner is always sampled
     const n = Math.max(1, Math.ceil(len / step));
+    // Two more roads past the step guard reach the same hang: a subnormal step
+    // (Number.MIN_VALUE passes `> 0`, then len / step overflows to Infinity)
+    // and a segment long enough — even finitely — to want more samples than
+    // any real plan walk (a quarter-foot walk of a full sheet is ~1e3). Either
+    // way this is garbage input, not a finer walk: refuse the whole ring.
+    if (!Number.isFinite(n) || out.length + n > SAMPLE_BUDGET) return [];
     for (let k = 0; k < n; k++) {
       const t = k / n;
       out.push([a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t]);


### PR DESCRIPTION
Follow-up to #351 — this commit was pushed to that PR's branch minutes after it merged, so it never landed.

## Why the step guard alone is not enough

Review on the downstream port showed two roads past `if (!(step > 0))` to the same hang:

- **a subnormal step**: `Number.MIN_VALUE` passes `> 0`, then `len / step` overflows to `Infinity`;
- **a garbage-length segment**: 1e308-scale coordinates give a *finite* `len` wanting `n ≈ 4e306` samples — a plain `Number.isFinite(n)` check passes and the loop OOMs the process before `Infinity` ever appears (we crashed a V8 test runner proving it). *Finite* is not *bounded*.

## The fix

`SAMPLE_BUDGET = 1_000_000` — a real quarter-foot walk of a full sheet is ~1e3 samples. Exceeding the budget (or a non-finite `n`) refuses the whole ring, consistent with the step guard's refuse-don't-spin doctrine: partial sampling would silently mis-measure, and `sharedRuns` already degrades cleanly on an empty sample list.

## Tests

Regression cases for the `Number.MIN_VALUE` step and a 1e308-coordinate ring, alongside #351's existing cases. mcp transitions suite green.

Found by review on a downstream port of this module.