### PR TITLE
mcp 0.9.66: version bump + changelog for the variant-guard sweep changes (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## 2026-08-28 — richer variants are named, and variant_guard makes them questions
+
+### Added
+- **`extra` disclosure on symbol_sweep placements.** A placement that reproduces the whole seed but carries more than 30% unmatched extra linework fully inside its footprint (a register against a grille seed — the same outline plus louvers) now carries its measured `extra` fraction on the row, in both scopes. By default it still counts — the #259 contained-seed workflow depends on supersets matching — but the classic mislabel is named instead of hiding in the count. Background lines crossing the symbol and coincident duplicate ink never trip it.
+- **`variant_guard: true` on symbol_sweep** — whole-symbol mode: extra-ink placements demote to `withheld` as questions instead of counting. Stands down automatically when `exclude` counter-examples are in play (negatives are manual variant discrimination). `sweep_schedule_row` keeps disclosure only — tag corroboration already discriminates variants there. (mcp 0.9.66)
+
 ## 2026-08-26 — the readout keeps a tape log
 
 ### Added

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.65",
+  "version": "0.9.66",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.65",
+  "version": "0.9.66",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.65",
+      "version": "0.9.66",
       "transport": {
         "type": "stdio"
       }

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.65",
+  "version": "0.9.66",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.65",
+      "version": "0.9.66",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
#353 changed `mcp/` without the three-surface version bump the guard enforces — main is red on `mcp-version-guard` (my miss: merged on a script bug that ignored the failing check; owned in the session log). This bumps 0.9.65 → 0.9.66 on all three surfaces plus the CHANGELOG entry. The other red job (`mcp ubuntu`, `npm ci` dying in `onnxruntime-node` postinstall) is a dependency-install flake unrelated to #353's diff — no dependency changes in either PR; this run will confirm.