### PR TITLE
test(oneclick): add conservative hatch policy reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 ## Unreleased - conservative hatch-policy reference experiment (#371)
 
 ### Added
-- **A disconnected hatch-policy reference and reproducible negative real-sheet run.** The experiment separates lattice proposals, conservative classification, and strict-versus-transparent retry gating without changing production One-Click. Its captured run against the two PDF-backed bench cases shows why it remains a reference: the real finish plan's raw extractor output contains degenerate segments the proposal rejects, the filtered 71,819-segment sheet exceeds a five-second proposal budget, and all 37 existing hatch families remain uncertain without evidence identifiers the extractor does not emit.
+- **A disconnected hatch-policy reference and reproducible negative real-sheet run.** The experiment separates lattice proposals, conservative classification, and strict-versus-transparent retry gating without changing production One-Click. Its captured run covers the two existing PDF-backed bench cases plus Dublin A-601 and matching Roseburg floor/RCP pages from the public open-sheet corpus. Every real page contains degenerate extractor segments, every filtered full-sheet proposal exceeds a five-second budget, and all 123 existing family instances remain uncertain without evidence identifiers the extractor does not emit.
 
 ## Unreleased — `get_sheet_vectors`: the strokes the engine floods against, readable by any agent (#367)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased - conservative hatch-policy reference experiment (#371)
+
+### Added
+- **A disconnected hatch-policy reference and reproducible negative real-sheet run.** The experiment separates lattice proposals, conservative classification, and strict-versus-transparent retry gating without changing production One-Click. Its captured run against the two PDF-backed bench cases shows why it remains a reference: the real finish plan's raw extractor output contains degenerate segments the proposal rejects, the filtered 71,819-segment sheet exceeds a five-second proposal budget, and all 37 existing hatch families remain uncertain without evidence identifiers the extractor does not emit.
+
 ## Unreleased — `get_sheet_vectors`: the strokes the engine floods against, readable by any agent (#367)
 
 ### Added

--- a/docs/design/HATCH_POLICY_REFERENCE.md
+++ b/docs/design/HATCH_POLICY_REFERENCE.md
@@ -1,0 +1,47 @@
+# Hatch-family reference policy
+
+This experiment tests an alternative policy around the current One-Click hatch primitives. It is a reviewable model, not a production replacement. OpenTakeoff does not import `hatchPolicyReference.js` from the room engine.
+
+The reference answers three questions:
+
+1. Which line segments fit one normal-offset lattice?
+2. Does trusted provenance or context support calling that family hatch, a repeated building element, or uncertain?
+3. If a hatch family trapped the strict flood, may a transparent retry replace it without losing rooms or crossing protected geometry?
+
+## Detection contract
+
+`proposeLineFamilies` groups segments by sheet-local stroke width and angle modulo pi. It normalizes coordinates against a robust sheet scale, merges split pieces into rows, and fits pitch and phase with missing-row tolerance. The fit reports row and capped-length inlier rates, occupancy, residual, spatial span, and member IDs.
+
+`analyzeLineFamilies` also reports every unassigned segment ID. The caller can therefore audit which source geometry the proposal stage ignored.
+
+The reference does not fit tangential dash recurrence. The split-row carpet fixture proves only that collinear fragments do not receive extra row votes. Do not use this module as evidence of dash-phase support.
+
+## Classification contract
+
+`classifyLineFamily` returns `hatch`, `repeated-building-element`, or `uncertain`.
+
+Native hatch provenance is accepted only when every family member belongs to the same extractor group and the caller supplies that group through a separate trusted set. Caller-authored segment fields cannot mark themselves trusted. Flattened geometry requires separately trusted clip or fill evidence. Geometry alone remains uncertain because a periodic partition bank can be identical to hatch after flattening.
+
+Paired support rails protect stair treads and similar repeated construction. Orthogonal grids remain uncertain. The synthetic corpus also keeps dimension ticks, ceiling grids, shelving-like banks, and irregular parallel lines out of the hatch label.
+
+## Retry contract
+
+`gateTransparentRetry` keeps both the strict result and the transparent candidate in its decision record. Only a testable hatch decision with finite confidence may request a retry.
+
+The retry fails closed when metrics are missing or when it leaks, creates invalid polygons, exceeds the area-growth budget, loses wall support or coverage, overlaps a protected class, increases downstream errors, loses or traps a seed, fails to recover a formerly trapped seed, or changes the room split and merge relation.
+
+The defaults are test values, not recommended production thresholds. Tune them on projects that stay separate from final held-out sheets. Report every protected-class failure and every retry that is worse than the strict result, even when aggregate hatch recall improves.
+
+## Run the checks
+
+From `web/`:
+
+```sh
+node --import tsx --test test/hatchPolicyReference.test.ts
+```
+
+The full repository check remains the merge gate:
+
+```sh
+npm run check
+```

--- a/docs/design/HATCH_POLICY_REFERENCE.md
+++ b/docs/design/HATCH_POLICY_REFERENCE.md
@@ -32,6 +32,8 @@ The retry fails closed when metrics are missing or when it leaks, creates invali
 
 The defaults are test values, not recommended production thresholds. Tune them on projects that stay separate from final held-out sheets. Report every protected-class failure and every retry that is worse than the strict result, even when aggregate hatch recall improves.
 
+The first run against the repository's own extracted vectors did not clear the real-sheet bar. See [HATCH_POLICY_REFERENCE_VERIFICATION.md](HATCH_POLICY_REFERENCE_VERIFICATION.md). The current extractor does not emit the trusted group or evidence identifiers this classifier requires, the raw real sheet contains degenerate segments the proposal stage rejects, and the filtered full-sheet proposal exceeded its declared time budget. Keep this as a negative-control reference unless those failures are addressed and re-measured.
+
 ## Run the checks
 
 From `web/`:

--- a/docs/design/HATCH_POLICY_REFERENCE_VERIFICATION.md
+++ b/docs/design/HATCH_POLICY_REFERENCE_VERIFICATION.md
@@ -1,0 +1,33 @@
+# Hatch-policy reference verification
+
+## Result
+
+The reference policy does not clear OpenTakeoff's real-sheet bar in its current form. This is a captured negative result, not an accuracy claim.
+
+The runner uses `extractVectorGeometry` on the two PDF-backed cases in `web/bench/corpus`. That is the same segment, meta-byte, and luminance output exposed by `get_sheet_vectors`; the MCP parity test separately holds the public verb byte-for-byte against this extraction path.
+
+| Case | Extracted segments | Existing classifier | Reference result |
+| --- | ---: | --- | --- |
+| `sample-plan` | 6 | 0 soft segments, 0 families | 0 proposals |
+| `va-finish-plan` | 71,819 | 25,157 soft segments, 37 families | raw input rejected; filtered proposal timed out after 5 seconds |
+
+The real finish-plan input contains 2,895 zero-length segments. The reference proposal stage rejects the first one as degenerate. Removing only those segments avoids that validation error, but the full-sheet proposal stage does not finish inside the declared five-second budget.
+
+The classification-only comparison is also intentionally unfavorable to the reference. It feeds all 37 families found by the existing classifier perfect lattice metrics, while limiting context to evidence present in the extractor output. All 37 remain `uncertain`. The extractor does not currently emit the trusted group IDs or clip/fill evidence IDs required for a `hatch` decision. Consequently, this reference would soften none of the families that the current classifier handles.
+
+These results leave two unresolved requirements:
+
+1. The proposal stage needs an input adapter that accounts for extractor degenerates and an algorithmic bound suitable for dense real sheets.
+2. The classification contract needs evidence the extractor actually supplies, with a held-out comparison against `classifyHatchSegs` before it can be considered a policy.
+
+The retry gate still has only synthetic coverage. This run did not find a real case where today's escalation splits or merges a room, so it does not support integrating the gate into production yet.
+
+## Reproduce
+
+From `web/`:
+
+```sh
+npm run bench:hatch-policy-reference -- --output bench/hatch-policy-reference-results.json
+```
+
+The exact captured output is committed at [`web/bench/hatch-policy-reference-results.json`](../../web/bench/hatch-policy-reference-results.json). The runner terminates the proposal child after five seconds and records `timeout`; it does not infer completion from silence.

--- a/docs/design/HATCH_POLICY_REFERENCE_VERIFICATION.md
+++ b/docs/design/HATCH_POLICY_REFERENCE_VERIFICATION.md
@@ -4,21 +4,30 @@
 
 The reference policy does not clear OpenTakeoff's real-sheet bar in its current form. This is a captured negative result, not an accuracy claim.
 
-The runner uses `extractVectorGeometry` on the two PDF-backed cases in `web/bench/corpus`. That is the same segment, meta-byte, and luminance output exposed by `get_sheet_vectors`; the MCP parity test separately holds the public verb byte-for-byte against this extraction path.
+The runner uses `extractVectorGeometry` on the two PDF-backed cases in `web/bench/corpus` and three pages from the public VA plan sets in `bench/open-sheets`. That is the same segment, meta-byte, and luminance output exposed by `get_sheet_vectors`; the MCP parity test separately holds the public verb byte-for-byte against this extraction path.
 
 | Case | Extracted segments | Existing classifier | Reference result |
 | --- | ---: | --- | --- |
 | `sample-plan` | 6 | 0 soft segments, 0 families | 0 proposals |
-| `va-finish-plan` | 71,819 | 25,157 soft segments, 37 families | raw input rejected; filtered proposal timed out after 5 seconds |
+| `va-finish-plan` | 71,819 | 25,157 soft segments, 37 families in 54 ms | raw input rejected; filtered proposal timed out after 5 seconds |
+| Dublin A-601 finish plan | 35,538 | 12,950 soft segments, 28 families in 41 ms | raw input rejected; filtered proposal timed out after 5 seconds |
+| Roseburg A-03a floor plan | 72,303 | 2,137 soft segments, 35 families in 83 ms | raw input rejected; filtered proposal timed out after 5 seconds |
+| Roseburg A-04a RCP | 62,867 | 1,887 soft segments, 23 families in 77 ms | raw input rejected; filtered proposal timed out after 5 seconds |
 
-The real finish-plan input contains 2,895 zero-length segments. The reference proposal stage rejects the first one as degenerate. Removing only those segments avoids that validation error, but the full-sheet proposal stage does not finish inside the declared five-second budget.
+All four real-sheet inputs contain zero-length segments: 2,895 in the original finish-plan case, 2,026 in Dublin, 727 in Roseburg A-03a, and 604 in Roseburg A-04a. The reference proposal stage rejects the first degenerate segment in each input. Removing only those segments avoids that validation error, but no full-sheet proposal finishes inside the declared five-second budget.
 
-The classification-only comparison is also intentionally unfavorable to the reference. It feeds all 37 families found by the existing classifier perfect lattice metrics, while limiting context to evidence present in the extractor output. All 37 remain `uncertain`. The extractor does not currently emit the trusted group IDs or clip/fill evidence IDs required for a `hatch` decision. Consequently, this reference would soften none of the families that the current classifier handles.
+The classification-only comparison is also intentionally favorable on geometry and strict on evidence. It feeds every family found by the existing classifier perfect lattice metrics, while limiting context to evidence present in the extractor output. All 123 family instances across the four real-sheet runs remain `uncertain`. The extractor does not currently emit the trusted group IDs or clip/fill evidence IDs required for a `hatch` decision. Consequently, this reference would soften none of the families that the current classifier handles.
+
+## Review questions from the open sheets
+
+The Dublin sheet visibly contains two finish patterns, including adjacent corridor regions. The reference does not reach a family result. After degenerate filtering it times out, so it cannot answer "two families or one" within the budget. The existing classifier returns 28 family instances, but they are not a stable two-family partition: the dominant diagonal pattern is split among several adjacent angle/pitch buckets. For example, `h-a56.0p1.7w1` appears four times, while nearby 55.5 and 57 degree signatures produce additional instances. This is evidence of fragmentation, not evidence that the two materials were separated correctly.
+
+The Roseburg comparison uses the matching Area A floor-plan and reflected-ceiling-plan pages. The floor plan visibly hatches in-scope rooms while leaving `NO WORK` rooms plain; the RCP uses an orthogonal ceiling grid. The reference again times out on both filtered pages. The existing classifier returns 35 family instances on the floor plan and 23 on the RCP, but the full-page counts do not establish room-versus-grid discrimination. The committed per-instance IDs and bounding boxes make this failure checkable without treating a global family count as semantic accuracy.
 
 These results leave two unresolved requirements:
 
 1. The proposal stage needs an input adapter that accounts for extractor degenerates and an algorithmic bound suitable for dense real sheets.
-2. The classification contract needs evidence the extractor actually supplies, with a held-out comparison against `classifyHatchSegs` before it can be considered a policy.
+2. The classification contract needs evidence the extractor actually supplies, plus region-level ground truth for material hatch versus ceiling grid, before it can be considered a policy.
 
 The retry gate still has only synthetic coverage. This run did not find a real case where today's escalation splits or merges a room, so it does not support integrating the gate into production yet.
 

--- a/web/bench/hatch-policy-reference-results.json
+++ b/web/bench/hatch-policy-reference-results.json
@@ -1,0 +1,83 @@
+{
+  "generated_at": "2026-09-02T12:49:51.174Z",
+  "proposal_timeout_ms": 5000,
+  "results": [
+    {
+      "case": "sample-plan",
+      "source": {
+        "corpus": "bench/corpus/sample-plan.json",
+        "pdf": "demo/sample-plan.pdf",
+        "segments": 6,
+        "degenerate_segments": 0,
+        "meta_bytes": 6,
+        "luminance_values": 6
+      },
+      "existing_classifier": {
+        "elapsed_ms": 1,
+        "soft_segments": 0,
+        "families": 0
+      },
+      "reference_classifier_on_existing_families": {
+        "input_note": "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",
+        "labels": {
+          "hatch": 0,
+          "repeated-building-element": 0,
+          "uncertain": 0
+        }
+      },
+      "reference_proposal_raw": {
+        "status": "completed",
+        "elapsed_ms": 1,
+        "proposals": 0,
+        "labels": {
+          "hatch": 0,
+          "repeated-building-element": 0,
+          "uncertain": 0
+        }
+      },
+      "reference_proposal_without_degenerate_segments": {
+        "status": "completed",
+        "elapsed_ms": 1,
+        "proposals": 0,
+        "labels": {
+          "hatch": 0,
+          "repeated-building-element": 0,
+          "uncertain": 0
+        }
+      }
+    },
+    {
+      "case": "va-finish-plan",
+      "source": {
+        "corpus": "bench/corpus/va-finish-plan.json",
+        "pdf": "demo/sample-finish-plan.pdf",
+        "segments": 71819,
+        "degenerate_segments": 2895,
+        "meta_bytes": 71819,
+        "luminance_values": 71819
+      },
+      "existing_classifier": {
+        "elapsed_ms": 120,
+        "soft_segments": 25157,
+        "families": 37
+      },
+      "reference_classifier_on_existing_families": {
+        "input_note": "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",
+        "labels": {
+          "hatch": 0,
+          "repeated-building-element": 0,
+          "uncertain": 37
+        }
+      },
+      "reference_proposal_raw": {
+        "status": "error",
+        "elapsed_ms": 12,
+        "error": "segment-31153 must not be degenerate"
+      },
+      "reference_proposal_without_degenerate_segments": {
+        "status": "timeout",
+        "elapsed_ms": 5000
+      }
+    }
+  ]
+}

--- a/web/bench/hatch-policy-reference-results.json
+++ b/web/bench/hatch-policy-reference-results.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-09-02T12:49:51.174Z",
+  "generated_at": "2026-09-02T15:14:04.854Z",
   "proposal_timeout_ms": 5000,
   "results": [
     {
@@ -7,15 +7,17 @@
       "source": {
         "corpus": "bench/corpus/sample-plan.json",
         "pdf": "demo/sample-plan.pdf",
+        "page": 1,
         "segments": 6,
         "degenerate_segments": 0,
         "meta_bytes": 6,
         "luminance_values": 6
       },
       "existing_classifier": {
-        "elapsed_ms": 1,
+        "elapsed_ms": 0,
         "soft_segments": 0,
-        "families": 0
+        "families": 0,
+        "family_instances": []
       },
       "reference_classifier_on_existing_families": {
         "input_note": "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",
@@ -27,7 +29,7 @@
       },
       "reference_proposal_raw": {
         "status": "completed",
-        "elapsed_ms": 1,
+        "elapsed_ms": 0,
         "proposals": 0,
         "labels": {
           "hatch": 0,
@@ -37,7 +39,7 @@
       },
       "reference_proposal_without_degenerate_segments": {
         "status": "completed",
-        "elapsed_ms": 1,
+        "elapsed_ms": 0,
         "proposals": 0,
         "labels": {
           "hatch": 0,
@@ -51,15 +53,499 @@
       "source": {
         "corpus": "bench/corpus/va-finish-plan.json",
         "pdf": "demo/sample-finish-plan.pdf",
+        "page": 1,
         "segments": 71819,
         "degenerate_segments": 2895,
         "meta_bytes": 71819,
         "luminance_values": 71819
       },
       "existing_classifier": {
-        "elapsed_ms": 120,
+        "elapsed_ms": 54,
         "soft_segments": 25157,
-        "families": 37
+        "families": 37,
+        "family_instances": [
+          {
+            "id": "h-a46.5p2.1w1",
+            "angle_deg": 46.68,
+            "pitch_px": 2.12,
+            "rows": 15,
+            "segments": 64,
+            "bbox": [
+              4098.2,
+              319,
+              4344.5,
+              646.3
+            ]
+          },
+          {
+            "id": "h-a38.5p2.2w1",
+            "angle_deg": 38.38,
+            "pitch_px": 2.18,
+            "rows": 15,
+            "segments": 68,
+            "bbox": [
+              4094.6,
+              321.8,
+              4344.5,
+              686.6
+            ]
+          },
+          {
+            "id": "h-a44.0p1.8w1",
+            "angle_deg": 44.18,
+            "pitch_px": 1.84,
+            "rows": 14,
+            "segments": 55,
+            "bbox": [
+              3834.5,
+              293.1,
+              5860.6,
+              2375.8
+            ]
+          },
+          {
+            "id": "h-a45.5p2.0w1",
+            "angle_deg": 45.69,
+            "pitch_px": 1.98,
+            "rows": 14,
+            "segments": 63,
+            "bbox": [
+              3955.9,
+              312.5,
+              4344.5,
+              952.3
+            ]
+          },
+          {
+            "id": "h-a63.0p1.6w1",
+            "angle_deg": 62.97,
+            "pitch_px": 1.62,
+            "rows": 43,
+            "segments": 407,
+            "bbox": [
+              3664.1,
+              102.7,
+              4344.5,
+              1196.6
+            ]
+          },
+          {
+            "id": "h-a58.5p1.7w1",
+            "angle_deg": 58.42,
+            "pitch_px": 1.66,
+            "rows": 36,
+            "segments": 391,
+            "bbox": [
+              3792.7,
+              293,
+              4469,
+              1436.7
+            ]
+          },
+          {
+            "id": "h-a59.0p1.6w1",
+            "angle_deg": 59.13,
+            "pitch_px": 1.61,
+            "rows": 14,
+            "segments": 159,
+            "bbox": [
+              3813.6,
+              483.4,
+              4469,
+              1417
+            ]
+          },
+          {
+            "id": "h-a57.0p1.6w1",
+            "angle_deg": 57.07,
+            "pitch_px": 1.6,
+            "rows": 236,
+            "segments": 3095,
+            "bbox": [
+              3095.3,
+              102.7,
+              6048,
+              4319.8
+            ]
+          },
+          {
+            "id": "h-a52.0p1.6w1",
+            "angle_deg": 52.05,
+            "pitch_px": 1.61,
+            "rows": 68,
+            "segments": 751,
+            "bbox": [
+              251.8,
+              153.6,
+              5939.7,
+              3801.6
+            ]
+          },
+          {
+            "id": "h-a49.5p1.7w1",
+            "angle_deg": 49.75,
+            "pitch_px": 1.72,
+            "rows": 54,
+            "segments": 475,
+            "bbox": [
+              3306.5,
+              797.5,
+              4535,
+              2788.1
+            ]
+          },
+          {
+            "id": "h-a59.5p1.6w1",
+            "angle_deg": 59.6,
+            "pitch_px": 1.57,
+            "rows": 215,
+            "segments": 4131,
+            "bbox": [
+              2526.7,
+              102.7,
+              5927.8,
+              4219.9
+            ]
+          },
+          {
+            "id": "h-a42.0p1.6w1",
+            "angle_deg": 42.15,
+            "pitch_px": 1.56,
+            "rows": 21,
+            "segments": 274,
+            "bbox": [
+              2769.1,
+              697,
+              4917.3,
+              3932.2
+            ]
+          },
+          {
+            "id": "h-a56.5p1.6w1",
+            "angle_deg": 56.26,
+            "pitch_px": 1.57,
+            "rows": 268,
+            "segments": 4646,
+            "bbox": [
+              1946.6,
+              102.7,
+              5129,
+              4219.9
+            ]
+          },
+          {
+            "id": "h-a52.0p1.6w1",
+            "angle_deg": 52,
+            "pitch_px": 1.58,
+            "rows": 27,
+            "segments": 405,
+            "bbox": [
+              1984.3,
+              323.8,
+              4519.9,
+              4157
+            ]
+          },
+          {
+            "id": "h-a70.0p1.5w1",
+            "angle_deg": 70.05,
+            "pitch_px": 1.52,
+            "rows": 12,
+            "segments": 237,
+            "bbox": [
+              1984.3,
+              395.8,
+              3896.4,
+              3215.5
+            ]
+          },
+          {
+            "id": "h-a58.0p1.6w1",
+            "angle_deg": 57.79,
+            "pitch_px": 1.61,
+            "rows": 73,
+            "segments": 755,
+            "bbox": [
+              1946.6,
+              217,
+              3827.8,
+              3235
+            ]
+          },
+          {
+            "id": "h-a54.0p1.7w1",
+            "angle_deg": 54.2,
+            "pitch_px": 1.69,
+            "rows": 40,
+            "segments": 273,
+            "bbox": [
+              1966.3,
+              692.2,
+              2939.3,
+              2084.6
+            ]
+          },
+          {
+            "id": "h-a56.5p1.7w1",
+            "angle_deg": 56.25,
+            "pitch_px": 1.65,
+            "rows": 16,
+            "segments": 72,
+            "bbox": [
+              1984.3,
+              827.8,
+              4232.6,
+              4219.9
+            ]
+          },
+          {
+            "id": "h-a42.0p1.9w1",
+            "angle_deg": 42.03,
+            "pitch_px": 1.9,
+            "rows": 16,
+            "segments": 75,
+            "bbox": [
+              1831.2,
+              705.4,
+              2795,
+              2137
+            ]
+          },
+          {
+            "id": "h-a49.5p1.7w1",
+            "angle_deg": 49.74,
+            "pitch_px": 1.69,
+            "rows": 16,
+            "segments": 76,
+            "bbox": [
+              1389.4,
+              102.7,
+              2775.4,
+              2137
+            ]
+          },
+          {
+            "id": "h-a57.0p1.7w1",
+            "angle_deg": 56.96,
+            "pitch_px": 1.67,
+            "rows": 18,
+            "segments": 116,
+            "bbox": [
+              1768.8,
+              797.5,
+              2675.5,
+              2137
+            ]
+          },
+          {
+            "id": "h-a52.0p1.7w1",
+            "angle_deg": 52.17,
+            "pitch_px": 1.7,
+            "rows": 24,
+            "segments": 134,
+            "bbox": [
+              1723.2,
+              797.5,
+              2675.5,
+              2137
+            ]
+          },
+          {
+            "id": "h-a52.0p1.8w1",
+            "angle_deg": 52.18,
+            "pitch_px": 1.81,
+            "rows": 24,
+            "segments": 124,
+            "bbox": [
+              1666.8,
+              797.5,
+              2586,
+              2126.2
+            ]
+          },
+          {
+            "id": "h-a54.0p2.0w1",
+            "angle_deg": 54.19,
+            "pitch_px": 2.01,
+            "rows": 18,
+            "segments": 92,
+            "bbox": [
+              1414.8,
+              797.5,
+              2550,
+              2431
+            ]
+          },
+          {
+            "id": "h-a52.5p1.7w1",
+            "angle_deg": 52.58,
+            "pitch_px": 1.66,
+            "rows": 19,
+            "segments": 105,
+            "bbox": [
+              1091,
+              289,
+              2552.2,
+              2462.6
+            ]
+          },
+          {
+            "id": "h-a55.5p1.8w1",
+            "angle_deg": 55.39,
+            "pitch_px": 1.8,
+            "rows": 42,
+            "segments": 213,
+            "bbox": [
+              966.5,
+              307.7,
+              3681.6,
+              4219.9
+            ]
+          },
+          {
+            "id": "h-a49.5p1.9w1",
+            "angle_deg": 49.49,
+            "pitch_px": 1.88,
+            "rows": 16,
+            "segments": 71,
+            "bbox": [
+              820.6,
+              102.7,
+              2382.5,
+              2461.7
+            ]
+          },
+          {
+            "id": "h-a56.0p1.9w1",
+            "angle_deg": 56.06,
+            "pitch_px": 1.95,
+            "rows": 12,
+            "segments": 61,
+            "bbox": [
+              0,
+              812.4,
+              6048,
+              4319.8
+            ]
+          },
+          {
+            "id": "h-a57.5p1.7w1",
+            "angle_deg": 57.29,
+            "pitch_px": 1.71,
+            "rows": 11,
+            "segments": 63,
+            "bbox": [
+              582.5,
+              1121.3,
+              1132.3,
+              2083
+            ]
+          },
+          {
+            "id": "h-a63.5p1.8w1",
+            "angle_deg": 63.6,
+            "pitch_px": 1.85,
+            "rows": 11,
+            "segments": 51,
+            "bbox": [
+              164.9,
+              638.9,
+              1058.4,
+              2069.5
+            ]
+          },
+          {
+            "id": "h-a73.0p1.9w1",
+            "angle_deg": 73.03,
+            "pitch_px": 1.89,
+            "rows": 10,
+            "segments": 47,
+            "bbox": [
+              582.5,
+              1417,
+              985.9,
+              1969.4
+            ]
+          },
+          {
+            "id": "h-a67.5p2.0w1",
+            "angle_deg": 67.6,
+            "pitch_px": 1.96,
+            "rows": 29,
+            "segments": 162,
+            "bbox": [
+              110.9,
+              854.9,
+              1139,
+              2819.5
+            ]
+          },
+          {
+            "id": "h-a67.0p1.7w1",
+            "angle_deg": 66.92,
+            "pitch_px": 1.67,
+            "rows": 18,
+            "segments": 79,
+            "bbox": [
+              110.9,
+              1016.9,
+              781,
+              2053.4
+            ]
+          },
+          {
+            "id": "h-a65.5p1.7w1",
+            "angle_deg": 65.66,
+            "pitch_px": 1.73,
+            "rows": 16,
+            "segments": 125,
+            "bbox": [
+              456.5,
+              1705.7,
+              754.3,
+              2020.8
+            ]
+          },
+          {
+            "id": "h-a68.0p2.3w1",
+            "angle_deg": 67.83,
+            "pitch_px": 2.27,
+            "rows": 11,
+            "segments": 56,
+            "bbox": [
+              146.9,
+              1313.8,
+              2039,
+              4219.9
+            ]
+          },
+          {
+            "id": "h-a42.5p2.2w1",
+            "angle_deg": 42.35,
+            "pitch_px": 2.24,
+            "rows": 11,
+            "segments": 34,
+            "bbox": [
+              110.9,
+              2024.9,
+              552.5,
+              2704.1
+            ]
+          },
+          {
+            "id": "h-a42.5p2.5w1",
+            "angle_deg": 42.63,
+            "pitch_px": 2.48,
+            "rows": 10,
+            "segments": 19,
+            "bbox": [
+              146.9,
+              2204.9,
+              582.5,
+              2767
+            ]
+          }
+        ]
       },
       "reference_classifier_on_existing_families": {
         "input_note": "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",
@@ -71,8 +557,1231 @@
       },
       "reference_proposal_raw": {
         "status": "error",
-        "elapsed_ms": 12,
+        "elapsed_ms": 7,
         "error": "segment-31153 must not be degenerate"
+      },
+      "reference_proposal_without_degenerate_segments": {
+        "status": "timeout",
+        "elapsed_ms": 5000
+      }
+    },
+    {
+      "case": "dublin-finish-plan",
+      "source": {
+        "pdf": "bench/open-sheets/va-dublin-bldg9a-finish-plan-A601.pdf",
+        "page": 1,
+        "segments": 35538,
+        "degenerate_segments": 2026,
+        "meta_bytes": 35538,
+        "luminance_values": 35538
+      },
+      "existing_classifier": {
+        "elapsed_ms": 41,
+        "soft_segments": 12950,
+        "families": 28,
+        "family_instances": [
+          {
+            "id": "h-a180.0p1.6w1",
+            "angle_deg": 179.99,
+            "pitch_px": 1.56,
+            "rows": 123,
+            "segments": 2566,
+            "bbox": [
+              176.9,
+              2508,
+              5990.6,
+              2704.3
+            ]
+          },
+          {
+            "id": "h-a54.5p1.8w1",
+            "angle_deg": 54.59,
+            "pitch_px": 1.76,
+            "rows": 17,
+            "segments": 80,
+            "bbox": [
+              4744.8,
+              2097.1,
+              5181.6,
+              2690.9
+            ]
+          },
+          {
+            "id": "h-a56.0p1.6w1",
+            "angle_deg": 55.85,
+            "pitch_px": 1.62,
+            "rows": 12,
+            "segments": 97,
+            "bbox": [
+              4710.5,
+              2153.5,
+              5105.3,
+              2690.9
+            ]
+          },
+          {
+            "id": "h-a56.0p1.7w1",
+            "angle_deg": 56.1,
+            "pitch_px": 1.66,
+            "rows": 85,
+            "segments": 608,
+            "bbox": [
+              4499.8,
+              2156.9,
+              5533.9,
+              3557.3
+            ]
+          },
+          {
+            "id": "h-a56.0p1.7w1",
+            "angle_deg": 56.24,
+            "pitch_px": 1.66,
+            "rows": 11,
+            "segments": 34,
+            "bbox": [
+              2548.3,
+              1665.6,
+              2933.8,
+              2254.1
+            ]
+          },
+          {
+            "id": "h-a55.5p1.7w1",
+            "angle_deg": 55.38,
+            "pitch_px": 1.71,
+            "rows": 11,
+            "segments": 47,
+            "bbox": [
+              2285.8,
+              1598.9,
+              2742,
+              2246.9
+            ]
+          },
+          {
+            "id": "h-a55.5p1.6w1",
+            "angle_deg": 55.4,
+            "pitch_px": 1.62,
+            "rows": 12,
+            "segments": 51,
+            "bbox": [
+              2261.8,
+              1598.9,
+              2718,
+              2246.9
+            ]
+          },
+          {
+            "id": "h-a55.5p1.7w1",
+            "angle_deg": 55.69,
+            "pitch_px": 1.66,
+            "rows": 17,
+            "segments": 83,
+            "bbox": [
+              2231.5,
+              1598.9,
+              2694,
+              2246.9
+            ]
+          },
+          {
+            "id": "h-a56.0p1.7w1",
+            "angle_deg": 56.05,
+            "pitch_px": 1.67,
+            "rows": 12,
+            "segments": 60,
+            "bbox": [
+              2206.1,
+              1598.9,
+              2646,
+              2246.9
+            ]
+          },
+          {
+            "id": "h-a57.0p1.7w1",
+            "angle_deg": 56.83,
+            "pitch_px": 1.65,
+            "rows": 12,
+            "segments": 65,
+            "bbox": [
+              2129.5,
+              1598.9,
+              2574,
+              2246.9
+            ]
+          },
+          {
+            "id": "h-a57.0p1.7w1",
+            "angle_deg": 57,
+            "pitch_px": 1.66,
+            "rows": 19,
+            "segments": 144,
+            "bbox": [
+              2068.1,
+              1598.9,
+              2515.7,
+              2246.9
+            ]
+          },
+          {
+            "id": "h-a57.0p1.7w1",
+            "angle_deg": 57.25,
+            "pitch_px": 1.66,
+            "rows": 10,
+            "segments": 108,
+            "bbox": [
+              2068.1,
+              1817.5,
+              2461.2,
+              2397.4
+            ]
+          },
+          {
+            "id": "h-a56.0p1.7w1",
+            "angle_deg": 56.08,
+            "pitch_px": 1.66,
+            "rows": 107,
+            "segments": 876,
+            "bbox": [
+              1942.8,
+              2145.6,
+              3463.7,
+              4123
+            ]
+          },
+          {
+            "id": "h-a56.5p1.8w1",
+            "angle_deg": 56.4,
+            "pitch_px": 1.78,
+            "rows": 80,
+            "segments": 373,
+            "bbox": [
+              905.5,
+              2156.9,
+              1276.1,
+              2690.9
+            ]
+          },
+          {
+            "id": "h-a90.0p1.7w1",
+            "angle_deg": 90,
+            "pitch_px": 1.68,
+            "rows": 24,
+            "segments": 145,
+            "bbox": [
+              5239.2,
+              2512.3,
+              5291,
+              3209
+            ]
+          },
+          {
+            "id": "h-a90.0p1.7w1",
+            "angle_deg": 90,
+            "pitch_px": 1.68,
+            "rows": 10,
+            "segments": 53,
+            "bbox": [
+              5147,
+              2512.3,
+              5163.4,
+              2856
+            ]
+          },
+          {
+            "id": "h-a90.0p2.9w1",
+            "angle_deg": 90,
+            "pitch_px": 2.88,
+            "rows": 11,
+            "segments": 57,
+            "bbox": [
+              2078.6,
+              1598.9,
+              2110.8,
+              2712
+            ]
+          },
+          {
+            "id": "h-a90.0p1.7w1",
+            "angle_deg": 90,
+            "pitch_px": 1.68,
+            "rows": 10,
+            "segments": 94,
+            "bbox": [
+              1241,
+              358.3,
+              1259.8,
+              2524.3
+            ]
+          },
+          {
+            "id": "h-a90.0p1.7w1",
+            "angle_deg": 90,
+            "pitch_px": 1.68,
+            "rows": 26,
+            "segments": 159,
+            "bbox": [
+              1177.2,
+              1923.1,
+              1240.8,
+              4157
+            ]
+          },
+          {
+            "id": "h-a90.0p1.7w1",
+            "angle_deg": 90,
+            "pitch_px": 1.68,
+            "rows": 14,
+            "segments": 110,
+            "bbox": [
+              1125.4,
+              306.7,
+              1153.9,
+              2604.7
+            ]
+          },
+          {
+            "id": "h-a90.0p1.7w1",
+            "angle_deg": 90,
+            "pitch_px": 1.68,
+            "rows": 20,
+            "segments": 122,
+            "bbox": [
+              1084.1,
+              2136,
+              1124.9,
+              2604.7
+            ]
+          },
+          {
+            "id": "h-a90.0p1.7w1",
+            "angle_deg": 90,
+            "pitch_px": 1.68,
+            "rows": 10,
+            "segments": 64,
+            "bbox": [
+              1035.6,
+              2156.9,
+              1055,
+              2690.9
+            ]
+          },
+          {
+            "id": "h-a107.0p1.7w1",
+            "angle_deg": 107.04,
+            "pitch_px": 1.71,
+            "rows": 20,
+            "segments": 92,
+            "bbox": [
+              2371.2,
+              1667.5,
+              2555.3,
+              2678.6
+            ]
+          },
+          {
+            "id": "h-a95.5p1.6w1",
+            "angle_deg": 95.74,
+            "pitch_px": 1.57,
+            "rows": 11,
+            "segments": 19,
+            "bbox": [
+              2347.2,
+              2170.1,
+              2443.7,
+              2678.6
+            ]
+          },
+          {
+            "id": "h-a98.0p1.6w1",
+            "angle_deg": 97.86,
+            "pitch_px": 1.57,
+            "rows": 13,
+            "segments": 33,
+            "bbox": [
+              2323.2,
+              1772.9,
+              2467.7,
+              2699
+            ]
+          },
+          {
+            "id": "h-a98.0p1.6w1",
+            "angle_deg": 97.75,
+            "pitch_px": 1.61,
+            "rows": 13,
+            "segments": 34,
+            "bbox": [
+              2299.2,
+              1695.8,
+              2467.7,
+              2678.6
+            ]
+          },
+          {
+            "id": "h-a99.0p1.6w1",
+            "angle_deg": 98.87,
+            "pitch_px": 1.62,
+            "rows": 13,
+            "segments": 32,
+            "bbox": [
+              2224.1,
+              1684.6,
+              2444.6,
+              3085
+            ]
+          },
+          {
+            "id": "h-a95.5p1.6w1",
+            "angle_deg": 95.71,
+            "pitch_px": 1.57,
+            "rows": 11,
+            "segments": 18,
+            "bbox": [
+              2251.2,
+              2170.1,
+              2347.7,
+              2678.6
+            ]
+          }
+        ]
+      },
+      "reference_classifier_on_existing_families": {
+        "input_note": "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",
+        "labels": {
+          "hatch": 0,
+          "repeated-building-element": 0,
+          "uncertain": 28
+        }
+      },
+      "reference_proposal_raw": {
+        "status": "error",
+        "elapsed_ms": 2,
+        "error": "segment-10256 must not be degenerate"
+      },
+      "reference_proposal_without_degenerate_segments": {
+        "status": "timeout",
+        "elapsed_ms": 5000
+      }
+    },
+    {
+      "case": "roseburg-floor-plan-a03a",
+      "source": {
+        "pdf": "bench/open-sheets/va-roseburg-b1ac-dwing-replace-finishes.pdf",
+        "page": 8,
+        "segments": 72303,
+        "degenerate_segments": 727,
+        "meta_bytes": 72303,
+        "luminance_values": 72303
+      },
+      "existing_classifier": {
+        "elapsed_ms": 83,
+        "soft_segments": 2137,
+        "families": 35,
+        "family_instances": [
+          {
+            "id": "h-a0.0p2.2w2",
+            "angle_deg": 0.03,
+            "pitch_px": 2.25,
+            "rows": 12,
+            "segments": 167,
+            "bbox": [
+              1054.7,
+              2287.2,
+              5604.1,
+              2317.4
+            ]
+          },
+          {
+            "id": "h-a0.0p1.7w1",
+            "angle_deg": 0,
+            "pitch_px": 1.69,
+            "rows": 17,
+            "segments": 259,
+            "bbox": [
+              155.9,
+              3752.5,
+              5681.2,
+              3784.3
+            ]
+          },
+          {
+            "id": "h-a0.0p1.8w1",
+            "angle_deg": 0,
+            "pitch_px": 1.78,
+            "rows": 10,
+            "segments": 148,
+            "bbox": [
+              155.9,
+              3840.8,
+              5846.5,
+              3859.2
+            ]
+          },
+          {
+            "id": "h-a0.0p2.1w1",
+            "angle_deg": 0,
+            "pitch_px": 2.05,
+            "rows": 17,
+            "segments": 184,
+            "bbox": [
+              109,
+              3880.7,
+              5893.7,
+              3918
+            ]
+          },
+          {
+            "id": "h-a0.0p2.1w1",
+            "angle_deg": 0,
+            "pitch_px": 2.09,
+            "rows": 14,
+            "segments": 116,
+            "bbox": [
+              110.9,
+              3918.8,
+              5893.7,
+              3950.8
+            ]
+          },
+          {
+            "id": "h-a0.0p2.1w1",
+            "angle_deg": 0,
+            "pitch_px": 2.08,
+            "rows": 14,
+            "segments": 397,
+            "bbox": [
+              110.9,
+              4027.6,
+              5893.7,
+              4054.7
+            ]
+          },
+          {
+            "id": "h-a0.0p1.6w1",
+            "angle_deg": 0,
+            "pitch_px": 1.63,
+            "rows": 19,
+            "segments": 216,
+            "bbox": [
+              111.6,
+              4093.2,
+              5650,
+              4128.5
+            ]
+          },
+          {
+            "id": "h-a104.0p2.6w1",
+            "angle_deg": 103.88,
+            "pitch_px": 2.59,
+            "rows": 22,
+            "segments": 65,
+            "bbox": [
+              5811.7,
+              3724.8,
+              5925.2,
+              4160.6
+            ]
+          },
+          {
+            "id": "h-a110.0p1.6w1",
+            "angle_deg": 109.95,
+            "pitch_px": 1.62,
+            "rows": 16,
+            "segments": 127,
+            "bbox": [
+              5773.7,
+              524,
+              5925.2,
+              4160.6
+            ]
+          },
+          {
+            "id": "h-a90.0p1.6w1",
+            "angle_deg": 89.83,
+            "pitch_px": 1.58,
+            "rows": 13,
+            "segments": 94,
+            "bbox": [
+              5773.7,
+              328.9,
+              5887.7,
+              4043
+            ]
+          },
+          {
+            "id": "h-a89.0p1.6w1",
+            "angle_deg": 88.96,
+            "pitch_px": 1.55,
+            "rows": 694,
+            "segments": 16024,
+            "bbox": [
+              4673.9,
+              103,
+              5818.3,
+              4256.5
+            ]
+          },
+          {
+            "id": "h-a94.5p1.6w1",
+            "angle_deg": 94.47,
+            "pitch_px": 1.58,
+            "rows": 22,
+            "segments": 329,
+            "bbox": [
+              4609.8,
+              153.7,
+              4675.4,
+              4160.6
+            ]
+          },
+          {
+            "id": "h-a90.5p1.8w1",
+            "angle_deg": 90.56,
+            "pitch_px": 1.83,
+            "rows": 11,
+            "segments": 38,
+            "bbox": [
+              4434.2,
+              983.6,
+              4607.9,
+              4256.5
+            ]
+          },
+          {
+            "id": "h-a95.5p2.0w1",
+            "angle_deg": 95.31,
+            "pitch_px": 2.02,
+            "rows": 10,
+            "segments": 44,
+            "bbox": [
+              3701.4,
+              113.4,
+              4126.1,
+              4256.5
+            ]
+          },
+          {
+            "id": "h-a93.0p1.6w1",
+            "angle_deg": 93.18,
+            "pitch_px": 1.59,
+            "rows": 13,
+            "segments": 71,
+            "bbox": [
+              3666.4,
+              1841.8,
+              3876.4,
+              4128.2
+            ]
+          },
+          {
+            "id": "h-a91.5p1.9w1",
+            "angle_deg": 91.61,
+            "pitch_px": 1.9,
+            "rows": 12,
+            "segments": 41,
+            "bbox": [
+              3610.6,
+              1841.8,
+              3876.4,
+              4128.2
+            ]
+          },
+          {
+            "id": "h-a84.5p2.8w1",
+            "angle_deg": 84.25,
+            "pitch_px": 2.83,
+            "rows": 12,
+            "segments": 57,
+            "bbox": [
+              2814.2,
+              1844,
+              2853.8,
+              4126.7
+            ]
+          },
+          {
+            "id": "h-a82.5p1.8w1",
+            "angle_deg": 82.72,
+            "pitch_px": 1.81,
+            "rows": 10,
+            "segments": 48,
+            "bbox": [
+              2148.1,
+              2478.5,
+              2184.6,
+              3958.1
+            ]
+          },
+          {
+            "id": "h-a83.0p2.4w1",
+            "angle_deg": 83.06,
+            "pitch_px": 2.39,
+            "rows": 11,
+            "segments": 43,
+            "bbox": [
+              2126,
+              2472,
+              2163.1,
+              3958.1
+            ]
+          },
+          {
+            "id": "h-a86.0p1.8w1",
+            "angle_deg": 85.76,
+            "pitch_px": 1.76,
+            "rows": 12,
+            "segments": 94,
+            "bbox": [
+              2096,
+              630.5,
+              2134.1,
+              4007.9
+            ]
+          },
+          {
+            "id": "h-a88.5p2.5w1",
+            "angle_deg": 88.53,
+            "pitch_px": 2.46,
+            "rows": 11,
+            "segments": 61,
+            "bbox": [
+              2069.9,
+              2029.4,
+              2112.4,
+              4007.9
+            ]
+          },
+          {
+            "id": "h-a90.5p1.8w1",
+            "angle_deg": 90.39,
+            "pitch_px": 1.83,
+            "rows": 31,
+            "segments": 211,
+            "bbox": [
+              2006.2,
+              838.9,
+              2074.3,
+              4059.6
+            ]
+          },
+          {
+            "id": "h-a96.5p1.9w1",
+            "angle_deg": 96.52,
+            "pitch_px": 1.91,
+            "rows": 15,
+            "segments": 70,
+            "bbox": [
+              1957.4,
+              1837.4,
+              2008,
+              4059.6
+            ]
+          },
+          {
+            "id": "h-a90.5p1.8w1",
+            "angle_deg": 90.26,
+            "pitch_px": 1.82,
+            "rows": 13,
+            "segments": 85,
+            "bbox": [
+              1911.1,
+              983.6,
+              1954.8,
+              4237.8
+            ]
+          },
+          {
+            "id": "h-a90.5p2.1w1",
+            "angle_deg": 90.64,
+            "pitch_px": 2.08,
+            "rows": 12,
+            "segments": 58,
+            "bbox": [
+              1873.9,
+              983.6,
+              1917,
+              4059.6
+            ]
+          },
+          {
+            "id": "h-a90.5p1.8w1",
+            "angle_deg": 90.73,
+            "pitch_px": 1.77,
+            "rows": 30,
+            "segments": 136,
+            "bbox": [
+              1799.8,
+              840.6,
+              1877,
+              4068.1
+            ]
+          },
+          {
+            "id": "h-a88.5p1.6w1",
+            "angle_deg": 88.57,
+            "pitch_px": 1.58,
+            "rows": 15,
+            "segments": 134,
+            "bbox": [
+              1777.8,
+              2020.9,
+              1822.1,
+              4059.6
+            ]
+          },
+          {
+            "id": "h-a86.5p1.8w1",
+            "angle_deg": 86.7,
+            "pitch_px": 1.83,
+            "rows": 26,
+            "segments": 139,
+            "bbox": [
+              1716.4,
+              587.2,
+              1780.2,
+              4068.1
+            ]
+          },
+          {
+            "id": "h-a90.5p1.9w1",
+            "angle_deg": 90.59,
+            "pitch_px": 1.94,
+            "rows": 13,
+            "segments": 81,
+            "bbox": [
+              1350.4,
+              2627.2,
+              1385.8,
+              4249
+            ]
+          },
+          {
+            "id": "h-a89.5p1.7w1",
+            "angle_deg": 89.38,
+            "pitch_px": 1.71,
+            "rows": 11,
+            "segments": 63,
+            "bbox": [
+              1239.8,
+              587.2,
+              1285.6,
+              4121
+            ]
+          },
+          {
+            "id": "h-a93.5p1.8w1",
+            "angle_deg": 93.69,
+            "pitch_px": 1.8,
+            "rows": 13,
+            "segments": 62,
+            "bbox": [
+              1221,
+              587.2,
+              1258.1,
+              4121
+            ]
+          },
+          {
+            "id": "h-a85.5p1.8w1",
+            "angle_deg": 85.61,
+            "pitch_px": 1.83,
+            "rows": 17,
+            "segments": 122,
+            "bbox": [
+              1167.8,
+              587.2,
+              1210.3,
+              4121
+            ]
+          },
+          {
+            "id": "h-a93.0p3.3w1",
+            "angle_deg": 92.97,
+            "pitch_px": 3.25,
+            "rows": 12,
+            "segments": 36,
+            "bbox": [
+              393.1,
+              1162.2,
+              445.9,
+              4193.5
+            ]
+          },
+          {
+            "id": "h-a90.0p1.9w1",
+            "angle_deg": 90,
+            "pitch_px": 1.85,
+            "rows": 10,
+            "segments": 42,
+            "bbox": [
+              173.9,
+              323.5,
+              209.9,
+              4157.5
+            ]
+          },
+          {
+            "id": "h-a87.5p1.6w1",
+            "angle_deg": 87.39,
+            "pitch_px": 1.58,
+            "rows": 45,
+            "segments": 605,
+            "bbox": [
+              106.4,
+              495,
+              173.9,
+              4166.5
+            ]
+          }
+        ]
+      },
+      "reference_classifier_on_existing_families": {
+        "input_note": "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",
+        "labels": {
+          "hatch": 0,
+          "repeated-building-element": 0,
+          "uncertain": 35
+        }
+      },
+      "reference_proposal_raw": {
+        "status": "error",
+        "elapsed_ms": 0,
+        "error": "segment-123 must not be degenerate"
+      },
+      "reference_proposal_without_degenerate_segments": {
+        "status": "timeout",
+        "elapsed_ms": 5000
+      }
+    },
+    {
+      "case": "roseburg-rcp-a04a",
+      "source": {
+        "pdf": "bench/open-sheets/va-roseburg-b1ac-dwing-replace-finishes.pdf",
+        "page": 11,
+        "segments": 62867,
+        "degenerate_segments": 604,
+        "meta_bytes": 62867,
+        "luminance_values": 62867
+      },
+      "existing_classifier": {
+        "elapsed_ms": 77,
+        "soft_segments": 1887,
+        "families": 23,
+        "family_instances": [
+          {
+            "id": "h-a0.0p2.5w1",
+            "angle_deg": 0,
+            "pitch_px": 2.52,
+            "rows": 10,
+            "segments": 231,
+            "bbox": [
+              4679.9,
+              311.9,
+              5778.8,
+              346.9
+            ]
+          },
+          {
+            "id": "h-a0.0p2.9w2",
+            "angle_deg": 0,
+            "pitch_px": 2.86,
+            "rows": 11,
+            "segments": 183,
+            "bbox": [
+              110.9,
+              2497.9,
+              5835.8,
+              2535.8
+            ]
+          },
+          {
+            "id": "h-a0.0p2.0w1",
+            "angle_deg": 0,
+            "pitch_px": 1.98,
+            "rows": 16,
+            "segments": 259,
+            "bbox": [
+              155.9,
+              3752.5,
+              5681.2,
+              3784.3
+            ]
+          },
+          {
+            "id": "h-a0.0p1.9w1",
+            "angle_deg": 0,
+            "pitch_px": 1.88,
+            "rows": 10,
+            "segments": 149,
+            "bbox": [
+              155.9,
+              3840.8,
+              5846.5,
+              3859.2
+            ]
+          },
+          {
+            "id": "h-a0.0p1.9w1",
+            "angle_deg": 0,
+            "pitch_px": 1.94,
+            "rows": 13,
+            "segments": 127,
+            "bbox": [
+              109,
+              3886.3,
+              5893.7,
+              3911.6
+            ]
+          },
+          {
+            "id": "h-a0.0p1.8w1",
+            "angle_deg": 0,
+            "pitch_px": 1.78,
+            "rows": 14,
+            "segments": 396,
+            "bbox": [
+              110.9,
+              4027.6,
+              5893.7,
+              4054.2
+            ]
+          },
+          {
+            "id": "h-a0.0p1.6w1",
+            "angle_deg": 0,
+            "pitch_px": 1.57,
+            "rows": 13,
+            "segments": 152,
+            "bbox": [
+              155.9,
+              4110.8,
+              5650,
+              4137
+            ]
+          },
+          {
+            "id": "h-a98.5p1.8w1",
+            "angle_deg": 98.61,
+            "pitch_px": 1.81,
+            "rows": 12,
+            "segments": 57,
+            "bbox": [
+              5808.1,
+              524,
+              5925.2,
+              4160.6
+            ]
+          },
+          {
+            "id": "h-a89.5p1.6w1",
+            "angle_deg": 89.49,
+            "pitch_px": 1.56,
+            "rows": 365,
+            "segments": 6481,
+            "bbox": [
+              5216.6,
+              103,
+              5925.2,
+              4256.5
+            ]
+          },
+          {
+            "id": "h-a88.5p1.6w1",
+            "angle_deg": 88.56,
+            "pitch_px": 1.55,
+            "rows": 350,
+            "segments": 7448,
+            "bbox": [
+              4663,
+              103,
+              5258.8,
+              4256.5
+            ]
+          },
+          {
+            "id": "h-a91.5p1.6w1",
+            "angle_deg": 91.65,
+            "pitch_px": 1.63,
+            "rows": 12,
+            "segments": 142,
+            "bbox": [
+              4626,
+              239.2,
+              4716.1,
+              4054.1
+            ]
+          },
+          {
+            "id": "h-a95.5p1.6w1",
+            "angle_deg": 95.5,
+            "pitch_px": 1.58,
+            "rows": 10,
+            "segments": 121,
+            "bbox": [
+              4626,
+              671.2,
+              4647.2,
+              1611.6
+            ]
+          },
+          {
+            "id": "h-a91.0p1.6w1",
+            "angle_deg": 90.94,
+            "pitch_px": 1.6,
+            "rows": 12,
+            "segments": 62,
+            "bbox": [
+              3899,
+              113.4,
+              3990.6,
+              4114.2
+            ]
+          },
+          {
+            "id": "h-a90.5p1.8w1",
+            "angle_deg": 90.41,
+            "pitch_px": 1.78,
+            "rows": 14,
+            "segments": 66,
+            "bbox": [
+              3775.9,
+              3753.5,
+              3807.2,
+              4128.2
+            ]
+          },
+          {
+            "id": "h-a88.5p1.7w1",
+            "angle_deg": 88.66,
+            "pitch_px": 1.7,
+            "rows": 14,
+            "segments": 56,
+            "bbox": [
+              3489.7,
+              1841.6,
+              3565.8,
+              4133
+            ]
+          },
+          {
+            "id": "h-a90.0p1.6w1",
+            "angle_deg": 90.14,
+            "pitch_px": 1.64,
+            "rows": 11,
+            "segments": 75,
+            "bbox": [
+              3340.3,
+              1695.1,
+              3392.9,
+              4128.2
+            ]
+          },
+          {
+            "id": "h-a89.0p1.8w1",
+            "angle_deg": 89.04,
+            "pitch_px": 1.79,
+            "rows": 12,
+            "segments": 65,
+            "bbox": [
+              2933,
+              2792.2,
+              2975.3,
+              4054
+            ]
+          },
+          {
+            "id": "h-a86.0p1.6w1",
+            "angle_deg": 85.84,
+            "pitch_px": 1.64,
+            "rows": 12,
+            "segments": 60,
+            "bbox": [
+              1778.8,
+              2500.8,
+              1822.1,
+              4059.6
+            ]
+          },
+          {
+            "id": "h-a91.0p2.0w1",
+            "angle_deg": 90.96,
+            "pitch_px": 1.97,
+            "rows": 10,
+            "segments": 46,
+            "bbox": [
+              1594.2,
+              122.9,
+              1682.5,
+              3956.8
+            ]
+          },
+          {
+            "id": "h-a89.0p1.7w1",
+            "angle_deg": 88.83,
+            "pitch_px": 1.72,
+            "rows": 10,
+            "segments": 47,
+            "bbox": [
+              1550.2,
+              3450.1,
+              1578.7,
+              3908.2
+            ]
+          },
+          {
+            "id": "h-a90.5p2.5w1",
+            "angle_deg": 90.73,
+            "pitch_px": 2.54,
+            "rows": 13,
+            "segments": 43,
+            "bbox": [
+              510.4,
+              900.7,
+              586,
+              4193.5
+            ]
+          },
+          {
+            "id": "h-a90.5p2.2w1",
+            "angle_deg": 90.4,
+            "pitch_px": 2.19,
+            "rows": 13,
+            "segments": 43,
+            "bbox": [
+              467.6,
+              279.2,
+              561.6,
+              4193.5
+            ]
+          },
+          {
+            "id": "h-a87.5p1.7w1",
+            "angle_deg": 87.69,
+            "pitch_px": 1.65,
+            "rows": 74,
+            "segments": 656,
+            "bbox": [
+              106.4,
+              323.5,
+              260.8,
+              4193.5
+            ]
+          }
+        ]
+      },
+      "reference_classifier_on_existing_families": {
+        "input_note": "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",
+        "labels": {
+          "hatch": 0,
+          "repeated-building-element": 0,
+          "uncertain": 23
+        }
+      },
+      "reference_proposal_raw": {
+        "status": "error",
+        "elapsed_ms": 0,
+        "error": "segment-4 must not be degenerate"
       },
       "reference_proposal_without_degenerate_segments": {
         "status": "timeout",

--- a/web/bench/hatchPolicyReference.mts
+++ b/web/bench/hatchPolicyReference.mts
@@ -1,0 +1,199 @@
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  classifyHatchSegs,
+  extractVectorGeometry,
+  hatchFamilies,
+} from "../src/lib/oneclick.ts";
+import {
+  classifyLineFamily,
+  proposeLineFamilies,
+} from "../src/lib/hatchPolicyReference.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
+const require = createRequire(import.meta.url);
+const pdfjs = await import(require.resolve("pdfjs-dist/legacy/build/pdf.mjs"));
+const PROPOSAL_TIMEOUT_MS = 5_000;
+
+const cases = ["sample-plan", "va-finish-plan"];
+
+async function loadCase(caseName: string) {
+  if (!cases.includes(caseName)) throw new Error(`unknown case: ${caseName}`);
+  const corpusPath = join(here, "corpus", `${caseName}.json`);
+  const corpus = JSON.parse(readFileSync(corpusPath, "utf8"));
+  const pdfPath = resolve(dirname(corpusPath), corpus.pdf);
+  const document = await pdfjs.getDocument({ url: pdfPath, useSystemFonts: true }).promise;
+  const page = await document.getPage(corpus.page || 1);
+  const viewport = page.getViewport({ scale: corpus.scale });
+  const geometry = extractVectorGeometry(
+    await page.getOperatorList(),
+    viewport.transform,
+    pdfjs.OPS,
+  );
+  await document.destroy();
+  return { corpusPath, pdfPath, geometry };
+}
+
+function referenceSegments(geometry: Awaited<ReturnType<typeof loadCase>>["geometry"]) {
+  return Array.from({ length: geometry.segs.length >> 2 }, (_, index) => ({
+    id: `segment-${index}`,
+    x1: geometry.segs[index * 4],
+    y1: geometry.segs[index * 4 + 1],
+    x2: geometry.segs[index * 4 + 2],
+    y2: geometry.segs[index * 4 + 3],
+    strokeWidth: Math.max(1, geometry.meta[index] >> 4),
+    meta: geometry.meta[index],
+    luminance: geometry.lum?.[index] ?? null,
+  }));
+}
+
+function isDegenerate(segment: ReturnType<typeof referenceSegments>[number]) {
+  return segment.x1 === segment.x2 && segment.y1 === segment.y2;
+}
+
+function optimisticGeometryOnlyDecision(family: ReturnType<typeof hatchFamilies>[number]) {
+  const width = Math.max(1, family.bbox[2] - family.bbox[0]);
+  const height = Math.max(1, family.bbox[3] - family.bbox[1]);
+  return classifyLineFamily(Object.freeze({
+    memberIds: Object.freeze(family.memberIdx.map((index) => `segment-${index}`)),
+    rowCount: family.rows,
+    rowInlierRate: 1,
+    segmentInlierRate: 1,
+    occupancy: 1,
+    medianNormalizedResidual: 0,
+    crossConnectorRatio: 0,
+    supportRailCount: 0,
+    aspectRatio: Math.max(width, height) / Math.min(width, height),
+  }));
+}
+
+async function proposalChild(caseName: string, filtered: boolean) {
+  const { geometry } = await loadCase(caseName);
+  const raw = referenceSegments(geometry);
+  const segments = filtered ? raw.filter((segment) => !isDegenerate(segment)) : raw;
+  const started = performance.now();
+  try {
+    const proposals = proposeLineFamilies(segments);
+    const labels = proposals.map((proposal) => classifyLineFamily(proposal).label);
+    process.stdout.write(JSON.stringify({
+      status: "completed",
+      elapsed_ms: Math.round(performance.now() - started),
+      proposals: proposals.length,
+      labels: Object.fromEntries(
+        ["hatch", "repeated-building-element", "uncertain"].map(
+          (label) => [label, labels.filter((value) => value === label).length],
+        ),
+      ),
+    }));
+  } catch (error) {
+    process.stdout.write(JSON.stringify({
+      status: "error",
+      elapsed_ms: Math.round(performance.now() - started),
+      error: error instanceof Error ? error.message : String(error),
+    }));
+  }
+}
+
+function runProposal(caseName: string, filtered: boolean): Promise<Record<string, unknown>> {
+  return new Promise((complete) => {
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", scriptPath, "--proposal-child", caseName, filtered ? "filtered" : "raw"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      complete({ status: "timeout", elapsed_ms: PROPOSAL_TIMEOUT_MS });
+    }, PROPOSAL_TIMEOUT_MS);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (stdout.trim()) {
+        try {
+          complete(JSON.parse(stdout));
+          return;
+        } catch {
+          // Report malformed child output below.
+        }
+      }
+      complete({
+        status: "child-error",
+        exit_code: code,
+        error: stderr.trim().split("\n").at(-1) || "proposal child returned no result",
+      });
+    });
+  });
+}
+
+async function main() {
+  const results = [];
+  for (const caseName of cases) {
+    const { corpusPath, pdfPath, geometry } = await loadCase(caseName);
+    const raw = referenceSegments(geometry);
+    const degenerate = raw.filter(isDegenerate).length;
+    const existingStarted = performance.now();
+    const existingSoft = classifyHatchSegs(geometry.segs, geometry.meta, 1);
+    const existingFamilies = hatchFamilies(geometry.segs, geometry.meta);
+    const existingElapsed = Math.round(performance.now() - existingStarted);
+    const geometryOnlyLabels = existingFamilies.map(
+      (family) => optimisticGeometryOnlyDecision(family).label,
+    );
+    const rawProposal = await runProposal(caseName, false);
+    const filteredProposal = degenerate > 0
+      ? await runProposal(caseName, true)
+      : rawProposal;
+    results.push({
+      case: caseName,
+      source: {
+        corpus: corpusPath.slice(resolve(here, "..").length + 1),
+        pdf: pdfPath.slice(resolve(here, "../..").length + 1),
+        segments: raw.length,
+        degenerate_segments: degenerate,
+        meta_bytes: geometry.meta.length,
+        luminance_values: geometry.lum?.length ?? 0,
+      },
+      existing_classifier: {
+        elapsed_ms: existingElapsed,
+        soft_segments: existingSoft.reduce((sum, value) => sum + value, 0),
+        families: existingFamilies.length,
+      },
+      reference_classifier_on_existing_families: {
+        input_note: "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",
+        labels: Object.fromEntries(
+          ["hatch", "repeated-building-element", "uncertain"].map(
+            (label) => [label, geometryOnlyLabels.filter((value) => value === label).length],
+          ),
+        ),
+      },
+      reference_proposal_raw: rawProposal,
+      reference_proposal_without_degenerate_segments: filteredProposal,
+    });
+  }
+
+  const report = {
+    generated_at: new Date().toISOString(),
+    proposal_timeout_ms: PROPOSAL_TIMEOUT_MS,
+    results,
+  };
+  const outputFlag = process.argv.indexOf("--output");
+  if (outputFlag >= 0) {
+    const outputPath = resolve(process.argv[outputFlag + 1]);
+    writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  }
+}
+
+if (process.argv[2] === "--proposal-child") {
+  await proposalChild(process.argv[3], process.argv[4] === "filtered");
+} else {
+  await main();
+}

--- a/web/bench/hatchPolicyReference.mts
+++ b/web/bench/hatchPolicyReference.mts
@@ -20,13 +20,36 @@ const require = createRequire(import.meta.url);
 const pdfjs = await import(require.resolve("pdfjs-dist/legacy/build/pdf.mjs"));
 const PROPOSAL_TIMEOUT_MS = 5_000;
 
-const cases = ["sample-plan", "va-finish-plan"];
+const cases = {
+  "sample-plan": { corpus: "sample-plan" },
+  "va-finish-plan": { corpus: "va-finish-plan" },
+  "dublin-finish-plan": {
+    pdf: "../../bench/open-sheets/va-dublin-bldg9a-finish-plan-A601.pdf",
+    page: 1,
+    scale: 2,
+  },
+  "roseburg-floor-plan-a03a": {
+    pdf: "../../bench/open-sheets/va-roseburg-b1ac-dwing-replace-finishes.pdf",
+    page: 8,
+    scale: 2,
+  },
+  "roseburg-rcp-a04a": {
+    pdf: "../../bench/open-sheets/va-roseburg-b1ac-dwing-replace-finishes.pdf",
+    page: 11,
+    scale: 2,
+  },
+} as const;
+
+type CaseName = keyof typeof cases;
 
 async function loadCase(caseName: string) {
-  if (!cases.includes(caseName)) throw new Error(`unknown case: ${caseName}`);
-  const corpusPath = join(here, "corpus", `${caseName}.json`);
-  const corpus = JSON.parse(readFileSync(corpusPath, "utf8"));
-  const pdfPath = resolve(dirname(corpusPath), corpus.pdf);
+  if (!(caseName in cases)) throw new Error(`unknown case: ${caseName}`);
+  const definition = cases[caseName as CaseName];
+  const corpusPath = "corpus" in definition
+    ? join(here, "corpus", `${definition.corpus}.json`)
+    : null;
+  const corpus = corpusPath ? JSON.parse(readFileSync(corpusPath, "utf8")) : definition;
+  const pdfPath = resolve(corpusPath ? dirname(corpusPath) : here, corpus.pdf);
   const document = await pdfjs.getDocument({ url: pdfPath, useSystemFonts: true }).promise;
   const page = await document.getPage(corpus.page || 1);
   const viewport = page.getViewport({ scale: corpus.scale });
@@ -36,7 +59,7 @@ async function loadCase(caseName: string) {
     pdfjs.OPS,
   );
   await document.destroy();
-  return { corpusPath, pdfPath, geometry };
+  return { corpusPath, pdfPath, page: corpus.page || 1, geometry };
 }
 
 function referenceSegments(geometry: Awaited<ReturnType<typeof loadCase>>["geometry"]) {
@@ -135,8 +158,8 @@ function runProposal(caseName: string, filtered: boolean): Promise<Record<string
 
 async function main() {
   const results = [];
-  for (const caseName of cases) {
-    const { corpusPath, pdfPath, geometry } = await loadCase(caseName);
+  for (const caseName of Object.keys(cases)) {
+    const { corpusPath, pdfPath, page, geometry } = await loadCase(caseName);
     const raw = referenceSegments(geometry);
     const degenerate = raw.filter(isDegenerate).length;
     const existingStarted = performance.now();
@@ -153,8 +176,9 @@ async function main() {
     results.push({
       case: caseName,
       source: {
-        corpus: corpusPath.slice(resolve(here, "..").length + 1),
+        ...(corpusPath ? { corpus: corpusPath.slice(resolve(here, "..").length + 1) } : {}),
         pdf: pdfPath.slice(resolve(here, "../..").length + 1),
+        page,
         segments: raw.length,
         degenerate_segments: degenerate,
         meta_bytes: geometry.meta.length,
@@ -164,6 +188,14 @@ async function main() {
         elapsed_ms: existingElapsed,
         soft_segments: existingSoft.reduce((sum, value) => sum + value, 0),
         families: existingFamilies.length,
+        family_instances: existingFamilies.map((family) => ({
+          id: family.id,
+          angle_deg: family.angle_deg,
+          pitch_px: family.pitch_px,
+          rows: family.rows,
+          segments: family.segments,
+          bbox: family.bbox,
+        })),
       },
       reference_classifier_on_existing_families: {
         input_note: "Optimistic perfect-lattice metrics, but only evidence emitted by the extractor.",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test test/*.test.ts",
     "bench": "node --import tsx bench/run.mts",
+    "bench:hatch-policy-reference": "node --import tsx bench/hatchPolicyReference.mts",
     "bench:callouts": "node --import tsx bench/callouts.mts",
     "bench:batch": "node --import tsx bench/batch.mts",
     "check": "npm run typecheck && npm run lint && npm test && npm run bench && npm run build",

--- a/web/src/lib/hatchPolicyReference.js
+++ b/web/src/lib/hatchPolicyReference.js
@@ -1,0 +1,668 @@
+// Experimental reference policy. Production One-Click does not import this module.
+const DEFAULTS = Object.freeze({
+  angleToleranceDeg: 2,
+  widthBucketStep: 0.25,
+  minPitch: 0.002,
+  maxPitch: 0.4,
+  maxGapMultiple: 4,
+  offsetTolerance: 0.0005,
+  relativeOffsetTolerance: 0.08,
+  minRows: 5,
+  minInlierRate: 0.75,
+  minOccupancy: 0.7,
+  maxCrossConnectorRatio: 0.15,
+});
+
+// Trusted provenance is deliberately not stored on the public proposal shape.
+// Only proposals created in this module after validating the caller's separate
+// trusted group set can carry a native role into classification. Cloning or
+// reconstructing a proposal drops that privilege and fails closed.
+const trustedNativeRoles = new WeakMap();
+
+function finite(value, name) {
+  if (!Number.isFinite(value)) throw new Error(`${name} must be finite`);
+  return value;
+}
+
+function median(values) {
+  if (values.length === 0) return null;
+  const sorted = values.slice().sort((left, right) => left - right);
+  const middle = sorted.length >> 1;
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function quantile(values, fraction) {
+  if (values.length === 0) return null;
+  const sorted = values.slice().sort((left, right) => left - right);
+  const position = (sorted.length - 1) * fraction;
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  const weight = position - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+function angleModuloPi(segment) {
+  let angle = Math.atan2(segment.y2 - segment.y1, segment.x2 - segment.x1);
+  if (angle < 0) angle += Math.PI;
+  if (angle >= Math.PI) angle -= Math.PI;
+  return angle;
+}
+
+function angleDistance(left, right) {
+  const difference = Math.abs(left - right);
+  return Math.min(difference, Math.PI - difference);
+}
+
+function segmentLength(segment) {
+  return Math.hypot(segment.x2 - segment.x1, segment.y2 - segment.y1);
+}
+
+function normalizedPhase(value, pitch) {
+  const phase = value % pitch;
+  return phase < 0 ? phase + pitch : phase;
+}
+
+function latticeResidual(value, phase, pitch) {
+  const steps = Math.round((value - phase) / pitch);
+  return Math.abs(value - (phase + steps * pitch));
+}
+
+function intersects(left, right, epsilon = 1e-9) {
+  const ax = left.x2 - left.x1;
+  const ay = left.y2 - left.y1;
+  const bx = right.x2 - right.x1;
+  const by = right.y2 - right.y1;
+  const determinant = ax * by - ay * bx;
+  if (Math.abs(determinant) <= epsilon) return false;
+  const cx = right.x1 - left.x1;
+  const cy = right.y1 - left.y1;
+  const t = (cx * by - cy * bx) / determinant;
+  const u = (cx * ay - cy * ax) / determinant;
+  return t >= -epsilon && t <= 1 + epsilon && u >= -epsilon && u <= 1 + epsilon;
+}
+
+function validateSegments(segments) {
+  if (!Array.isArray(segments)) throw new Error("segments must be an array");
+  const ids = new Set();
+  return segments.map((segment, index) => {
+    const id = segment.id ?? `s${index}`;
+    const normalized = {
+      ...segment,
+      id: String(id),
+      x1: finite(segment.x1, `${id}.x1`),
+      y1: finite(segment.y1, `${id}.y1`),
+      x2: finite(segment.x2, `${id}.x2`),
+      y2: finite(segment.y2, `${id}.y2`),
+      strokeWidth: segment.strokeWidth === undefined
+        ? 1
+        : finite(segment.strokeWidth, `${id}.strokeWidth`),
+    };
+    if (ids.has(normalized.id)) throw new Error(`duplicate segment id: ${normalized.id}`);
+    ids.add(normalized.id);
+    if (normalized.strokeWidth <= 0) throw new Error(`${id}.strokeWidth must be positive`);
+    if (segmentLength(normalized) === 0) throw new Error(`${id} must not be degenerate`);
+    return normalized;
+  });
+}
+
+function sheetCoordinateScale(segments) {
+  const xs = segments.flatMap((segment) => [segment.x1, segment.x2]);
+  const ys = segments.flatMap((segment) => [segment.y1, segment.y2]);
+  const lengths = segments.map(segmentLength);
+  const useQuantiles = xs.length >= 20;
+  const xSpan = useQuantiles
+    ? quantile(xs, 0.95) - quantile(xs, 0.05)
+    : Math.max(...xs) - Math.min(...xs);
+  const ySpan = useQuantiles
+    ? quantile(ys, 0.95) - quantile(ys, 0.05)
+    : Math.max(...ys) - Math.min(...ys);
+  return Math.max(xSpan, ySpan, 20 * (median(lengths) || 0), Number.EPSILON);
+}
+
+function candidateGroups(segments, configuration) {
+  const angleStep = configuration.angleToleranceDeg * Math.PI / 180;
+  const widths = segments.map((segment) => segment.strokeWidth);
+  const sheetMedianWidth = median(widths) || 1;
+  const groupMaps = [0, angleStep / 2].map(() => new Map());
+
+  for (const segment of segments) {
+    const angle = angleModuloPi(segment);
+    const style = segment.style ?? Math.round(
+      (segment.strokeWidth / sheetMedianWidth) / configuration.widthBucketStep,
+    );
+    for (let pass = 0; pass < groupMaps.length; pass += 1) {
+      const shifted = (angle + pass * angleStep / 2) % Math.PI;
+      const angleBucket = Math.floor(shifted / angleStep);
+      const key = `${angleBucket}|${style}`;
+      const group = groupMaps[pass].get(key) || [];
+      group.push(segment);
+      groupMaps[pass].set(key, group);
+    }
+  }
+  return groupMaps.flatMap((groups) => [...groups.values()]);
+}
+
+export function fitNormalOffsetLattice(segments, options = {}) {
+  const configuration = { ...DEFAULTS, ...options };
+  const sourceSegments = validateSegments(segments);
+  if (sourceSegments.length < configuration.minRows) return null;
+  const coordinateScale = options.coordinateScale || sheetCoordinateScale(sourceSegments);
+  if (!Number.isFinite(coordinateScale) || coordinateScale <= 0) {
+    throw new Error("coordinateScale must be positive and finite");
+  }
+  const normalizedSegments = sourceSegments.map((segment) => ({
+    ...segment,
+    x1: segment.x1 / coordinateScale,
+    y1: segment.y1 / coordinateScale,
+    x2: segment.x2 / coordinateScale,
+    y2: segment.y2 / coordinateScale,
+  }));
+
+  let cosine = 0;
+  let sine = 0;
+  for (const segment of normalizedSegments) {
+    const doubled = angleModuloPi(segment) * 2;
+    cosine += Math.cos(doubled);
+    sine += Math.sin(doubled);
+  }
+  let angle = Math.atan2(sine, cosine) / 2;
+  if (angle < 0) angle += Math.PI;
+  const tangent = [Math.cos(angle), Math.sin(angle)];
+  const normal = [-tangent[1], tangent[0]];
+  const projected = normalizedSegments.map((segment) => {
+    const midpointX = (segment.x1 + segment.x2) / 2;
+    const midpointY = (segment.y1 + segment.y2) / 2;
+    return {
+      segment,
+      rho: midpointX * normal[0] + midpointY * normal[1],
+      length: segmentLength(segment),
+    };
+  }).sort((left, right) => left.rho - right.rho);
+  const rowMergeTolerance = configuration.offsetTolerance / 2;
+  const offsetRows = [];
+  for (const item of projected) {
+    const current = offsetRows[offsetRows.length - 1];
+    if (current && Math.abs(item.rho - current.anchor) <= rowMergeTolerance) {
+      current.items.push(item);
+      current.rho = current.items.reduce((sum, row) => sum + row.rho, 0) / current.items.length;
+    } else {
+      offsetRows.push({ anchor: item.rho, rho: item.rho, items: [item] });
+    }
+  }
+  const uniqueOffsets = offsetRows.map((row) => row.rho);
+  if (offsetRows.length < configuration.minRows) return null;
+
+  const pitchCandidates = new Set();
+  for (let left = 0; left < uniqueOffsets.length; left += 1) {
+    for (let right = left + 1; right < uniqueOffsets.length; right += 1) {
+      const difference = uniqueOffsets[right] - uniqueOffsets[left];
+      for (let multiple = 1; multiple <= configuration.maxGapMultiple; multiple += 1) {
+        const pitch = difference / multiple;
+        if (pitch >= configuration.minPitch && pitch <= configuration.maxPitch) {
+          pitchCandidates.add(+pitch.toFixed(6));
+        }
+      }
+    }
+  }
+
+  let best = null;
+  const segmentLengthCap = 2 * (median(projected.map((row) => row.length)) || 1);
+  const cappedTotalLength = projected.reduce(
+    (sum, row) => sum + Math.min(row.length, segmentLengthCap),
+    0,
+  );
+  for (const pitch of pitchCandidates) {
+    const tolerance = Math.max(
+      configuration.offsetTolerance,
+      pitch * configuration.relativeOffsetTolerance,
+    );
+    for (const source of uniqueOffsets) {
+      const phase = normalizedPhase(source, pitch);
+      const inlierRows = offsetRows.filter(
+        (row) => latticeResidual(row.rho, phase, pitch) <= tolerance,
+      );
+      const rowNumbers = inlierRows.map((row) => Math.round((row.rho - phase) / pitch));
+      const distinctRows = [...new Set(rowNumbers)].sort((left, right) => left - right);
+      if (distinctRows.length < configuration.minRows) continue;
+      const rowSpan = distinctRows[distinctRows.length - 1] - distinctRows[0] + 1;
+      const occupancy = distinctRows.length / rowSpan;
+      const rowInlierRate = inlierRows.length / offsetRows.length;
+      const inlierItems = inlierRows.flatMap((row) => row.items);
+      const cappedInlierLength = inlierItems.reduce(
+        (sum, row) => sum + Math.min(row.length, segmentLengthCap),
+        0,
+      );
+      const segmentInlierRate = cappedTotalLength > 0 ? cappedInlierLength / cappedTotalLength : 0;
+      const normalizedResiduals = inlierRows.map(
+        (row) => latticeResidual(row.rho, phase, pitch) / pitch,
+      );
+      const medianNormalizedResidual = median(normalizedResiduals) || 0;
+      const residualScore = Math.max(
+        0,
+        1 - medianNormalizedResidual / configuration.relativeOffsetTolerance,
+      );
+      const score = rowInlierRate * occupancy * occupancy * residualScore
+        * (1 - Math.exp(-distinctRows.length / 4));
+      const candidate = {
+        pitch,
+        phase,
+        tolerance,
+        inlierRows,
+        inlierItems,
+        distinctRows,
+        occupancy,
+        rowInlierRate,
+        segmentInlierRate,
+        medianNormalizedResidual,
+        score,
+      };
+      if (
+        !best || candidate.score > best.score + 1e-12 ||
+        (Math.abs(candidate.score - best.score) <= 1e-12 && candidate.pitch > best.pitch)
+      ) best = candidate;
+    }
+  }
+  if (
+    !best || best.rowInlierRate < configuration.minInlierRate ||
+    best.segmentInlierRate < configuration.minInlierRate ||
+    best.occupancy < configuration.minOccupancy
+  ) return null;
+
+  const inlierSegments = best.inlierItems.map((row) => row.segment);
+  const normalValues = best.inlierRows.map((row) => row.rho);
+  const tangentValues = inlierSegments.flatMap((segment) => [
+    segment.x1 * tangent[0] + segment.y1 * tangent[1],
+    segment.x2 * tangent[0] + segment.y2 * tangent[1],
+  ]);
+  const normalSpan = (Math.max(...normalValues) - Math.min(...normalValues)) * coordinateScale;
+  const tangentSpan = (Math.max(...tangentValues) - Math.min(...tangentValues)) * coordinateScale;
+  const shorterSpan = Math.max(1e-9, Math.min(normalSpan, tangentSpan));
+
+  return {
+    angleDeg: angle * 180 / Math.PI,
+    coordinateScale,
+    pitch: best.pitch * coordinateScale,
+    pitchNormalized: best.pitch,
+    phase: best.phase * coordinateScale,
+    tolerance: best.tolerance * coordinateScale,
+    rowCount: best.distinctRows.length,
+    rowInlierRate: best.rowInlierRate,
+    segmentInlierRate: best.segmentInlierRate,
+    inlierRate: best.rowInlierRate,
+    occupancy: best.occupancy,
+    medianNormalizedResidual: best.medianNormalizedResidual,
+    score: best.score,
+    normalSpan,
+    tangentSpan,
+    aspectRatio: Math.max(normalSpan, tangentSpan) / shorterSpan,
+    memberIds: inlierSegments.map((segment) => segment.id),
+  };
+}
+
+function connectorEvidence(family, segments) {
+  const members = new Set(family.memberIds);
+  const memberSegments = segments.filter((segment) => members.has(segment.id));
+  const touched = new Set();
+  let supportRailCount = 0;
+  const familyAngle = family.angleDeg * Math.PI / 180;
+  for (const other of segments) {
+    if (members.has(other.id) || other.contextRole === "clip-boundary") continue;
+    if (angleDistance(angleModuloPi(other), familyAngle) < 15 * Math.PI / 180) continue;
+    let connectorTouches = 0;
+    for (const member of memberSegments) {
+      if (intersects(member, other)) {
+        touched.add(member.id);
+        connectorTouches += 1;
+      }
+    }
+    if (memberSegments.length && connectorTouches / memberSegments.length >= 0.7) {
+      supportRailCount += 1;
+    }
+  }
+  return {
+    crossConnectorRatio: memberSegments.length ? touched.size / memberSegments.length : 0,
+    supportRailCount,
+  };
+}
+
+function nativeRoleFor(family, segments, trustedProvenanceGroups) {
+  const members = new Set(family.memberIds);
+  const memberSegments = segments.filter((segment) => members.has(segment.id));
+  if (!memberSegments.length || !(trustedProvenanceGroups instanceof Set)) return null;
+  const native = memberSegments.map((segment) => segment.native);
+  if (native.some((value) => !value || !trustedProvenanceGroups.has(value.groupId))) return null;
+  const groupIds = new Set(native.map((value) => value.groupId));
+  const roles = new Set(native.map((value) => value.role));
+  const kinds = new Set(native.map((value) => value.kind));
+  if (groupIds.size !== 1 || kinds.size !== 1 || roles.size !== 1) return "mixed";
+  const role = [...roles][0];
+  if (role === "pattern-stroke") return "hatch";
+  if (role === "boundary" || role === "clip-path") return "boundary";
+  return null;
+}
+
+function sameMembers(left, right) {
+  const leftSet = new Set(left.memberIds);
+  let common = 0;
+  for (const id of right.memberIds) if (leftSet.has(id)) common += 1;
+  return common / Math.max(left.memberIds.length, right.memberIds.length) >= 0.8;
+}
+
+export function proposeLineFamilies(inputSegments, options = {}) {
+  const configuration = { ...DEFAULTS, ...options };
+  const segments = validateSegments(inputSegments);
+  const coordinateScale = options.coordinateScale || sheetCoordinateScale(segments);
+  const proposals = [];
+  for (const group of candidateGroups(segments, configuration)) {
+    const fit = fitNormalOffsetLattice(group, { ...configuration, coordinateScale });
+    if (!fit) continue;
+    const connectors = connectorEvidence(fit, segments);
+    const proposal = Object.freeze({
+      ...fit,
+      memberIds: Object.freeze([...fit.memberIds]),
+      ...connectors,
+    });
+    const nativeRole = nativeRoleFor(fit, segments, options.trustedProvenanceGroups);
+    if (nativeRole) trustedNativeRoles.set(proposal, nativeRole);
+    const duplicate = proposals.findIndex((existing) => sameMembers(existing, proposal));
+    if (duplicate < 0) proposals.push(proposal);
+    else if (proposal.score > proposals[duplicate].score) proposals[duplicate] = proposal;
+  }
+  return proposals.sort((left, right) => right.score - left.score);
+}
+
+export function analyzeLineFamilies(inputSegments, options = {}) {
+  const segments = validateSegments(inputSegments);
+  const proposals = proposeLineFamilies(segments, options);
+  const assigned = new Set(proposals.flatMap((proposal) => proposal.memberIds));
+  return {
+    proposals,
+    unassignedIds: segments.filter((segment) => !assigned.has(segment.id)).map((segment) => segment.id),
+  };
+}
+
+export function classifyLineFamily(family, context = {}, options = {}) {
+  if (!family) throw new Error("family is required");
+  const configuration = { ...DEFAULTS, ...options };
+  const reasons = [];
+
+  const nativeRole = trustedNativeRoles.get(family);
+  if (nativeRole === "hatch") {
+    return { label: "hatch", confidence: 1, testable: true, reasons: ["native-hatch-provenance"] };
+  }
+  if (nativeRole === "boundary") {
+    return { label: "repeated-building-element", confidence: 1, testable: false, reasons: ["native-boundary-provenance"] };
+  }
+  const repeatedBuildingKinds = new Set(["stairs", "shelving", "louvre", "partition-bank"]);
+  if (context.protectedKind && repeatedBuildingKinds.has(context.protectedKind)) {
+    return {
+      label: "repeated-building-element",
+      confidence: 0.95,
+      testable: false,
+      reasons: [`protected-context:${context.protectedKind}`],
+    };
+  }
+  if (context.protectedKind) {
+    return {
+      label: "uncertain",
+      confidence: 0.9,
+      testable: false,
+      reasons: [`protected-context:${context.protectedKind}`],
+    };
+  }
+  if (
+    family.supportRailCount >= 2 && family.supportRailCount <= 3 &&
+    family.crossConnectorRatio >= 0.7
+  ) {
+    return {
+      label: "repeated-building-element",
+      confidence: 0.85,
+      testable: false,
+      reasons: ["paired-support-rails", "cross-connected-family"],
+    };
+  }
+
+  const strongLattice = family.inlierRate >= configuration.minInlierRate
+    && family.occupancy >= configuration.minOccupancy
+    && family.rowCount >= configuration.minRows;
+  if (strongLattice) reasons.push("strong-normal-offset-lattice");
+  const trustedEvidenceIds = options.trustedEvidenceIds instanceof Set
+    ? options.trustedEvidenceIds
+    : new Set();
+  const hasSharedClip = context.sharedClipEvidenceId
+    && trustedEvidenceIds.has(context.sharedClipEvidenceId);
+  const hasRegionFill = context.regionFillEvidenceId
+    && trustedEvidenceIds.has(context.regionFillEvidenceId);
+  if (hasSharedClip) reasons.push("trusted-shared-clip-evidence");
+  if (hasRegionFill) reasons.push("trusted-region-fill-evidence");
+  if (family.crossConnectorRatio > configuration.maxCrossConnectorRatio) {
+    reasons.push("cross-connected-family");
+  }
+
+  if (family.supportRailCount >= 4) {
+    return {
+      label: "uncertain",
+      confidence: 0.8,
+      testable: false,
+      reasons: [...reasons, "orthogonal-grid-ambiguity"],
+    };
+  }
+
+  if (
+    strongLattice && (hasSharedClip || hasRegionFill) &&
+    family.crossConnectorRatio <= configuration.maxCrossConnectorRatio
+  ) {
+    return { label: "hatch", confidence: 0.9, testable: true, reasons };
+  }
+  return {
+    label: "uncertain",
+    confidence: strongLattice ? 0.65 : 0.35,
+    testable: false,
+    reasons: reasons.length ? reasons : ["insufficient-family-evidence"],
+  };
+}
+
+const GATE_DEFAULTS = Object.freeze({
+  minDecisionConfidence: 0.6,
+  maxAreaGrowth: 3,
+  minWallEdgeFraction: 0.6,
+  maxWallEdgeDrop: 0.05,
+  maxProtectedOverlap: 0,
+  maxErrorIncrease: 0,
+});
+
+function validateGatePolicy(policy) {
+  for (const name of ["minDecisionConfidence", "minWallEdgeFraction", "maxWallEdgeDrop"]) {
+    if (!Number.isFinite(policy[name]) || policy[name] < 0 || policy[name] > 1) {
+      throw new Error(`${name} must be between 0 and 1`);
+    }
+  }
+  if (!Number.isFinite(policy.maxAreaGrowth) || policy.maxAreaGrowth < 1) {
+    throw new Error("maxAreaGrowth must be at least 1");
+  }
+  for (const name of ["maxProtectedOverlap", "maxErrorIncrease"]) {
+    if (!Number.isFinite(policy[name]) || policy[name] < 0) {
+      throw new Error(`${name} must be non-negative`);
+    }
+  }
+}
+
+function missingRunMetrics(run, prefix) {
+  const failures = [];
+  for (const name of [
+    "area",
+    "wallEdgeFraction",
+    "coverage",
+    "perimeterOnPreservedWall",
+    "invalidPolygonCount",
+    "protectedOverlap",
+    "errorCount",
+  ]) {
+    if (!Number.isFinite(run[name])) failures.push(`${prefix}-missing-${name}`);
+  }
+  for (const name of ["assignedSeedIds", "trappedSeedIds"]) {
+    if (!Array.isArray(run[name])) failures.push(`${prefix}-missing-${name}`);
+  }
+  if (!run.roomBySeed || typeof run.roomBySeed !== "object" || Array.isArray(run.roomBySeed)) {
+    failures.push(`${prefix}-missing-roomBySeed`);
+  }
+  if (typeof run.exteriorLeak !== "boolean") failures.push(`${prefix}-missing-exteriorLeak`);
+  return failures;
+}
+
+function invalidRunMetrics(run, prefix) {
+  const failures = [];
+  if (typeof run.status !== "string" || run.status.length === 0) {
+    failures.push(`${prefix}-invalid-status`);
+  }
+  if (run.trapped !== undefined && typeof run.trapped !== "boolean") {
+    failures.push(`${prefix}-invalid-trapped`);
+  }
+  for (const name of ["wallEdgeFraction", "coverage", "perimeterOnPreservedWall"]) {
+    if (Number.isFinite(run[name]) && (run[name] < 0 || run[name] > 1)) {
+      failures.push(`${prefix}-invalid-${name}`);
+    }
+  }
+  for (const name of ["area", "invalidPolygonCount", "protectedOverlap", "errorCount"]) {
+    if (Number.isFinite(run[name]) && run[name] < 0) failures.push(`${prefix}-invalid-${name}`);
+  }
+  for (const name of ["invalidPolygonCount", "errorCount"]) {
+    if (Number.isFinite(run[name]) && !Number.isInteger(run[name])) {
+      failures.push(`${prefix}-invalid-${name}`);
+    }
+  }
+  if (Array.isArray(run.assignedSeedIds) && Array.isArray(run.trappedSeedIds)) {
+    const assigned = new Set(run.assignedSeedIds);
+    const trapped = new Set(run.trappedSeedIds);
+    if (assigned.size !== run.assignedSeedIds.length) failures.push(`${prefix}-duplicate-assigned-seed`);
+    if (trapped.size !== run.trappedSeedIds.length) failures.push(`${prefix}-duplicate-trapped-seed`);
+    if ([...assigned].some((seedId) => trapped.has(seedId))) failures.push(`${prefix}-seed-both-assigned-and-trapped`);
+    if (run.roomBySeed && typeof run.roomBySeed === "object") {
+      for (const seedId of assigned) {
+        if (run.roomBySeed[seedId] == null) failures.push(`${prefix}-assigned-seed-without-room`);
+      }
+    }
+  }
+  return failures;
+}
+
+function topologyRegressions(strict, retry) {
+  const failures = [];
+  const retryAssigned = new Set(retry.assignedSeedIds);
+  const strictTrapped = new Set(strict.trappedSeedIds);
+  const retryTrapped = new Set(retry.trappedSeedIds);
+  for (const seedId of strict.assignedSeedIds) {
+    if (!retryAssigned.has(seedId)) failures.push("assigned-seed-lost");
+  }
+  for (const seedId of strictTrapped) {
+    if (
+      !retryTrapped.has(seedId) &&
+      (!retryAssigned.has(seedId) || retry.roomBySeed[seedId] == null)
+    ) failures.push("trapped-seed-not-recovered");
+  }
+  for (const seedId of retryTrapped) {
+    if (!strictTrapped.has(seedId)) failures.push("new-trapped-seed");
+  }
+  const strictToRetry = new Map();
+  const retryToStrict = new Map();
+  for (const seedId of strict.assignedSeedIds) {
+    const strictRoom = strict.roomBySeed[seedId];
+    const retryRoom = retry.roomBySeed[seedId];
+    if (strictRoom == null || retryRoom == null) {
+      failures.push("missing-room-mapping");
+      continue;
+    }
+    const retryRooms = strictToRetry.get(strictRoom) || new Set();
+    retryRooms.add(retryRoom);
+    strictToRetry.set(strictRoom, retryRooms);
+    const strictRooms = retryToStrict.get(retryRoom) || new Set();
+    strictRooms.add(strictRoom);
+    retryToStrict.set(retryRoom, strictRooms);
+  }
+  // A formerly trapped seed represents a room the strict result could not
+  // recover. It may become assigned, but it may not share the retry room of
+  // an already assigned strict room or another independently trapped seed.
+  for (const seedId of strictTrapped) {
+    if (!retryAssigned.has(seedId)) continue;
+    const retryRoom = retry.roomBySeed[seedId];
+    if (retryRoom == null) continue;
+    const owners = retryToStrict.get(retryRoom) || new Set();
+    owners.add(`trapped:${seedId}`);
+    retryToStrict.set(retryRoom, owners);
+  }
+  if ([...strictToRetry.values()].some((rooms) => rooms.size !== 1)) failures.push("room-split");
+  if ([...retryToStrict.values()].some((rooms) => rooms.size > 1)) failures.push("room-merge");
+  return [...new Set(failures)];
+}
+
+export function gateTransparentRetry(input, options = {}) {
+  const { decision, strict, retry = null } = input || {};
+  if (!decision || !strict) throw new Error("decision and strict result are required");
+  const policy = { ...GATE_DEFAULTS, ...options };
+  validateGatePolicy(policy);
+  const eligibleLabel = decision.label === "hatch" && decision.testable;
+  const validConfidence = Number.isFinite(decision.confidence)
+    && decision.confidence >= 0 && decision.confidence <= 1;
+  if (!eligibleLabel || !validConfidence || decision.confidence < policy.minDecisionConfidence) {
+    return { action: "keep-strict", selected: strict, strict, retry, reasons: ["family-not-eligible"] };
+  }
+  if (!strict.trapped && !["tiny", "fragmented", "trapped"].includes(strict.status)) {
+    return { action: "keep-strict", selected: strict, strict, retry, reasons: ["strict-result-not-trapped"] };
+  }
+  if (!retry) {
+    return { action: "run-transparent-retry", selected: strict, strict, retry, reasons: ["eligible-trapped-result"] };
+  }
+
+  const failures = [
+    ...missingRunMetrics(strict, "strict"),
+    ...missingRunMetrics(retry, "retry"),
+    ...invalidRunMetrics(strict, "strict"),
+    ...invalidRunMetrics(retry, "retry"),
+  ];
+  if (failures.length) {
+    return { action: "keep-strict", selected: strict, strict, retry, reasons: failures };
+  }
+  if (retry.status !== "ok" || retry.exteriorLeak) failures.push("retry-not-bounded");
+  if (retry.invalidPolygonCount > 0) failures.push("invalid-retry-polygons");
+  const strictArea = strict.area;
+  const retryArea = retry.area;
+  const growth = strictArea > 0 ? retryArea / strictArea : Infinity;
+  if (retryArea <= 0 || retryArea < strictArea) failures.push("area-regression");
+  if (growth > policy.maxAreaGrowth) failures.push("area-growth-budget");
+  const strictWall = strict.wallEdgeFraction;
+  const retryWall = retry.wallEdgeFraction;
+  if (retryWall < policy.minWallEdgeFraction) failures.push("wall-edge-floor");
+  if (retryWall < strictWall - policy.maxWallEdgeDrop) failures.push("wall-edge-regression");
+  if (retry.perimeterOnPreservedWall < strict.perimeterOnPreservedWall - policy.maxWallEdgeDrop) {
+    failures.push("preserved-wall-regression");
+  }
+  if (retry.coverage < strict.coverage) failures.push("coverage-regression");
+  if (retry.protectedOverlap > policy.maxProtectedOverlap) {
+    failures.push("protected-class-overlap");
+  }
+  const strictErrors = strict.errorCount;
+  const retryErrors = retry.errorCount;
+  if (retryErrors > strictErrors + policy.maxErrorIncrease) failures.push("downstream-error-regression");
+  if (retry.trappedSeedIds.length >= strict.trappedSeedIds.length) failures.push("trapped-seeds-not-improved");
+  failures.push(...topologyRegressions(strict, retry));
+
+  if (failures.length) {
+    return {
+      action: "keep-strict",
+      selected: strict,
+      strict,
+      retry,
+      reasons: [...new Set(failures)],
+      areaGrowth: growth,
+    };
+  }
+  return {
+    action: "accept-transparent-retry",
+    selected: retry,
+    strict,
+    retry,
+    reasons: ["retry-within-budgets"],
+    areaGrowth: growth,
+  };
+}

--- a/web/test/hatchPolicyReference.test.ts
+++ b/web/test/hatchPolicyReference.test.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { familyCases, gateCases } from "./hatchPolicyReferenceCorpus.js";
+import {
+  analyzeLineFamilies,
+  classifyLineFamily,
+  fitNormalOffsetLattice,
+  gateTransparentRetry,
+  proposeLineFamilies,
+} from "../src/lib/hatchPolicyReference.js";
+
+test("normal-offset fit recovers pitch and phase with a missing row", () => {
+  const segments = [10, 20, 30, 50, 60, 70].map((x, index) => ({
+    id: `s${index}`,
+    x1: x,
+    y1: 0,
+    x2: x,
+    y2: 100,
+    strokeWidth: 1,
+  }));
+  const fit = fitNormalOffsetLattice(segments);
+  assert.ok(fit);
+  assert.ok(Math.abs(fit.pitch - 10) < 1e-6);
+  assert.equal(fit.rowCount, 6);
+  assert.equal(fit.occupancy, 6 / 7);
+  assert.equal(fit.inlierRate, 1);
+});
+
+test("lattice evidence survives translation, scale, order, endpoint reversal, and row splitting", () => {
+  const base = [10, 20, 30, 40, 50, 60, 70].map((x, index) => ({
+    id: `s${index}`, x1: x, y1: 0, x2: x, y2: 100, strokeWidth: 1,
+  }));
+  const variants = [
+    base.map((segment) => ({
+      ...segment,
+      id: `translated-${segment.id}`,
+      x1: segment.x1 + 10000,
+      x2: segment.x2 + 10000,
+      y1: segment.y1 - 5000,
+      y2: segment.y2 - 5000,
+    })),
+    base.map((segment) => ({
+      ...segment,
+      id: `small-${segment.id}`,
+      x1: segment.x1 * 0.1,
+      x2: segment.x2 * 0.1,
+      y1: segment.y1 * 0.1,
+      y2: segment.y2 * 0.1,
+    })),
+    base.map((segment) => ({
+      ...segment,
+      id: `large-${segment.id}`,
+      x1: segment.x1 * 1000,
+      x2: segment.x2 * 1000,
+      y1: segment.y1 * 1000,
+      y2: segment.y2 * 1000,
+    })),
+    base.slice().reverse().map((segment) => ({
+      ...segment,
+      id: `reversed-${segment.id}`,
+      x1: segment.x2,
+      y1: segment.y2,
+      x2: segment.x1,
+      y2: segment.y1,
+    })),
+    base.flatMap((segment) => Array.from({ length: 5 }, (_, part) => ({
+      ...segment,
+      id: `split-${segment.id}-${part}`,
+      y1: part * 20,
+      y2: (part + 1) * 20,
+    }))),
+  ];
+  const expectedScales = [1, 0.1, 1000, 1, 1];
+  variants.forEach((segments, index) => {
+    const fit = fitNormalOffsetLattice(segments);
+    assert.ok(fit, `variant ${index}`);
+    assert.ok(Math.abs(fit.pitch - 10 * expectedScales[index]) < 1e-6, `variant ${index}`);
+    assert.equal(fit.rowCount, 7, `variant ${index}`);
+    assert.equal(fit.rowInlierRate, 1, `variant ${index}`);
+  });
+});
+
+test("synthetic family cases produce the declared conservative labels", () => {
+  for (const fixture of familyCases) {
+    const proposals = proposeLineFamilies(fixture.segments, fixture.options);
+    if (fixture.expectedLabel === null) {
+      assert.equal(proposals.length, 0, fixture.name);
+      continue;
+    }
+    assert.ok(proposals.length > 0, `${fixture.name}: expected a family proposal`);
+    const decisions = proposals.map(
+      (family) => classifyLineFamily(family, fixture.context, fixture.options),
+    );
+    assert.ok(
+      decisions.every((decision) => decision.label === fixture.expectedLabel),
+      `${fixture.name}: got ${decisions.map((decision) => decision.label).join(", ")}`,
+    );
+  }
+});
+
+test("the same periodic rows change label when native provenance is present", () => {
+  const plain = {
+    segments: [10, 20, 30, 40, 50, 60, 70].map((x, index) => ({
+      id: `plain-${index}`, x1: x, y1: 0, x2: x, y2: 100, strokeWidth: 1,
+    })),
+    context: {},
+  };
+  const native = familyCases.find((fixture) => fixture.name === "native-hatch");
+  assert.ok(native);
+  const plainDecision = classifyLineFamily(proposeLineFamilies(plain.segments)[0], plain.context);
+  const nativeDecision = classifyLineFamily(
+    proposeLineFamilies(native.segments, native.options)[0],
+    native.context,
+    native.options,
+  );
+  assert.equal(plainDecision.label, "uncertain");
+  assert.equal(plainDecision.testable, false);
+  assert.equal(nativeDecision.label, "hatch");
+  assert.deepEqual(nativeDecision.reasons, ["native-hatch-provenance"]);
+});
+
+test("cross-connected grids are not silently suppressed", () => {
+  const fixture = familyCases.find((row) => row.name === "ceiling-grid-without-provenance");
+  assert.ok(fixture);
+  const decisions = proposeLineFamilies(fixture.segments)
+    .map((family) => classifyLineFamily(family, fixture.context));
+  assert.ok(decisions.length >= 2);
+  assert.ok(decisions.every((decision) => decision.label === "uncertain"));
+  assert.ok(decisions.every((decision) => decision.testable === false));
+});
+
+test("analysis reports every segment not assigned to a fitted family", () => {
+  const fixture = familyCases.find((row) => row.name === "stair-treads");
+  assert.ok(fixture);
+  const analysis = analyzeLineFamilies(fixture.segments, fixture.options);
+  const assigned = new Set(analysis.proposals.flatMap((proposal) => proposal.memberIds));
+  const unassigned = new Set(analysis.unassignedIds);
+  assert.equal(assigned.size + unassigned.size, fixture.segments.length);
+  for (const segment of fixture.segments) {
+    assert.notEqual(assigned.has(segment.id), unassigned.has(segment.id));
+  }
+});
+
+test("retry gate keeps strict output unless every declared budget passes", () => {
+  for (const fixture of gateCases) {
+    const outcome = gateTransparentRetry(fixture);
+    assert.equal(outcome.action, fixture.expectedAction, fixture.name);
+    assert.equal(outcome.strict, fixture.strict, fixture.name);
+    assert.equal(outcome.retry, fixture.retry, fixture.name);
+    assert.equal(
+      outcome.selected,
+      fixture.expectedAction === "accept-transparent-retry" ? fixture.retry : fixture.strict,
+      fixture.name,
+    );
+  }
+});
+
+test("an uncertain family cannot trigger transparency", () => {
+  const strict = gateCases[0].strict;
+  const outcome = gateTransparentRetry({
+    decision: { label: "uncertain", confidence: 0.9, testable: true },
+    strict,
+  });
+  assert.equal(outcome.action, "keep-strict");
+  assert.equal(outcome.selected, strict);
+});
+
+test("retry gate rejects missing topology metrics and room merges", () => {
+  const fixture = gateCases[0];
+  const missing = gateTransparentRetry({
+    decision: fixture.decision,
+    strict: fixture.strict,
+    retry: { status: "ok" },
+  });
+  assert.equal(missing.action, "keep-strict");
+  assert.ok(missing.reasons.some((reason) => reason.startsWith("retry-missing-")));
+
+  const mergeStrict = {
+    ...fixture.strict,
+    assignedSeedIds: ["room-a", "room-c"],
+    roomBySeed: { "room-a": "strict-a", "room-c": "strict-c" },
+  };
+  const mergeRetry = {
+    ...fixture.retry,
+    assignedSeedIds: ["room-a", "room-c", "room-b"],
+    roomBySeed: { "room-a": "retry-merged", "room-c": "retry-merged", "room-b": "retry-b" },
+  };
+  const merged = gateTransparentRetry({ decision: fixture.decision, strict: mergeStrict, retry: mergeRetry });
+  assert.equal(merged.action, "keep-strict");
+  assert.ok(merged.reasons.includes("room-merge"));
+
+  const lostRecovery = {
+    ...fixture.retry,
+    assignedSeedIds: ["room-a"],
+    trappedSeedIds: [],
+    roomBySeed: { "room-a": "retry-a" },
+  };
+  const lost = gateTransparentRetry({
+    decision: fixture.decision,
+    strict: fixture.strict,
+    retry: lostRecovery,
+  });
+  assert.equal(lost.action, "keep-strict");
+  assert.ok(lost.reasons.includes("trapped-seed-not-recovered"));
+});
+
+test("provenance must belong to a separately trusted extractor group", () => {
+  const fixture = familyCases.find((row) => row.name === "native-hatch");
+  assert.ok(fixture);
+  const proposal = proposeLineFamilies(fixture.segments)[0];
+  assert.equal(classifyLineFamily(proposal).label, "uncertain");
+});
+
+test("a caller-authored native role cannot forge trusted provenance", () => {
+  const proposal = proposeLineFamilies(familyCases[0].segments)[0];
+  assert.ok(proposal);
+  assert.equal(classifyLineFamily({ ...proposal, nativeRole: "hatch" }).label, "uncertain");
+});
+
+test("trusted proposals cannot be mutated after provenance validation", () => {
+  const fixture = familyCases.find((row) => row.name === "native-hatch");
+  assert.ok(fixture);
+  const proposal = proposeLineFamilies(fixture.segments, fixture.options)[0];
+  assert.ok(proposal);
+  assert.equal(Object.isFrozen(proposal), true);
+  assert.equal(Object.isFrozen(proposal.memberIds), true);
+  assert.equal(Reflect.set(proposal, "memberIds", ["forged-wall"]), false);
+  assert.equal(Reflect.set(proposal.memberIds, "0", "forged-wall"), false);
+  assert.equal(Reflect.set(proposal, "score", 0), false);
+  assert.equal(classifyLineFamily(proposal).label, "hatch");
+});
+
+test("retry gate rejects a recovered seed merged into an existing room", () => {
+  const fixture = gateCases[0];
+  const retry = {
+    ...fixture.retry,
+    roomBySeed: { "room-a": "retry-a", "room-b": "retry-a" },
+  };
+  const outcome = gateTransparentRetry({ decision: fixture.decision, strict: fixture.strict, retry });
+  assert.equal(outcome.action, "keep-strict");
+  assert.ok(outcome.reasons.includes("room-merge"));
+});
+
+test("retry gate rejects zero-area and shrinking retries", () => {
+  const fixture = gateCases[0];
+  for (const area of [0, fixture.strict.area - 1]) {
+    const retry = { ...fixture.retry, area };
+    const outcome = gateTransparentRetry({ decision: fixture.decision, strict: fixture.strict, retry });
+    assert.equal(outcome.action, "keep-strict");
+    assert.ok(outcome.reasons.includes("area-regression"));
+  }
+});
+
+test("retry gate rejects out-of-range and internally inconsistent metrics", () => {
+  const fixture = gateCases[0];
+  const invalidRuns = [
+    { ...fixture.retry, area: -1 },
+    { ...fixture.retry, coverage: 1.1 },
+    { ...fixture.retry, wallEdgeFraction: -0.1 },
+    { ...fixture.retry, invalidPolygonCount: -1 },
+    { ...fixture.retry, invalidPolygonCount: 0.5 },
+    { ...fixture.retry, errorCount: 0.5 },
+    { ...fixture.retry, status: "" },
+    { ...fixture.retry, trapped: "no" },
+    { ...fixture.retry, assignedSeedIds: ["room-a", "room-a", "room-b"] },
+    { ...fixture.retry, assignedSeedIds: ["room-a", "room-b"], trappedSeedIds: ["room-b"] },
+  ];
+  for (const retry of invalidRuns) {
+    const outcome = gateTransparentRetry({ decision: fixture.decision, strict: fixture.strict, retry });
+    assert.equal(outcome.action, "keep-strict");
+    assert.ok(outcome.reasons.some((reason) => reason.startsWith("retry-")));
+  }
+});
+
+test("invalid inputs fail closed", () => {
+  assert.throws(
+    () => fitNormalOffsetLattice([{ id: "bad", x1: 0, y1: 0, x2: NaN, y2: 1 }]),
+    /must be finite/,
+  );
+  assert.throws(() => classifyLineFamily(null), /family is required/);
+  assert.throws(() => gateTransparentRetry({}), /required/);
+  assert.throws(
+    () => proposeLineFamilies([
+      { id: "same", x1: 0, y1: 0, x2: 1, y2: 0 },
+      { id: "same", x1: 0, y1: 1, x2: 1, y2: 1 },
+    ]),
+    /duplicate segment id/,
+  );
+  const strict = gateCases[0].strict;
+  const invalidConfidence = gateTransparentRetry({
+    decision: { label: "hatch", testable: true, confidence: NaN },
+    strict,
+  });
+  assert.equal(invalidConfidence.action, "keep-strict");
+  assert.throws(
+    () => gateTransparentRetry(
+      { decision: { label: "hatch", testable: true, confidence: 1 }, strict },
+      { minDecisionConfidence: NaN },
+    ),
+    /between 0 and 1/,
+  );
+});

--- a/web/test/hatchPolicyReferenceCorpus.js
+++ b/web/test/hatchPolicyReferenceCorpus.js
@@ -1,0 +1,165 @@
+function segment(id, x1, y1, x2, y2, extra = {}) {
+  return { id, x1, y1, x2, y2, strokeWidth: 1, ...extra };
+}
+
+function verticalFamily(prefix, xs, y1, y2, extra = {}) {
+  return xs.map((x, index) => segment(`${prefix}-${index}`, x, y1, x, y2, extra));
+}
+
+function horizontalFamily(prefix, ys, x1, x2, extra = {}) {
+  return ys.map((y, index) => segment(`${prefix}-${index}`, x1, y, x2, y, extra));
+}
+
+function clippedBoundary(x1, y1, x2, y2) {
+  return [
+    segment("clip-top", x1, y1, x2, y1, { strokeWidth: 2, contextRole: "clip-boundary" }),
+    segment("clip-bottom", x1, y2, x2, y2, { strokeWidth: 2, contextRole: "clip-boundary" }),
+  ];
+}
+
+const regular = [10, 20, 30, 40, 50, 60, 70];
+
+export const familyCases = [
+  {
+    name: "native-hatch",
+    segments: verticalFamily("hatch", regular, 0, 100, {
+      native: { groupId: "native-hatch-1", kind: "dxf-hatch", role: "pattern-stroke" },
+    }),
+    context: {},
+    options: { trustedProvenanceGroups: new Set(["native-hatch-1"]) },
+    expectedLabel: "hatch",
+  },
+  {
+    name: "flattened-hatch-with-clip",
+    segments: [
+      ...verticalFamily("hatch", regular, 0, 100),
+      ...clippedBoundary(0, 0, 80, 100),
+    ],
+    context: { sharedClipEvidenceId: "clip-1" },
+    options: { trustedEvidenceIds: new Set(["clip-1"]) },
+    expectedLabel: "hatch",
+  },
+  {
+    name: "split-row-carpet-with-fill-evidence",
+    segments: regular.flatMap((x, row) => [
+      segment(`dash-${row}-a`, x, 0, x, 42),
+      segment(`dash-${row}-b`, x, 58, x, 100),
+    ]),
+    context: { regionFillEvidenceId: "fill-1" },
+    options: { trustedEvidenceIds: new Set(["fill-1"]) },
+    expectedLabel: "hatch",
+  },
+  {
+    name: "stair-treads",
+    segments: [
+      ...horizontalFamily("tread", regular, 0, 50),
+      segment("stringer-left", 0, 0, 0, 80, { contextRole: "structure" }),
+      segment("stringer-right", 50, 0, 50, 80, { contextRole: "structure" }),
+    ],
+    context: {},
+    expectedLabel: "repeated-building-element",
+  },
+  {
+    name: "dimension-ticks",
+    segments: [
+      ...verticalFamily("tick", regular, 0, 12),
+      segment("dimension-line", 0, 6, 80, 6, { contextRole: "structure" }),
+    ],
+    context: { protectedKind: "dimension" },
+    expectedLabel: "uncertain",
+  },
+  {
+    name: "ceiling-grid-without-provenance",
+    segments: [
+      ...verticalFamily("grid-v", regular, 0, 80),
+      ...horizontalFamily("grid-h", regular, 0, 80),
+    ],
+    context: {},
+    expectedLabel: "uncertain",
+  },
+  {
+    name: "same-pen-partition-bank",
+    segments: [
+      ...verticalFamily("partition", regular, 0, 100),
+      segment("bank-top", 0, 0, 80, 0, { strokeWidth: 2, contextRole: "structure" }),
+      segment("bank-bottom", 0, 100, 80, 100, { strokeWidth: 2, contextRole: "structure" }),
+    ],
+    context: {},
+    expectedLabel: "repeated-building-element",
+  },
+  {
+    name: "irregular-parallels",
+    segments: verticalFamily("irregular", [10, 18, 31, 47, 68, 91, 119], 0, 100),
+    context: {},
+    expectedLabel: null,
+  },
+];
+
+const strictRun = {
+  status: "trapped",
+  trapped: true,
+  area: 40,
+  wallEdgeFraction: 0.72,
+  coverage: 0.4,
+  perimeterOnPreservedWall: 0.72,
+  invalidPolygonCount: 0,
+  protectedOverlap: 0,
+  errorCount: 0,
+  exteriorLeak: false,
+  assignedSeedIds: ["room-a"],
+  trappedSeedIds: ["room-b"],
+  roomBySeed: { "room-a": "strict-a", "room-b": null },
+};
+
+const safeRetry = {
+  status: "ok",
+  area: 92,
+  wallEdgeFraction: 0.76,
+  coverage: 0.9,
+  perimeterOnPreservedWall: 0.76,
+  invalidPolygonCount: 0,
+  protectedOverlap: 0,
+  errorCount: 0,
+  exteriorLeak: false,
+  assignedSeedIds: ["room-a", "room-b"],
+  trappedSeedIds: [],
+  roomBySeed: { "room-a": "retry-a", "room-b": "retry-b" },
+};
+
+export const gateCases = [
+  {
+    name: "safe-recovery",
+    decision: { label: "hatch", confidence: 0.9, testable: true },
+    strict: { ...strictRun },
+    retry: { ...safeRetry },
+    expectedAction: "accept-transparent-retry",
+  },
+  {
+    name: "eligible-hatch-family-can-be-probed",
+    decision: { label: "hatch", confidence: 0.8, testable: true },
+    strict: { ...strictRun },
+    retry: null,
+    expectedAction: "run-transparent-retry",
+  },
+  {
+    name: "wall-edge-regression-keeps-strict",
+    decision: { label: "hatch", confidence: 0.8, testable: true },
+    strict: { ...strictRun, wallEdgeFraction: 0.8, perimeterOnPreservedWall: 0.8 },
+    retry: { ...safeRetry, wallEdgeFraction: 0.61, perimeterOnPreservedWall: 0.61 },
+    expectedAction: "keep-strict",
+  },
+  {
+    name: "protected-class-overlap-keeps-strict",
+    decision: { label: "hatch", confidence: 0.9, testable: true },
+    strict: { ...strictRun },
+    retry: { ...safeRetry, protectedOverlap: 1 },
+    expectedAction: "keep-strict",
+  },
+  {
+    name: "known-building-element-never-retries",
+    decision: { label: "repeated-building-element", confidence: 0.95, testable: false },
+    strict: { ...strictRun },
+    retry: null,
+    expectedAction: "keep-strict",
+  },
+];


### PR DESCRIPTION
## What

This adds a disconnected reference experiment for conservative hatch-family handling in One-Click:

- robust normal-offset lattice fitting for repeated parallel line families
- three-way classification into hatch, repeated building element, or uncertain
- explicit trusted provenance and contextual evidence boundaries
- a fail-closed gate for comparing strict flood results with a transparent retry
- a synthetic corpus covering hatch, stair treads, dimension ticks, ceiling grids, partition banks, irregular parallels, and retry regressions

Production One-Click does not import the new module, so this PR does not change runtime behavior.

## Real-sheet result

The requested runs against the two existing PDF-backed bench cases and the public open-sheet corpus are captured in the repository. The result is negative.

| Case | Extracted segments | Existing classifier | Reference result |
| --- | ---: | --- | --- |
| `sample-plan` | 6 | 0 soft segments, 0 families | 0 proposals |
| `va-finish-plan` | 71,819 | 25,157 soft segments, 37 families in 54 ms | raw input rejected; filtered proposal timed out after 5 seconds |
| Dublin A-601 finish plan | 35,538 | 12,950 soft segments, 28 families in 41 ms | raw input rejected; filtered proposal timed out after 5 seconds |
| Roseburg A-03a floor plan | 72,303 | 2,137 soft segments, 35 families in 83 ms | raw input rejected; filtered proposal timed out after 5 seconds |
| Roseburg A-04a RCP | 62,867 | 1,887 soft segments, 23 families in 77 ms | raw input rejected; filtered proposal timed out after 5 seconds |

Every real page contains zero-length extractor segments. Filtering only those avoids validation failure, but no full-sheet proposal finishes inside the five-second child-process budget. A classification-only comparison then gives all 123 existing family instances optimistic perfect-lattice metrics while withholding evidence that the extractor does not emit. All remain `uncertain`.

The Dublin run therefore does not yield a trustworthy "two families or one" answer. Its existing-family output fragments the dominant diagonal pattern across adjacent angle/pitch buckets. The matching Roseburg floor and RCP pages likewise do not establish room-hatch versus ceiling-grid discrimination. Per-instance IDs and bounding boxes are committed so the negative result is checkable.

This identifies two prerequisites: a bounded proposal algorithm that accepts the extractor's real contract, and region-level evidence that the extractor actually supplies. The retry gate also remains synthetic-only; these runs found no real split or merge regression in the existing escalation path.

See `docs/design/HATCH_POLICY_REFERENCE_VERIFICATION.md` and the captured `web/bench/hatch-policy-reference-results.json`.

## Limitations

- The classifier corpus is synthetic. The open-sheet runs expose runtime and evidence gaps but do not establish accuracy.
- Tangential dash recurrence is not implemented.
- Thresholds are test values, not production recommendations.
- This is an alternative policy reference around the current One-Click primitives, not a claim that the current implementation lacks separation.

## Verification

- `node --import tsx --test test/hatchPolicyReference.test.ts`: 16 passed
- `npm run bench:hatch-policy-reference -- --output bench/hatch-policy-reference-results.json`: captured five cases, including Dublin and matching Roseburg floor/RCP pages
- `npm run check`: typecheck, tests, benchmark, and production build passed
- Full suite: 1,707 passed, 3 skipped, 0 failed
- ESLint reports one pre-existing unused-disable warning in `TakeoffCanvas.jsx`
- Independent adversarial review reproduced and closed mutation, metric-validation, and recovered-room topology gaps

## Agent authorship

Prepared by Codex, operated through the `uwe-schwarz` GitHub account, in response to the public [OpenTakeoff construction-work invitation](https://artifactory.online/t/57/takeoff-real-construction-work-for-agents-with-a-scoreboard-and-a-cert).

The PR is rebased onto and targets the restored `agents` branch. It does not target the production-deploying `main` branch.
