### PR TITLE
detectScale: a schedule cell before the scale note no longer hides it (#375)

### DIFF
--- a/web/src/lib/sheets.ts
+++ b/web/src/lib/sheets.ts
@@ -202,18 +202,27 @@ function _findScales(canon: string): ScaleWithKeys[] {
 // → {upp, label, multi} or null. Title-block region is authoritative; a single
 // page-wide note is accepted; several distinct scales with no title-block note
 // is ambiguous (details are often drawn larger) → suggest nothing.
+// Two reads of the same items (#375): per-item canon joined with "|" first, so a
+// neighbouring run that ends in a digit (a schedule cell "PT-1" before the note)
+// can never fuse into "11/8\"" and trip the boundary guard; then the old
+// whitespace-stripped concatenation as the fallback, which is what still catches a
+// note the exporter split across runs ("1/8\"" then "= 1'-0\"").
+function _scaleHits(parts: string[]): ScaleWithKeys[] {
+  const joined = _findScales(parts.map(_canonScaleText).filter(Boolean).join("|"));
+  return joined.length ? joined : _findScales(_canonScaleText(parts.join(" ")));
+}
 export function detectScale(textContent: TextContentLike, viewport: Viewport): DetectedScale | null {
   const W = viewport.width, H = viewport.height;
-  let all = "", tb = "";
+  const all: string[] = [], tb: string[] = [];
   for (const it of textContent.items || []) {
     const str = it.str || "";
     if (!str.trim()) continue;
-    all += str + " ";
+    all.push(str);
     const t = pdfjsLib.Util.transform(viewport.transform, it.transform);
-    if (t[4] > W * 0.55 && t[5] > H * 0.5) tb += str + " ";
+    if (t[4] > W * 0.55 && t[5] > H * 0.5) tb.push(str);
   }
-  const tbHits = _findScales(_canonScaleText(tb));
-  const allHits = _findScales(_canonScaleText(all));
+  const tbHits = _scaleHits(tb);
+  const allHits = _scaleHits(all);
   if (tbHits.length) return { upp: tbHits[0].upp, label: tbHits[0].label, multi: allHits.length > 1 };
   if (allHits.length === 1) return { upp: allHits[0].upp, label: allHits[0].label, multi: false };
   return null;

--- a/web/test/scaleDetect.test.ts
+++ b/web/test/scaleDetect.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { detectScale } from "../src/lib/sheets";
+
+// identity-scale viewport: item transform [1,0,0,1,x,y] → position (x, y)
+const VP = { width: 6048, height: 4320, transform: [1, 0, 0, 1, 0, 0] } as never;
+const item = (str: string, x: number, y: number) => ({ str, transform: [1, 0, 0, 1, x, y], width: str.length * 12, height: 25 });
+
+test("#375: a scale note right after a digit-ending run (schedule cell) still detects", () => {
+  // The Dublin A-601 item order as pdf.js emits it: schedule cells, the note under
+  // the view title, the view-number bubble, the title. Whitespace-stripped
+  // concatenation read this as PT-11/8" and the 11/8" guard rejected it.
+  const items = [
+    item("PT-1", 2072, 470), item("PT-1", 2072, 505),
+    item('1/8" = 1\'-0"', 621, 3552), item("1", 519, 3538),
+    item("FLOOR PLAN - PHASE I - FINISH PLAN", 614, 3507),
+  ];
+  const d = detectScale({ items } as never, VP);
+  assert.ok(d, "note under the view title must be detected");
+  assert.equal(d!.label, '1/8" = 1\'-0"');
+  assert.equal(d!.multi, false);
+});
+
+test("#375: the 11/8\" and 1-1/2\" boundary guards still hold inside one run", () => {
+  assert.equal(detectScale({ items: [item('11/8" = 1\'-0"', 621, 3552)] } as never, VP), null);
+  assert.equal(detectScale({ items: [item('1-1/2" = 1\'-0"', 100, 100)] } as never, VP)?.label, '1-1/2" = 1\'-0"');
+});
+
+test("#375: a note the exporter split across runs still detects through the fallback", () => {
+  const items = [item("SCALE:", 4000, 4000), item('1/4"', 4100, 4000), item("=", 4150, 4000), item("1'-0\"", 4180, 4000)];
+  assert.equal(detectScale({ items } as never, VP)?.label, '1/4" = 1\'-0"');
+});


### PR DESCRIPTION
Closes #375.

`detectScale` joined every text run with a space and stripped all whitespace before matching, so on Dublin A-601 the schedule cell `PT-1` that precedes the note produced `PT-11/8"=1'-0"` and the `11/8"` boundary guard rejected the real note. Now each run is canonicalized on its own and joined with a separator; the old concatenation stays as the fallback for a note an exporter split across runs.

Proof: with the server run from this branch, `load_plan` on `evals/four-asks-2026-09-02/sheets/va-dublin-bldg9a-finish-plan-A601.pdf` reports `detected_scale: 1/8" = 1'-0"` and `set_scale {use_detected: true}` adopts it (upp 0.05556). Before: "No detected scale".

Tests: `web/test/scaleDetect.test.ts` — digit-ending neighbour, both boundary guards (`11/8"` still rejected, `1-1/2"` still its own scale), split-run fallback. `npm run check` green on Node 24.

Hand test: load the Dublin A-601 sheet from the eval folder in the app; the scale chip should offer 1/8" = 1'-0" without calibrating.