### PR TITLE
detect_rooms: a tag box is not a room — wide-box bubble rule and an ownership gate (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased — a tag box is not a room (#373)
+
+### Fixed
+- **`detect_rooms` no longer commits room-number boxes as rooms (mcp 0.9.69).** Revit draws the number inside a box wide enough for "CR11-10"; on the Dublin A-601 finish plan that box is 108×36 px around 42×25 px of digits — a width ratio of 2.58 that cleared the 2.5× bubble guard by a hair — and the batch verb returned twelve 12 SF "rooms" at confidence 1.0, plus the schedule table's own cells. The bubble guard now also treats a ring no taller than 2.5 text heights and no wider than 6 text widths as the label's furniture (`BUBBLE_WIDE_RATIO`), and the ladder's recovery rung has to pass the canvas's ownership test (`floodSurroundsLabelPx`) before its flood is this label's room — the rung under restroom 110 had flooded a 10 SF door-swing pocket, which would have committed as "110". Rooms whose every clean flood belongs to some other space are counted in a new `withheld.unowned` with the seed for a `one_click` inside the room.
+
 ## Unreleased — `get_sheet_vectors`: the strokes the engine floods against, readable by any agent (#367)
 
 ### Added

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.65",
+  "version": "0.9.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.65",
+      "version": "0.9.69",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,9 +1,9 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.68",
+  "version": "0.9.69",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
-  "description": "OpenTakeoff MCP server — drive the takeoff engine from your MCP client over stdio.",
+  "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20"

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.68",
+  "version": "0.9.69",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.68",
+      "version": "0.9.69",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/outputs.ts
+++ b/mcp/src/outputs.ts
@@ -125,6 +125,7 @@ export const detectRoomsOutput = {
     degenerate: z.number().int().describe("Traced to fewer than 3 vertices"),
     duplicate: z.number().int().describe("Flooded to a region another label already claimed — counted once, never twice"),
     bubble: z.number().int().describe("Labels whose every clean flood was their own label BUBBLE (ring bbox ≈ label bbox — plans box their room numbers). Scale-free, so it guards unscaled previews too"),
+    unowned: z.number().int().describe("Labels whose every clean, non-bubble flood did not SURROUND the label's box — a ladder rung stepped past the wall into a neighbouring space or a door-swing pocket. Withheld rather than committed under the tag (#373); one_click inside the room answers it"),
     implausible: z.number().int().describe("Enclosed, clean, non-bubble, but smaller than min_area_sf — a door swing or wall cavity rather than a room"),
     unresolved: z.number().int().describe("Assign mode: rooms the schedule could not answer for (no row, no FLOOR cell, or a compound cell) — withheld into unresolved[], never committed under a guess. Always present; 0 outside assign mode"),
     min_area_sf: z.number().optional().describe("The plausibility floor applied (scaled mode only)"),

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -37,7 +37,7 @@ import { buildRasterMask, RASTER_MIN_IMG_FRAC, RASTER_MIN_SEGS, RASTER_RDP_EPS }
 // passes at a One-Click. This server used to call the raw floodRegion on
 // scale-unpinned masks here, so an MCP trace and a canvas click at the same
 // seed measured DIFFERENT square footage under the same origin.method.
-import { ROOM_LABEL_RE, seedLadderPx, isLabelBubblePx, floodAtSeed, type LabelBBox } from "../../web/src/lib/detectRooms.ts";
+import { ROOM_LABEL_RE, seedLadderPx, isLabelBubblePx, floodSurroundsLabelPx, floodAtSeed, type LabelBBox } from "../../web/src/lib/detectRooms.ts";
 import { fingerprintSymbol, matchSymbol, buildNegative, SWEEP_TOL_PX, type SweepOptions, type SymbolFingerprint, type SymbolMatchResult, type SweepMatch, type SweepWithheld, type SweepRejected, type SymbolNegative } from "../../web/src/lib/symbolsweep.ts";
 import { labelPlacements, type PlacementLabel } from "../../web/src/lib/symbollabels.ts";
 import { buildSnapGrid, nearestSnap, closedMetrics, openLen } from "../../web/src/lib/geometry.js";
@@ -1510,7 +1510,7 @@ export class Session {
     // Trace every label first (ladder + bubble guard per label). Nothing
     // commits in this pass — withholding has to be decided across the whole
     // batch (dedupe needs to see every ring).
-    const withheld = { degenerate: 0, duplicate: 0, bubble: 0, implausible: 0, unresolved: 0 };
+    const withheld = { degenerate: 0, duplicate: 0, bubble: 0, unowned: 0, implausible: 0, unresolved: 0 };
     const unresolved: { label: string; reason: string; area_sf: number; perimeter_lf: number; seed: [number, number] }[] = [];
     type Cand = { label: string; ring: Point[]; areaPx2: number; perimPx: number; seed: readonly [number, number] | number[]; ev: FloodEvidence; merged: string[] };
     const byRing = new Map<string, Cand>();
@@ -1521,7 +1521,7 @@ export class Session {
     const sweepMppf = raster ? (s.upp ? mask.ws / s.upp : 0) : (mask.mppf || 0);
     for (const lb of labels) {
       let ring: Point[] | null = null, ev: FloodEvidence | null = null, seed: [number, number] | null = null;
-      let sawBubble = false, sawDegenerate = false;
+      let sawBubble = false, sawDegenerate = false, sawUnowned = false;
       for (const probe of seedLadderPx(lb.bbox)) {
         // the sealed engine at each ladder rung — floodAtSeed, the ONE entry
         // point every non-canvas surface floods through (web detectRooms.ts),
@@ -1535,12 +1535,20 @@ export class Session {
           : snapVertices(traceRegion(f), (px, py, d) => (s.snap ? nearestSnap(s.snap, px, py, d) : null), SNAP_TOL);
         if (r.length < 3) { sawDegenerate = true; continue; }
         if (isLabelBubblePx(r as [number, number][], lb.bbox)) { sawBubble = true; continue; }
+        // ownership (#373): a rung that steps past the room's wall floods the
+        // NEIGHBOURING space or a door pocket — on Dublin A-601 the below-box
+        // rung under restroom 110 flooded a 10 SF swing pocket and it would
+        // have committed as "110". The flood must surround the label's box
+        // (the canvas's own test, floodSurroundsLabelPx) or it is not this
+        // label's room; withheld as unowned, never committed under the tag.
+        if (!floodSurroundsLabelPx(f, lb.bbox)) { sawUnowned = true; continue; }
         // harvest the scalar evidence now; the region bitmap goes with `f`
         ring = r; ev = Session.floodEvidence(f, raster, sweepMppf); seed = probe;
         break;
       }
       if (!ring || !ev || !seed) {
-        if (sawBubble) withheld.bubble++;            // only its own bubble ever flooded clean
+        if (sawBubble && !sawUnowned) withheld.bubble++;   // only its own bubble ever flooded clean
+        else if (sawUnowned) withheld.unowned++;             // every clean flood was some other space's
         else if (sawDegenerate) withheld.degenerate++;
         // a label with no clean flood at any probe simply isn't counted as a
         // seed that traced — same as the historical single-seed gate
@@ -1632,7 +1640,7 @@ export class Session {
         seed_norm: [u.seed[0] / s.widthPx, u.seed[1] / s.heightPx] as [number, number],
       }));
     }
-    const withheldTotal = withheld.degenerate + withheld.duplicate + withheld.bubble + withheld.implausible + withheld.unresolved;
+    const withheldTotal = withheld.degenerate + withheld.duplicate + withheld.bubble + withheld.unowned + withheld.implausible + withheld.unresolved;
     return {
       detected: rooms.length,
       rooms,
@@ -1646,7 +1654,7 @@ export class Session {
       ...(assign ? { unresolved } : {}),
       ...(s.detected?.multi ? { multiple_scales: true as const } : {}),
       ...(withheldTotal
-        ? { note: `${withheldTotal} seed(s) withheld — ${withheld.duplicate} duplicate region(s), ${withheld.bubble} label-bubble(s), ${withheld.implausible} under ${minAreaSf} SF, ${withheld.degenerate} untraceable${assign ? `, ${withheld.unresolved} unresolved against the schedule (see unresolved[])` : ""}.` }
+        ? { note: `${withheldTotal} seed(s) withheld — ${withheld.duplicate} duplicate region(s), ${withheld.bubble} label-bubble(s), ${withheld.unowned} unowned (every clean flood was a neighbouring space or door pocket — one_click inside the room), ${withheld.implausible} under ${minAreaSf} SF, ${withheld.degenerate} untraceable${assign ? `, ${withheld.unresolved} unresolved against the schedule (see unresolved[])` : ""}.` }
         : {}),
       ...(s.upp == null ? { warning: `No scale set for ${s.key} — quantities unavailable. Call set_scale${s.detected ? ` (detected: ${s.detected.label})` : ""}.` } : {}),
     };

--- a/mcp/test/overlap.test.ts
+++ b/mcp/test/overlap.test.ts
@@ -134,19 +134,36 @@ test("no two regions the engine hands over on one sheet share floor", async (t) 
   const ADJUDICATED: { a: string; b: string; maxSf: number; why: string }[] = [
     { a: "detect:557", b: "click:corridor-CE-5", maxSf: 641, why: "same corridor, named off its printed area" },
     { a: "click:room-140", b: "click:enclosed-sliver-in-140", maxSf: 12, why: "#188 annotation-ring recovery" },
+    { a: "detect:140", b: "click:enclosed-sliver-in-140", maxSf: 12, why: "#188 annotation-ring recovery — the same sliver, now that the sweep reaches 140 (#373)" },
+    { a: "detect:153", b: "detect:557", maxSf: 1, why: "a threshold sliver at 153's door against corridor CE-5 — under a third of a square foot, visible only since the sweep reaches 153 (#373)" },
+    { a: "detect:153", b: "click:corridor-CE-5", maxSf: 1, why: "the same threshold sliver, corridor arm" },
   ];
   const known = (h: { a: Ring; b: Ring }) =>
     ADJUDICATED.find((k) =>
       (k.a === h.a.name && k.b === h.b.name) || (k.a === h.b.name && k.b === h.a.name));
 
-  const fresh = hits.filter((h) => !known(h));
+  // ── cross-arm parity, not double-count (#373) ─────────────────────────────
+  // The hand clicks below were stand-ins for rooms the sweep could not reach
+  // while the wide tag boxes stopped its ladder. Now that detect_rooms reaches
+  // 140 and 158, "detect:140 x click:room-140" is the SAME room measured by two
+  // arms, and the honest assertion is that the two arms agree, not that they
+  // never touch.
+  const sameRoom = (h: { a: Ring; b: Ring }) => {
+    const m = (n: string) => n.replace(/^detect:/, "").replace(/^click:room-/, "");
+    return h.a.name !== h.b.name && m(h.a.name) === m(h.b.name);
+  };
+  for (const h of hits.filter(sameRoom)) {
+    assert.ok(Math.abs(h.a.sf - h.b.sf) < 0.5, `${h.a.name} and ${h.b.name} are one room traced by two arms and must agree: ${h.a.sf} vs ${h.b.sf} SF`);
+  }
+
+  const fresh = hits.filter((h) => !known(h) && !sameRoom(h));
   assert.deepEqual(
     fresh.map((h) => `${h.a.name} x ${h.b.name} = ${h.sf.toFixed(2)} SF`), [],
     "unadjudicated double-count: two regions the engine handed over share floor. "
     + "Either fix it, or add it to ADJUDICATED with the reason it is tolerable.",
   );
 
-  for (const h of hits) {
+  for (const h of hits.filter((x) => !sameRoom(x))) {
     const k = known(h)!;
     assert.ok(h.sf <= k.maxSf, `${h.a.name} x ${h.b.name} grew to ${h.sf.toFixed(2)} SF, past its ${k.maxSf} SF ceiling (${k.why})`);
   }

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -888,29 +888,38 @@ test("detect_rooms assign_from_schedule: each room commits under its own row; un
   assert.equal(r.isError, false);
   // pinned from the first observed run — deterministic flood + fixture; re-pinned
   // for the RFC #60 engine (sealed ladder + lattice classifier shift which label
-  // seeds flood clean: 7/19 -> 6/17, same contract, better boundaries), and
-  // AGAIN for the sealed-engine session wiring (floodAtSeed on scale-pinned
-  // masks — the canvas's own feet-true arguments — replacing the raw
-  // floodRegion): 6 -> 5. The dropped room is 133, and the drop is the sealed
-  // engine being HONEST: the raw flood only reached 133's floor by LEAKING
-  // through its drawn tag box's pinhole (46.74 SF); sealing closes the box, the
-  // snapped 4.62 SF box ring is no room, and the 5 SF plausibility floor
-  // withholds it (withheld.implausible) instead of committing a tag box as a
-  // room. 142 also corrects 285.96 -> 161.00 SF — the min-passage rule severs
-  // a hairline conjunction the raw flood measured as one space — and 134A
-  // gains its annexed door swing (78.93 -> 90.13 SF). Canvas parity is proven
-  // against the bench corpus goldens in parity.test.ts.
-  assert.equal(r.data.detected, 5);
+  // seeds flood clean: 7/19 -> 6/17, same contract, better boundaries), AGAIN
+  // for the sealed-engine session wiring (floodAtSeed on scale-pinned masks:
+  // 6 -> 5), and AGAIN for #373 (5 -> 4). The #373 re-pin is the wide-box
+  // bubble rule plus the ownership gate being HONEST about what the old 5 were:
+  // the tag boxes on this sheet are wider than 2.5 text widths, so the center
+  // rung's box flood cleared the bubble guard, stopped the ladder, and was
+  // withheld under the 5 SF floor — 25 real rooms never got their second rung.
+  // Now the box is a bubble, the ladder reaches the room, and the sweep hands
+  // over 21 more rooms (unresolved against the schedule, below). Of the old 5
+  // commits, NONE was the room its row named: 170, 150 and 167 were pockets
+  // under the tag (8.44 / 5.61 / 7.14 SF), 142's 161 SF was the space south of
+  // its door (142's own floor is tile-hatched and never floods), and 134A's
+  // 93.07 SF was room 136. The ownership gate now withholds all five as
+  // unowned, while 136 commits under ITS row at the same 93.07 SF. Fewer
+  // commits, every one of them the room its row names.
+  assert.equal(r.data.detected, 4);
   assert.ok(r.data.rooms.every((x: any) => typeof x.shape_id === "string" && typeof x.condition === "string"),
     "every reported room committed, each carrying the tag it committed under");
   const tags = new Set(r.data.rooms.map((x: any) => x.condition));
-  assert.equal(tags.size, 5, `distinct finishes from distinct rows — the whole point (5 rooms, 5 rows after the sealed-wiring re-pin). Got: ${[...tags].join(",")}`);
+  assert.equal(tags.size, 3, `distinct finishes from distinct rows — the whole point (4 rooms over 3 rows' finishes after the #373 re-pin: two share CPT-1). Got: ${[...tags].join(",")}`);
+  assert.deepEqual(
+    r.data.rooms.map((x: any) => [x.label, x.condition]).sort(),
+    [["133", "EXIST"], ["136", "CPT-1"], ["149", "CPT-1"], ["153", "WSF-1"]],
+    "each committed room carries its OWN row's floor finish",
+  );
+  assert.equal(r.data.withheld.unowned, 12, "wrong-space floods are withheld as unowned, never committed under a tag (#373)");
   assert.ok([...tags].every((t: any) => !/[/,]/.test(t)), "no minted tag is a compound literal");
 
   // the never-guesses contract: withheld rooms are reported with their real
   // geometry and a reason, never committed and never dropped
-  assert.equal(r.data.withheld.unresolved, 17);
-  assert.equal(r.data.unresolved.length, 17);
+  assert.equal(r.data.withheld.unresolved, 31);
+  assert.equal(r.data.unresolved.length, 31);
   for (const u of r.data.unresolved) {
     assert.ok(u.reason.length > 0, "every withheld room says why");
     assert.ok(u.area_sf > 0 && u.perimeter_lf > 0, "withheld from committing, not from reporting");
@@ -922,7 +931,7 @@ test("detect_rooms assign_from_schedule: each room commits under its own row; un
   // and the sealed engine's account (confidence + factors) stamps centrally
   // in commit(), so every flood-committed shape ships scored
   const payload = await call(client, "export_takeoff", {});
-  assert.equal(payload.data.shapes.length, 5);
+  assert.equal(payload.data.shapes.length, 4);
   for (const shp of payload.data.shapes) {
     assert.equal(shp.origin.assignment.source, "schedule");
     assert.ok(shp.origin.assignment.room_tag, "the room tag that resolved");
@@ -934,15 +943,15 @@ test("detect_rooms assign_from_schedule: each room commits under its own row; un
   const inv = await call(client, "list_shapes", {});
   assert.ok(inv.data.shapes.every((x: any) => x.assignment === "schedule"), "list_shapes carries the flat verdict");
   const summary = await call(client, "takeoff_summary");
-  assert.equal(summary.data.conditions.length, 5);
-  assert.equal(summary.data.conditions.reduce((n: number, c: any) => n + c.shape_count, 0), 5);
+  assert.equal(summary.data.conditions.length, 3);
+  assert.equal(summary.data.conditions.reduce((n: number, c: any) => n + c.shape_count, 0), 4);
 
   // mutual exclusion: both finish-tag sources at once is a contradiction,
   // refused before any flooding — nothing minted, nothing committed
   const both = await call(client, "detect_rooms", { sheet: FKEY, condition: "CPT-1", assign_from_schedule: true });
   assert.equal(both.isError, true);
   assert.match(both.data.error, /at most one of/);
-  assert.equal((await call(client, "takeoff_summary")).data.conditions.length, 5, "the refusal changed nothing");
+  assert.equal((await call(client, "takeoff_summary")).data.conditions.length, 3, "the refusal changed nothing");
 
   // a reassign onto a different tag is the agent choosing the finish — the
   // schedule verdict (and its citation) must not survive that edit; undo

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.68",
+  "version": "0.9.69",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.68",
+      "version": "0.9.69",
       "transport": {
         "type": "stdio"
       }

--- a/web/src/lib/detectRooms.ts
+++ b/web/src/lib/detectRooms.ts
@@ -215,6 +215,15 @@ export interface DetectedRegion {
 
 /** Ring bbox ≤ this × label bbox (both axes) ⇒ the label's own bubble. */
 export const BUBBLE_RATIO = 2.5;
+/** The wide-box rule (#373): a ring no taller than BUBBLE_RATIO × the label's
+ *  text height and no wider than this × its text width is a tag box or a
+ *  schedule cell, never a room. Revit draws the room-number box wide enough
+ *  for "CR11-10" — on the Dublin A-601 finish plan it is 108×36 px around
+ *  42×25 px of digits, a width ratio of 2.58 that cleared the square guard by
+ *  a hair and committed twelve 12 SF "rooms" at confidence 1.0; the schedule
+ *  cells on the same sheet are 174×34 px. A long thin corridor a label sits in
+ *  stays a room: its length runs past this cap. */
+export const BUBBLE_WIDE_RATIO = 6;
 
 export interface LabelBBox { x0: number; y0: number; x1: number; y1: number }
 
@@ -311,7 +320,9 @@ export function isLabelBubblePx(ring: [number, number][], b: LabelBBox): boolean
     if (x > x1) x1 = x; if (y > y1) y1 = y;
   }
   const lw = Math.max(b.x1 - b.x0, 1e-6), lh = Math.max(b.y1 - b.y0, 1e-6);
-  return (x1 - x0) <= BUBBLE_RATIO * lw && (y1 - y0) <= BUBBLE_RATIO * lh;
+  const rw = x1 - x0, rh = y1 - y0;
+  if (rw <= BUBBLE_RATIO * lw && rh <= BUBBLE_RATIO * lh) return true;   // the square bubble
+  return rh <= BUBBLE_RATIO * lh && rw <= BUBBLE_WIDE_RATIO * lw;        // the wide tag box / table cell (#373)
 }
 
 /** Seed the SAME flood the click path uses at each label and apply the

--- a/web/test/detectLadder.test.ts
+++ b/web/test/detectLadder.test.ts
@@ -7,7 +7,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { buildMask, floodRegion, traceRegion } from "../src/lib/oneclick.ts";
-import { seedLadderPx, isLabelBubblePx, BUBBLE_RATIO, type LabelBBox } from "../src/lib/detectRooms.ts";
+import { seedLadderPx, isLabelBubblePx, BUBBLE_RATIO, BUBBLE_WIDE_RATIO, type LabelBBox } from "../src/lib/detectRooms.ts";
 
 function squareSegs(x0: number, y0: number, x1: number, y1: number): number[] {
   return [x0, y0, x1, y0, x1, y0, x1, y1, x1, y1, x0, y1, x0, y1, x0, y0];
@@ -52,4 +52,17 @@ test("isLabelBubblePx boundary: the ratio is the contract", () => {
   const ringAt = (s: number): [number, number][] => [[0, 0], [s, 0], [s, s], [0, s]];
   assert.ok(isLabelBubblePx(ringAt(10 * BUBBLE_RATIO), b), "at the ratio: still the label's furniture");
   assert.ok(!isLabelBubblePx(ringAt(10 * BUBBLE_RATIO + 1), b), "past it: a real (small) space");
+});
+
+// #373 — the wide tag box. Measured on the Dublin A-601 finish plan: the drawn
+// number box is 108×36 px around 42×25 px of digits (width ratio 2.58, past
+// the square guard by a hair), and the room-finish schedule's cells are
+// 174×34 px around the same digits. Both flooded clean and committed as rooms.
+test("isLabelBubblePx: a wide, text-height tag box is the label's furniture (#373)", () => {
+  const b: LabelBBox = { x0: 2138.6, y0: 1929, x1: 2180.4, y1: 1954.1 };   // "110" on A-601
+  const rect = (x0: number, y0: number, w: number, h: number): [number, number][] => [[x0, y0], [x0 + w, y0], [x0 + w, y0 + h], [x0, y0 + h]];
+  assert.ok(isLabelBubblePx(rect(2106, 1927.7, 108, 36), b), "the Revit number box");
+  assert.ok(isLabelBubblePx(rect(299, 824.2, 174, 34.5), b), "a schedule cell");
+  assert.ok(!isLabelBubblePx(rect(2106, 1927.7, 108, 90), b), "as tall as 3.6 text heights: a real small space");
+  assert.ok(!isLabelBubblePx(rect(1900, 1927.7, 42 * BUBBLE_WIDE_RATIO + 1, 36), b), "a corridor a label sits in runs past the width cap");
 });


### PR DESCRIPTION
Closes #373.

**What was wrong.** Revit draws the room number inside a box wide enough for "CR11-10". On Dublin A-601 that box is 108×36 px around 42×25 px of digits, a width ratio of 2.58 against a bubble guard cut at 2.5, so `detect_rooms` returned twelve 12 SF "rooms" at confidence 1.0 plus the schedule table's cells. On the bundled sample plan the same box flood satisfied the ladder's first rung and 25 real rooms were withheld as implausible without the ladder ever reaching them.

**The change.**
- `isLabelBubblePx` also treats a ring no taller than 2.5 text heights and no wider than 6 text widths (`BUBBLE_WIDE_RATIO`) as the label's furniture. A corridor a label sits in runs past the width cap and stays a room.
- The MCP ladder's clean flood must pass the canvas's ownership test (`floodSurroundsLabelPx`) before it is this label's room. Rooms whose every clean flood belongs to some other space land in a new `withheld.unowned` (schema + note), never under the tag.

**Measured, server run from this branch.**
| Sheet | Before | After |
|---|---|---|
| Dublin A-601 (`evals/four-asks-2026-09-02/sheets/`) | 43 detected, 12 of them 72×54 px tag boxes at conf 1.0, plus schedule cells | 18 detected: the 17 labeled rooms + the grid bubbles; 31 withheld as bubbles, 8 unowned, 0 boxes committed. Restroom 110 is 69.95 SF, not a 10 SF door pocket |
| Bundled sample plan, plain sweep | 25 real rooms withheld as implausible (their box flooded first) | those 21 rooms returned (125, 133, 134, 136…163); 142 withheld as unowned because its tile-hatched floor never floods and the old 161 SF was the space south of its door |
| Sample plan, `assign_from_schedule` | 5 commits, none the room its row named (170/150/167 tag pockets at 8/6/7 SF, 142's 161 SF wrong space, 134A's 93 SF = room 136) | 4 commits, each its own row (133 EXIST, 136 CPT-1, 149 CPT-1, 153 WSF-1); 31 unresolved reported with seeds |

Tests: `web/test/detectLadder.test.ts` pins the wide box, the schedule cell, a tall small room, and a corridor past the cap; `mcp/test/tools.test.ts` and `overlap.test.ts` re-pinned with the account above (the overlap test now treats a detect ring and a hand click on the same room as cross-arm parity and asserts they agree). 193/193 mcp, web `npm run check` green on Node 24. mcp 0.9.69 on all four version surfaces + CHANGELOG.

Still open on A-601 after this: the grid bubbles along the sheet edge (18, 19, 25) flood the exterior and come back as "undecidable-passage" rooms at 0.84; and restroom 112 still fragments on its fixtures (36 SF). Both are separate mechanisms.

Hand test: load `sheets/va-dublin-bldg9a-finish-plan-A601.pdf` from the eval folder, set 1/8" = 1'-0", run `detect_rooms` — no 12 SF rooms, and 110/111/113 land on their walls.