### PR TITLE
sheetgraph: a two-tier Revit room-finish schedule reads every row (#374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased — a two-tier Revit schedule reads every row (#374)
+
+### Fixed
+- **Room-finish schedule reader: 2 of 21 rows → 20 of 20 on a two-tier Revit header (mcp 0.9.71).** The Dublin A-601 finish plan puts CEILING | FLOOR | BASE | WAINSCOT | WALL FINISH on a parent tier and ROOM # | ROOM NAME | FINISH | FINISH | MAT | HT | MAT | HT | EAST NORTH SOUTH | WEST on the tier that defines the columns. The descent from parent tier to defining tier demanded the required surface words of the lower tier too — which by construction carries none — so the key column never anchored, the walker read the sheet's grid bubbles as rows, and `resolve_tag 110` answered "no schedule row" for a room that has one. Six things, each measured on that sheet: the descent trusts the tier above for the required words; MAT / MATERIAL / COMMENTS join the header vocabulary; a header run of several surface words ("EAST NORTH SOUTH") is one column per word; a sub-column whose merged parent is centred over its sibling inherits the sibling's parent (BASE over MAT | HT gives "BASE HT"); a parent-tier word two column pitches outside the band (the finish-abbreviation list beside the schedule) never mints a column; and cells band by the interval they overlap, with placeholder dashes voting for a column's existence but never for where it starts (Revit centres its codes and left-aligns its names). Corridor keys "CR11-9" / "CR11-10" are row keys. `detect_rooms assign_from_schedule` now finds the FLOOR cell under its two-tier name ("FLOOR FINISH"). The bundled sample plan still reads exactly its 29 rows, every prior fixture holds.
+
 ## Unreleased — a small seed does not commit a crowd (#376)
 
 ### Changed

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1659,9 +1659,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -2139,9 +2139,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opentakeoff-mcp",
-      "version": "0.9.70",
+      "version": "0.9.71",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentakeoff-mcp",
-  "version": "0.9.70",
+  "version": "0.9.71",
   "mcpName": "io.github.Kentucky-ai/opentakeoff",
   "type": "module",
   "description": "OpenTakeoff MCP server \u2014 drive the takeoff engine from your MCP client over stdio.",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.70",
+  "version": "0.9.71",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.70",
+      "version": "0.9.71",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/session.ts
+++ b/mcp/src/session.ts
@@ -4299,7 +4299,10 @@ export class Session {
   private floorTagFor(g: SheetGraph, tag: string): { tag: string; sheet: string } | { reason: string } {
     const res = resolveTag(g, tag);
     if (res.status !== "resolved") return { reason: res.reason };
-    const floor = res.finishes.find((f) => f.surface === "FLOOR");
+    // the column is "FLOOR" on a one-tier schedule and "FLOOR FINISH" under a
+    // two-tier header (the sub-header takes its parent's name, #374); either
+    // way the surface's first word is the surface
+    const floor = res.finishes.find((f) => f.surface === "FLOOR" || f.surface.startsWith("FLOOR "));
     const code = floor?.code.trim();
     if (!floor || !code) return { reason: `schedule row ${res.tag} states no FLOOR finish` };
     if (/[/,]|\bOR\b/i.test(code)) return { reason: `ambiguous: floor cell "${code}" names more than one finish with no stated split` };

--- a/web/public/.well-known/mcp.json
+++ b/web/public/.well-known/mcp.json
@@ -8,12 +8,12 @@
     "url": "https://github.com/Kentucky-ai/opentakeoff",
     "source": "github"
   },
-  "version": "0.9.70",
+  "version": "0.9.71",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "opentakeoff-mcp",
-      "version": "0.9.70",
+      "version": "0.9.71",
       "transport": {
         "type": "stdio"
       }

--- a/web/src/lib/sheetgraph.ts
+++ b/web/src/lib/sheetgraph.ts
@@ -298,7 +298,10 @@ export interface ScheduleTable {
 
 /** Columns that ARE a surface in their own right — never renamed by a parent. */
 const SURFACE_WORDS = new Set(["FLOOR", "BASE", "WALL", "WALLS", "CEILING", "NORTH", "SOUTH", "EAST", "WEST", "WAINSCOT"]);
-const ROOM_HEADERS = ["ROOM", "NO", "NUMBER", "NAME", "MARK", "LOCATION", "FLOOR", "BASE", "WALL", "WALLS", "NORTH", "SOUTH", "EAST", "WEST", "CEILING", "WAINSCOT", "REMARKS", "CLG", "HT", "HEIGHT", "FINISH", "CASEWORK", "CABINET", "COUNTER", "COUNTERTOP", "BLDG", "BUILDING"];
+const ROOM_HEADERS = ["ROOM", "NO", "NUMBER", "NAME", "MARK", "LOCATION", "FLOOR", "BASE", "WALL", "WALLS", "NORTH", "SOUTH", "EAST", "WEST", "CEILING", "WAINSCOT", "REMARKS", "CLG", "HT", "HEIGHT", "FINISH", "MAT", "MATERIAL", "COMMENTS", "CASEWORK", "CABINET", "COUNTER", "COUNTERTOP", "BLDG", "BUILDING"];
+// MAT / MATERIAL joined the vocabulary for #374: a Revit room-finish schedule
+// splits BASE and WAINSCOT into MAT | HT sub-columns, and an un-anchored MAT
+// column banded its codes into whichever neighbour was nearest.
 // TAG joined the vocabulary AND the key set for #356: a materials schedule keyed
 // TAG | MANUFACTURER | STYLE | COLOR scores six clean header hits and was still refused,
 // because TAG was in neither list. Common convention when a set has no room-finish schedule.
@@ -339,6 +342,14 @@ function headerHits(row: GraphSpan[], vocab: string[]): Array<{ label: string; s
   for (const t of row) {
     const words = headerLabels(t.str, vocab);
     if (!words.length) continue;
+    // "EAST NORTH SOUTH" set as ONE text run over three columns (#374): every
+    // word is a surface, so each is a column, laid out across the run's width
+    const all = norm(t.str).split(/[^A-Z]+/).filter(Boolean);
+    if (all.length >= 2 && all.every((w) => SURFACE_WORDS.has(w))) {
+      const n = all.length, w = (t.w || 0) / n;
+      all.forEach((word, k) => { used.add(word); out.push({ label: word, span: { ...t, x: t.x + w * k, w } }); });
+      continue;
+    }
     const w = words.find((word) => !used.has(word)) ?? words[0];
     used.add(w);
     out.push({ label: w, span: t });
@@ -347,7 +358,10 @@ function headerHits(row: GraphSpan[], vocab: string[]): Array<{ label: string; s
 }
 const qualifies = (hits: Array<{ label: string }>, required: string[], minHits: number) => {
   const seen = new Set(hits.map((h) => h.label));
-  return seen.size >= minHits && required.some((r) => seen.has(r));
+  // an empty `required` is "no surface demanded of THIS row" (the descent
+  // below, where the row above already proved the surfaces are here) — it is
+  // not "no row can qualify", which is what `[].some()` used to say (#374)
+  return seen.size >= minHits && (!required.length || required.some((r) => seen.has(r)));
 };
 
 function findHeaderRow(rows: GraphSpan[][], vocab: string[], required: string[], minHits: number): { anchors: Anchor[]; rowIndex: number } | null {
@@ -372,7 +386,13 @@ function findHeaderRow(rows: GraphSpan[][], vocab: string[], required: string[],
         // few by accident — a material schedule's "VINYL WALL BASE" hits WALL
         // and BASE — and descending into one shifts every column by a row.
         const ratio = h.length / Math.max(1, rows[j].length);
-        if (qualifies(h, required, minHits) && h.length > hits.length && ratio >= 0.6) { next = j; break; }
+        // The row ABOVE already proved the required surfaces are here. A
+        // two-tier Revit schedule (#374) puts FLOOR / BASE / WAINSCOT on the
+        // parent tier and ROOM # | ROOM NAME | FINISH | MAT | HT on the tier
+        // that actually defines the columns — which carries none of the
+        // required words itself. Demanding them again refused the descent,
+        // the key column never anchored, and 21 rows read as 2.
+        if (qualifies(h, [], minHits) && h.length > hits.length && ratio >= 0.6) { next = j; break; }
       }
       if (next < 0) break;
       idx = next;
@@ -388,15 +408,32 @@ function findHeaderRow(rows: GraphSpan[][], vocab: string[], required: string[],
     for (const h of hits) (once.has(h.label) ? dup : once).add(h.label);
     const anchors: Anchor[] = [];
     const used = new Set<string>();
+    const parents: (string | null)[] = [];   // the parent each hit resolved, by index (#374)
     for (let j = 0; j < hits.length; j++) {
       const h = hits[j];
+      parents[j] = null;
       let label = h.label;
       // An ambiguous label takes its parent's name first (two FINISH columns
       // become FLOOR FINISH and CEILING FINISH) …
       if (dup.has(h.label) && !SURFACE_WORDS.has(h.label)) {
         const hi = j + 1 < hits.length ? hits[j + 1].span.x : Infinity;
-        const parent = parentLabelOver(rows, idx, i, h.span.x, hi, vocab);
-        if (parent && parent !== h.label) label = `${parent} ${h.label}`;
+        // the parent is centred over its sub-columns TOGETHER, so the sub-column
+        // on the right (HT under BASE | HT) has the parent's centre to its LEFT
+        // — outside [this.x, next.x). Fall back to the column's own extent,
+        // midpoint-to-midpoint between its neighbours (#374).
+        const lo2 = j > 0 ? (hits[j - 1].span.x + (hits[j - 1].span.w || 0) + h.span.x) / 2 : h.span.x;
+        const hi2 = j + 1 < hits.length ? (h.span.x + (h.span.w || 0) + hits[j + 1].span.x) / 2 : hi;
+        let parent = parentLabelOver(rows, idx, i, h.span.x, hi, vocab) ?? parentLabelOver(rows, idx, i, lo2, hi2, vocab);
+        // A merged parent is centred over its sub-columns TOGETHER (BASE over
+        // MAT | HT), which can leave the right-hand sub-column with no parent
+        // text over its own extent at all. The sub-column immediately to its
+        // left already resolved that parent; an adjacent, unresolved sub-label
+        // is its sibling and inherits it (#374).
+        if (!parent && j > 0 && parents[j - 1] && h.span.x - (hits[j - 1].span.x + (hits[j - 1].span.w || 0)) < bandLimits(hits.map((x) => ({ label: x.label, x: x.span.x }))).medGap * 1.5) parent = parents[j - 1];
+        // a generic sub-word under a surface parent IS that surface's column
+        // (FLOOR over FINISH → FLOOR), so resolve_tag and assign_from_schedule
+        // find it under the surface name; a splitting sub-word keeps both
+        if (parent && parent !== h.label) { label = `${parent} ${h.label}`; parents[j] = parent; }
       }
       // … and failing that, a cell naming more than one vocabulary word falls
       // through to its next one: "ROOM #" and "ROOM NAME" both lead with ROOM,
@@ -416,10 +453,17 @@ function findHeaderRow(rows: GraphSpan[][], vocab: string[], required: string[],
     // columns that are already anchored below it.
     if (idx > i) {
       const lo = Math.min(...anchors.map((a) => a.x)), hi = Math.max(...anchors.map((a) => a.x));
+      // …but a parent-tier word FAR outside the band is some other block that
+      // shares the header's y — the finish-abbreviation list beside a Revit
+      // schedule reads "RUBBER BASE" and "CERAMIC FLOOR TILE" on the parent
+      // row (#374). Two column pitches beyond the band is as far as a real
+      // spanning column (REMARKS) sits.
+      const reach = bandLimits(anchors).medGap * 2;
       for (let j = i; j < idx; j++) {
         for (const h of headerHits(rows[j], vocab)) {
           const cx = h.span.x + (h.span.w || 0) / 2;
           if (cx >= lo && cx <= hi) continue;
+          if (cx < lo - reach || cx > hi + reach) continue;
           if (used.has(h.label)) continue;
           used.add(h.label);
           anchors.push({ label: h.label, x: cx });
@@ -574,7 +618,7 @@ const nearestAnchor = (x: number, anchors: Anchor[]) => {
 // remark stays in; a code column (CEILING, WALL, COLOR) hugs its anchor —
 // field-found on a real gym set: a finish legend sitting 300px right of a
 // room schedule bled into every CEILING cell under the generous edge.
-const WIDE_LAST = new Set(["REMARKS", "DESCRIPTION", "NOTES"]);
+const WIDE_LAST = new Set(["REMARKS", "DESCRIPTION", "NOTES", "COMMENTS"]);
 function bandLimits(anchors: Anchor[]): { x0: number; x1: number; medGap: number } {
   const gaps = anchors.slice(1).map((a, i) => a.x - anchors[i].x).sort((a, b) => a - b);
   const medGap = gaps.length ? gaps[gaps.length >> 1] : 150;
@@ -592,6 +636,7 @@ function bandLimits(anchors: Anchor[]): { x0: number; x1: number; medGap: number
 const CODE_RE = /^[A-Z]{1,4}(-?[A-Z0-9]{1,4})?$/;
 const ROW_KEY_RE = /^\d{1,3}[A-Z]{0,2}$/;
 const QUALIFIED_KEY_RE = /^([A-Z]{1,2})-(\d{1,3}[A-Z]{0,2})$/;
+const CORRIDOR_KEY_RE = /^[A-Z]{1,3}(?:\d{1,3}-\d{1,3}|\d{3})[A-Z]?$/;   // CR11-9, C101 — never a two-character tag like "T1"
 
 export interface ExtractOpts { buildings?: Set<string>; deltas?: DeltaIndex }
 
@@ -618,6 +663,11 @@ function rowKeyOf(raw: string, kind: "room-finish" | "finish", buildings?: Set<s
     return CODE_RE.test(key) ? { key } : null;
   }
   if (ROW_KEY_RE.test(key)) return { key };
+  // "CR11-9", "C101": letters-then-digits keys a Revit schedule gives
+  // corridors and lettered wings (#374). Letters-dash-digits ("PT-2") is a
+  // finish code and stays out; letters-dash-digits with a named building is
+  // the qualified form below.
+  if (CORRIDOR_KEY_RE.test(key)) return { key };
   const q = key.match(QUALIFIED_KEY_RE);
   if (q && buildings?.has(q[1])) return { key, building: q[1] };
   return null;
@@ -644,6 +694,7 @@ const centerX = (t: GraphSpan) => t.x + (t.w || 0) / 2;
  * own order; otherwise banding falls back to nearest-anchor, so a table this
  * does not fit is never mangled by a half-built column map. */
 type ColumnMap = { coord: "left" | "center"; cols: Array<{ start: number; label: string }>; score: number };
+const PLACEHOLDER_RE = /^[-–—]{1,3}$/;
 
 function columnMapFor(
   rows: GraphSpan[][],
@@ -656,10 +707,18 @@ function columnMapFor(
   const at = (t: GraphSpan) => (coord === "left" ? t.x : t.x + (t.w || 0) / 2);
   const xs: number[] = [];
   const hs: number[] = [];
+  const dashes: number[] = [];
   for (let i = Math.max(cfg.fromIdx, 0); i < rows.length; i++) {
     if (rowY(rows[i]) <= cfg.belowY) continue;
     for (const t of rows[i]) {
       if (t.x < x0 || t.x > x1 || revisionOf(t.str) != null) continue;
+      // A placeholder dash is CENTRED in its column while the codes beside it
+      // are left-aligned, and on a column that is mostly dashes ("--" in 16
+      // of 20 WAINSCOT rows) the dash edge became the column start and the
+      // four real codes, starting a few px left of it, banded into the
+      // column before (Dublin A-601: "BASE HT" read "4\" CWT-1", #374). A
+      // dash says nothing about where cells start, so it does not vote.
+      if (PLACEHOLDER_RE.test(t.str.trim())) { dashes.push(at(t)); continue; }
       xs.push(at(t));
       hs.push(t.h || 8);
     }
@@ -683,6 +742,21 @@ function columnMapFor(
     if (!own) continue;
     const cur = byLabel.get(own.label);
     if (cur == null || c.start < cur) byLabel.set(own.label, c.start);
+  }
+  // A column that is dashes in most rows and a real code in a few (the
+  // WAINSCOT column: "--" in 16 rows, CWT-1 in 4) can lose its real cluster
+  // to the keep floor above. It is still a column: the dashes place it, and
+  // the real cells — when there are any — say where it starts.
+  if (byLabel.size < anchors.length && dashes.length) {
+    dashes.sort((a, b) => a - b);
+    const dc: Array<{ start: number; n: number }> = [];
+    for (const x of dashes) { const last = dc[dc.length - 1]; if (last && x - last.start <= tol) { last.n++; continue; } dc.push({ start: x, n: 1 }); }
+    for (const c of dc.filter((d) => d.n >= 2)) {
+      const own = anchors.find((a) => a.x >= c.start);
+      if (!own || byLabel.has(own.label)) continue;
+      const real = clusters.filter((k) => k.n >= 1 && anchors.find((a) => a.x >= k.start)?.label === own.label).sort((a, b) => a.start - b.start)[0];
+      byLabel.set(own.label, real ? real.start : c.start);
+    }
   }
   if (byLabel.size !== anchors.length) return null;
   const cols = [...byLabel.entries()].map(([label, start]) => ({ label, start })).sort((a, b) => a.start - b.start);
@@ -750,6 +824,22 @@ function bandDataRows(
     const at = cols.coord === "left" ? t.x : centerX(t);
     let label = cols.cols[0].label;
     for (const c of cols.cols) { if (at + 1 >= c.start) label = c.label; else break; }
+    // Left-aligned map, but a Revit schedule CENTRES its codes while it
+    // left-aligns its names, so a wide code ("LVT-1 / LVT-2" in a column of
+    // "CPT-1"s) starts left of the column's start and its left edge alone
+    // reads as the column before. The cell's whole extent decides: the column
+    // whose interval it overlaps most owns it (#374). A short cell sitting on
+    // its start is unchanged — its extent lies inside one interval.
+    if (cols.coord === "left" && (t.w || 0) > 0) {
+      const x1 = t.x + (t.w || 0);
+      let best = label, bestOv = -1;
+      for (let ci = 0; ci < cols.cols.length; ci++) {
+        const lo = cols.cols[ci].start, hi = ci + 1 < cols.cols.length ? cols.cols[ci + 1].start : Infinity;
+        const ov = Math.min(hi, x1) - Math.max(lo, t.x);
+        if (ov > bestOv) { bestOv = ov; best = cols.cols[ci].label; }
+      }
+      if (bestOv > 0) label = best;
+    }
     return label;
   };
   const add = (row: TableRow, toks: GraphSpan[]) => {

--- a/web/test/sheetgraph.test.ts
+++ b/web/test/sheetgraph.test.ts
@@ -1171,3 +1171,65 @@ test("#356: TAG-keyed materials schedule extracts as kind finish; keynote lists 
   };
   assert.equal(extractTable(keynoteSheet, "finish"), null);
 });
+
+// ── two-tier Revit header (#374) ────────────────────────────────────────────
+// The Dublin A-601 finish plan carries its schedule on the plan sheet with the
+// surfaces on a PARENT tier and the defining columns on the tier below:
+//   CEILING | FLOOR  |    BASE    |  WAINSCOT  |      WALL FINISH
+//   ROOM # | ROOM NAME | FINISH | FINISH | MAT | HT | MAT | HT | EAST NORTH SOUTH | WEST
+// The defining tier carries no FLOOR/BASE word of its own, so the descent
+// refused it, the key column never anchored, and the walker read the sheet's
+// grid bubbles far below as rows: 21 rows read as 2, and resolve_tag answered
+// "no schedule row" for rooms that had one.
+const dublinTiers: SheetSpans = {
+  key: "dublin.pdf#1",
+  sheet_number: "A-601",
+  spans: [
+    sp("PHASE I - ROOM FINISH SCHEDULE", 300, 30),
+    sp("CEILING", 300, 60), sp("FLOOR", 400, 60), sp("BASE", 520, 60), sp("WAINSCOT", 680, 60), sp("WALL FINISH", 860, 60),
+    sp("ROOM #", 100, 72), sp("ROOM NAME", 160, 72), sp("FINISH", 300, 72), sp("FINISH", 400, 72), sp("MAT", 500, 72), sp("HT", 560, 72), sp("MAT", 660, 72), sp("HT", 720, 72), sp("EAST NORTH SOUTH", 800, 72), sp("WEST", 940, 72),
+    sp("103", 100, 90), sp("IV TESTING", 160, 90), sp("ACT-1", 300, 90), sp("CPT-1", 400, 90), sp("RB-1", 500, 90), sp("4\"", 560, 90), sp("--", 660, 90), sp("--", 720, 90), sp("PT-2", 800, 90), sp("PT-2", 940, 90),
+    sp("103A", 100, 106), sp("STG", 160, 106),
+    sp("110", 100, 122), sp("RESTROOM", 160, 122), sp("ACT-1", 300, 122), sp("CFT-1", 400, 122), sp("CTB-1", 500, 122), sp("4\"", 560, 122), sp("CWT-1", 660, 122), sp("4' - 0\"", 720, 122), sp("WC-1", 800, 122), sp("WC-1", 940, 122),
+    sp("111", 100, 138), sp("RESTROOM", 160, 138), sp("ACT-1", 300, 138), sp("CFT-1", 400, 138), sp("CTB-1", 500, 138), sp("4\"", 560, 138), sp("CWT-1", 660, 138), sp("4' - 0\"", 720, 138), sp("WC-1", 800, 138), sp("WC-1", 940, 138),
+    sp("CR11-9", 100, 154), sp("CORRIDOR", 160, 154), sp("ACT-1", 300, 154), sp("LVT-1 / LVT-2", 400, 154), sp("PRB-1", 500, 154), sp("4\"", 560, 154), sp("--", 660, 154), sp("--", 720, 154), sp("PT-1", 800, 154), sp("PT-1", 940, 154),
+    // the plan below the schedule: grid bubbles and a room tag, keyed-looking, far down
+    sp("18", 300, 700), sp("19", 400, 700), sp("RESTROOM", 900, 800), sp("110", 904, 812),
+    sp("FLOOR PLAN - PHASE I - FINISH PLAN", 300, 900), sp("1/8\" = 1'-0\"", 300, 912),
+  ],
+};
+
+test("#374: a two-tier header anchors the key column from the lower tier; surfaces keep their names", () => {
+  const rf = extractTable(dublinTiers, "room-finish")!;
+  assert.ok(rf, "the table is found");
+  assert.deepEqual(rf.rows.map((r) => r.key), ["103", "103A", "110", "111", "CR11-9"], "every schedule row, and NOT the plan's grid bubbles below it");
+  assert.equal(rf.title?.text, "PHASE I - ROOM FINISH SCHEDULE");
+  const r110 = rf.rows.find((r) => r.key === "110")!;
+  assert.equal(r110.cells["FLOOR FINISH"].text, "CFT-1", "FINISH under FLOOR takes its parent's name");
+  assert.equal(r110.cells["CEILING FINISH"].text, "ACT-1");
+  assert.equal(r110.cells["BASE MAT"].text, "CTB-1", "MAT under BASE takes its parent's name");
+  assert.equal(r110.cells["BASE HT"].text, "4\"", "BASE over HT keeps both halves");
+  assert.equal(r110.cells["WAINSCOT MAT"].text, "CWT-1");
+  assert.equal(r110.cells["WAINSCOT HT"].text, "4' - 0\"");
+  assert.equal(r110.cells.NAME.text, "RESTROOM");
+  assert.ok(["EAST", "NORTH", "SOUTH", "WEST"].every((w) => rf.headers.includes(w)), `one run "EAST NORTH SOUTH" is three columns: ${rf.headers.join(" | ")}`);
+  const r103a = rf.rows.find((r) => r.key === "103A")!;
+  assert.equal(r103a.cells.NAME.text, "STG");
+  assert.equal(r103a.cells["FLOOR FINISH"], undefined, "a row with no floor cell says so by absence, never a neighbour's value");
+});
+
+test("#374: resolve_tag answers FLOOR / BASE / WAINSCOT for a room on a two-tier schedule", () => {
+  const g = buildSheetGraph([dublinTiers]);
+  const r = resolveTag(g, "110");
+  assert.equal(r.status, "resolved");
+  const by = Object.fromEntries((r as any).finishes.map((f: any) => [f.surface, f.code]));
+  assert.equal(by["FLOOR FINISH"], "CFT-1");
+  assert.equal(by["BASE MAT"], "CTB-1");
+  assert.equal(by["BASE HT"], "4\"");
+  assert.equal(by["WAINSCOT MAT"], "CWT-1");
+  assert.equal(by["CEILING FINISH"], "ACT-1");
+  assert.equal((r as any).finishes[0].surface, "FLOOR FINISH", "FLOOR still leads the answer");
+  const u = resolveTag(g, "103A");
+  assert.equal(u.status, "unresolved");
+  assert.match((u as any).reason, /no finish cells/, "103A has a row but no finishes — the reason says so, not 'no row'");
+});


### PR DESCRIPTION
Closes #374.

**What was wrong.** Dublin A-601 carries its room-finish schedule on the plan sheet with the surfaces on a parent tier and the defining columns on the tier below. The descent between tiers demanded the required surface words of the lower tier too, which by construction carries none (`[].some()` reads false), so the key column never anchored, the walker read the sheet's grid bubbles far below as rows (2 rows: "18", "2"), and `resolve_tag 110` answered "no schedule row".

**Changes, each measured on that sheet** (`web/src/lib/sheetgraph.ts`):
- the descent trusts the tier above for the required words;
- MAT / MATERIAL / COMMENTS join the room-finish header vocabulary;
- a header run of several surface words ("EAST NORTH SOUTH") is one column per word;
- a sub-column whose merged parent is centred over its sibling inherits the sibling's parent (BASE over MAT | HT gives "BASE MAT", "BASE HT");
- a parent-tier word two column pitches outside the band (the finish-abbreviation list beside the schedule: "RUBBER BASE", "CERAMIC FLOOR TILE") never mints a column;
- cells band by the interval they overlap; placeholder dashes vote for a column's existence but never for its start (Revit centres its codes and left-aligns its names);
- "CR11-9" / "CR11-10" are row keys ("T1"-style two-character tags are not);
- `detect_rooms assign_from_schedule` finds the FLOOR cell under its two-tier name ("FLOOR FINISH").

**Proof, server run from this branch on the Dublin sheet** (`evals/four-asks-2026-09-02/sheets/`):

| Verb | Before | After |
|---|---|---|
| `find_schedule room finish` | rows 2 | **rows 20** (100–116, 103A, CR11-9, CR11-10), headers ROOM · NAME · CEILING FINISH · FLOOR FINISH · BASE MAT · BASE HT · WAINSCOT MAT · WAINSCOT HT · EAST · NORTH · SOUTH · WEST · COMMENTS |
| `resolve_tag 110` | unresolved, "no schedule row" | resolved: FLOOR FINISH CFT-1, BASE MAT CTB-1, BASE HT 4", WAINSCOT MAT CWT-1, WAINSCOT HT 4'-0", walls WC-1 |
| `resolve_tag 103A` | "no schedule row" | "row 103A exists but carries no finish cells" (it is STG with every cell blank) |
| `resolve_tag CR11-9` | "no schedule row" | resolved: FLOOR FINISH LVT-1 / LVT-2 (a compound cell, which assign mode withholds as ambiguous by design) |

Every row of the real table checked cell by cell against the drawing, including the short names (TR, HAC, STG) and the four restrooms' CWT-1 wainscot column that a dash-majority column start had been swallowing.

Regression: the bundled sample plan still reads exactly its 29 rows; the pre-existing three-tier, rotated-header, continuation, multi-building and door-schedule fixtures all hold. Tests: `web/test/sheetgraph.test.ts` +2 (a Dublin-shaped two-tier fixture with grid bubbles below it; resolve through the graph). 37/37 sheetgraph, 193/193 mcp, web `npm run check` green on Node 24. mcp 0.9.71 on all four version surfaces + CHANGELOG.

Note: with only this branch, `assign_from_schedule` on A-601 still commits the room-number boxes (12 SF) under their rows; that is #373 / PR #379. The two together are the finish line: every labeled room under its own row's floor finish.

Hand test: load the Dublin A-601 sheet, run `find_schedule {kind: "room finish"}` (20 rows) and `resolve_tag 110`.