### PR TITLE
docs: research@kentucky-ai.com is the contact address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at michael@kentucky-ai.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at research@kentucky-ai.com. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/README.md
+++ b/README.md
@@ -712,6 +712,10 @@ instrument producing it.
 
 — Michael · [Kentucky AI](https://kentucky-ai.com)
 
+**Contact:** research collaborations, data questions, press, or anything that is not a bug —
+[research@kentucky-ai.com](mailto:research@kentucky-ai.com). Bugs and feature requests go in
+[issues](https://github.com/Kentucky-ai/opentakeoff/issues); security reports follow [SECURITY.md](SECURITY.md).
+
 ## License
 
 [Apache License 2.0](LICENSE)—use it, [fork it](#fork-it), ship it, build on top of it. See

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting
 
-Use GitHub's **[private vulnerability reporting](https://github.com/Kentucky-ai/opentakeoff/security/advisories/new)**—Security tab → Report a vulnerability. It is enabled on this repo, it keeps the report private until there's a fix, and it gets a real answer. Don't open a public issue for something you believe is exploitable.
+Use GitHub's **[private vulnerability reporting](https://github.com/Kentucky-ai/opentakeoff/security/advisories/new)**—Security tab → Report a vulnerability. It is enabled on this repo, it keeps the report private until there's a fix, and it gets a real answer. Don't open a public issue for something you believe is exploitable. If you can't use the GitHub form, email [research@kentucky-ai.com](mailto:research@kentucky-ai.com) with the same detail.
 
 Expect a first response within about a week. If a report is valid we'll agree on a disclosure date with you and credit you in the advisory unless you'd rather not be named.
 


### PR DESCRIPTION
README gains a **Contact** line under *Who's building this* (research collaborations, data questions, press → research@kentucky-ai.com; bugs → issues; security → SECURITY.md). CODE_OF_CONDUCT's enforcement address and SECURITY.md's fallback both point at the same address. Docs only; no code, no version change. The repo's homepage field was switched from the netlify.app host to https://opentakeoff.kentucky-ai.com alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)