### PR TITLE
Microsoft 365 sync: harden the real-tenant corners ahead of the live proof (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OpenTakeoff. Dates are release/merge dates on `main`.
 
+## Unreleased — Microsoft 365 sync: the real-tenant corners, hardened ahead of the live proof (#315)
+
+### Changed
+- **The Graph client survives a revoked token.** A 401 mid-session now asks MSAL for one forced refresh and retries with the new token; a second 401 surfaces as a readable *sign in again* state (`GraphAuthError`, stage `sign-in`) instead of reading as "offline" forever. 403 names the permission stage.
+- **File content is read through the item's pre-authenticated download URL with no bearer** — the documented browser path — instead of following the `/content` redirect with an Authorization header, which is the corner where business SharePoint and consumer OneDrive diverge. The `/content` stream stays as the fallback for an item with no download URL.
+- **Throttling covers 504 and honors `Retry-After` as an HTTP-date** as well as seconds.
+- **Every MSAL sign-in failure names its stage** — consent, tenant, app registration, popup, network, sign-in — with the AADSTS code, so a tester's report says which stage broke (`web/src/lib/msgraph/errors.js`). Web only, no MCP change.
+- `SELF_HOSTING.md` gains a **no-tenant test path** (a personal Microsoft account's OneDrive against a free Entra registration with `VITE_MSAL_TENANT=consumers`) — the finish line on #315 is still a live two-machine round trip, and this is the way to run one without a business tenant.
+
 ## Unreleased — Scope collision: two conditions claiming the same floor, as a number that has to read zero (mcp 0.9.75, #366)
 
 ### Added

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -90,6 +90,56 @@ the same sidecar, rev discipline, three-way merge, and presence heartbeats the
 folder and Drive transports use. "Stop" (landing or Manage panel) opts back
 out without touching local work.
 
+### No tenant? Test with a personal Microsoft account
+
+You do not need a business tenant to run the live round trip. Any Microsoft
+account (outlook.com / hotmail.com / live.com) has a consumer OneDrive, which is
+a Graph drive like any SharePoint library, and an app registration can be made
+in a free Entra tenant:
+
+1. [Sign up for a free Azure account](https://azure.microsoft.com/free) — it
+   comes with an Entra tenant you administer. No subscription is needed for an
+   app registration.
+2. Register the app as in step 1 above, but choose **Accounts in any
+   organizational directory and personal Microsoft accounts** as the supported
+   account type. `Files.ReadWrite.All` is a delegated permission personal
+   accounts grant themselves at sign-in — no admin consent.
+3. In Graph Explorer, signed in with the personal account: `GET /me/drive` →
+   `id`. That is `VITE_GRAPH_DRIVE_ID`; leave the folder as `root` or create a
+   folder and use its item id.
+4. Configure the build with `VITE_MSAL_TENANT=consumers` (or `common` if you
+   will test both account types) and sign in with the personal account.
+
+Two browsers (or one normal window and one incognito window signed into the
+same account) are the two machines for the round trip. Report the result as a
+consumer-OneDrive run — the corners it shares with business SharePoint are the
+sign-in, the download path and throttling; the corners it does not are
+admin-consent policies and library permissions.
+
+### What the client does at the corners a tenant may hit
+
+Written to Graph's documented contract and exercised against a mock tenant in
+`web/test/graphDrive.test.ts` — but only a real tenant proves them:
+
+- **A token the tenant revokes mid-session** (consent changed, password reset,
+  conditional access): Graph answers 401; the client asks MSAL for **one
+  forced refresh** and retries with the new token. A second 401 is surfaced
+  as *"Microsoft 365 rejected the sign-in token … sign in again"* — never a
+  silent "offline".
+- **File content** is read through the item's `@microsoft.graph.downloadUrl`
+  with **no Authorization header**. The `/content` stream redirects to that
+  same URL on a different host, and whether a bearer on the redirected request
+  is ignored or refused is exactly where business SharePoint and consumer
+  OneDrive diverge; fetching the URL bare removes the question.
+- **Throttling**: 429, 503 and 504 honor `Retry-After` in seconds or as an
+  HTTP-date, capped at 15 s per wait, three tries, then a throw the reconciler
+  reads as offline until its next poll.
+- **403** names the permission stage (the account cannot reach the library, or
+  the app lacks `Files.ReadWrite.All`).
+- **Sign-in failures** name their stage in the landing screen — *consent*,
+  *tenant*, *app registration*, *popup*, *network*, *sign-in* — with the
+  AADSTS code in parentheses (`web/src/lib/msgraph/errors.js`).
+
 ### What to report on #315
 
 - tenant type (business SharePoint / consumer OneDrive) and whether admin

--- a/web/src/lib/msgraph/auth.js
+++ b/web/src/lib/msgraph/auth.js
@@ -18,6 +18,7 @@
 // pull MSAL in.
 
 import { PublicClientApplication } from "@azure/msal-browser";
+import { describeMsalError } from "./errors.js";
 
 const SCOPES = ["Files.ReadWrite.All"];
 
@@ -46,7 +47,14 @@ export function createMsalAuth(cfg) {
     /** Interactive sign-in — MUST run in a user gesture (popup). */
     async signIn() {
       await init();
-      const res = await pca.loginPopup({ scopes: SCOPES, prompt: "select_account" });
+      let res;
+      try {
+        res = await pca.loginPopup({ scopes: SCOPES, prompt: "select_account" });
+      } catch (e) {
+        // every failure names its stage — consent, tenant, popup — so a
+        // tester's report says which one broke without reading MSAL codes
+        throw new Error(describeMsalError(e));
+      }
       if (res?.account) pca.setActiveAccount(res.account);
       return res?.account || account();
     },
@@ -62,16 +70,24 @@ export function createMsalAuth(cfg) {
     // The injected token source the Graph client takes — silent first, popup
     // fallback (which throws outside a gesture; callers treat that as
     // "needs sign-in", a readable state, not a crash loop).
-    async getToken() {
+    // `forceRefresh` is what the Graph client asks for ONCE after a 401 — MSAL
+    // skips its cache and goes to the token endpoint; a token the tenant
+    // revoked (consent change, password reset, conditional access) fails
+    // there with a readable reason instead of a cached zombie.
+    async getToken({ forceRefresh = false } = {}) {
       await init();
       const acc = account();
       if (!acc) throw new Error("m365: not signed in");
       try {
-        const res = await pca.acquireTokenSilent({ scopes: SCOPES, account: acc });
+        const res = await pca.acquireTokenSilent({ scopes: SCOPES, account: acc, forceRefresh });
         return res.accessToken;
-      } catch {
-        const res = await pca.acquireTokenPopup({ scopes: SCOPES, account: acc });
-        return res.accessToken;
+      } catch (silentErr) {
+        try {
+          const res = await pca.acquireTokenPopup({ scopes: SCOPES, account: acc });
+          return res.accessToken;
+        } catch (e) {
+          throw new Error(describeMsalError(e, silentErr));
+        }
       }
     },
   };

--- a/web/src/lib/msgraph/errors.js
+++ b/web/src/lib/msgraph/errors.js
@@ -1,0 +1,45 @@
+// MSAL failure → one readable sentence naming the STAGE that broke (#315).
+// Pure and dependency-free so it is unit-tested without MSAL, and so the
+// sign-in surface never shows a bare AADSTS code to an estimator.
+//
+// The codes below are MSAL's documented `errorCode` values plus the AADSTS
+// numbers a tenant returns for the corners the RFC names: admin-consent
+// policies, a personal account against a single-tenant app (and vice versa),
+// a redirect URI that does not match the registration, a blocked popup, and
+// a token the tenant revoked between sessions.
+
+const AADSTS = [
+  [/AADSTS65001|consent_required/i, "consent", "your tenant has not consented to this app: an admin must grant Files.ReadWrite.All (SELF_HOSTING.md, Microsoft 365 → step 1)"],
+  [/AADSTS650(52|53|57)|admin_consent/i, "consent", "the app needs admin consent in your tenant before users can grant it (SELF_HOSTING.md, Microsoft 365 → step 1)"],
+  [/AADSTS50020|AADSTS90072/i, "tenant", "this account does not belong to the tenant the build was configured for (VITE_MSAL_TENANT) — sign in with a work account from that tenant, or configure the build for the account type you use"],
+  [/AADSTS50011|redirect_uri/i, "app registration", "the redirect URI does not match the app registration — add this exact origin under the Single-page application platform"],
+  [/AADSTS700016|unauthorized_client/i, "app registration", "the client id was not found in the tenant — check VITE_MSAL_CLIENT_ID and that the registration allows this account type"],
+  [/AADSTS7000218/i, "app registration", "the registration is not a Single-page application (it is asking for a client secret) — re-register the platform as SPA"],
+  [/AADSTS50076|AADSTS50079|AADSTS50158|interaction_required/i, "sign-in", "the tenant requires a fresh interactive sign-in (MFA or conditional access) — click sign in again"],
+  [/AADSTS50173|AADSTS700082|AADSTS70008|token_renewal_error|invalid_grant/i, "sign-in", "the saved sign-in was revoked or expired — sign in again"],
+  [/popup_window_error|empty_window_error|BrowserAuthError: popup/i, "popup", "the browser blocked the sign-in popup — allow popups for this site and try again"],
+  [/user_cancelled|user_cancelled_error/i, "popup", "the sign-in popup was closed before it finished"],
+  [/monitor_window_timeout|BrowserAuthError: monitor/i, "popup", "the sign-in popup timed out — this happens when the redirect URI is not the app's own origin"],
+  [/no_network|network_error|Failed to fetch/i, "network", "the sign-in service could not be reached"],
+];
+
+/** @param {unknown} e the thrown MSAL error (message / errorCode / errorMessage)
+ *  @param {unknown} [prior] the silent-acquire error that preceded a popup attempt
+ *  @returns {string} "Microsoft 365 sign-in failed at <stage>: <what to do> (<original code>)" */
+export function describeMsalError(e, prior) {
+  const parts = [e, prior].filter(Boolean).map((x) => {
+    const o = /** @type {any} */ (x) || {};
+    return [o.errorCode, o.subError, o.errorMessage, o.message, typeof x === "string" ? x : ""].filter(Boolean).join(" | ");
+  });
+  // the error the user saw LAST decides the stage; the silent-acquire error
+  // that preceded a popup attempt is consulted only when the popup's own
+  // message names nothing (a generic failure after "interaction required")
+  for (const text of parts) {
+    const code = (text.match(/AADSTS\d+/) || [])[0] || (text.match(/^[a-z_]+/) || [])[0] || "";
+    for (const [re, stage, what] of AADSTS) {
+      if (re.test(text)) return `Microsoft 365 sign-in failed at ${stage}: ${what}${code ? ` (${code})` : ""}.`;
+    }
+  }
+  const raw = (/** @type {any} */ (e)?.message || String(e || "")).replace(/\s+/g, " ").trim();
+  return `Microsoft 365 sign-in failed: ${raw || "unknown error"} — report this text verbatim on issue #315.`;
+}

--- a/web/src/lib/msgraph/graphDrive.js
+++ b/web/src/lib/msgraph/graphDrive.js
@@ -18,19 +18,53 @@
 // there is no relay, no token store, no server of ours in the path. That
 // invariant is the security model and it is non-negotiable.
 //
-// Throttling (the RFC's named hazard): Graph answers 429 (and sometimes 503)
-// with a Retry-After. The reconciler treats provider throws as "offline", so
-// backoff lives HERE: honor Retry-After up to 3 attempts with a hard cap per
-// wait, then throw — a sustained throttle degrades to offline, never a wedge.
+// Throttling (the RFC's named hazard): Graph answers 429 (and sometimes 503 /
+// 504) with a Retry-After — in seconds, or as an HTTP-date. The reconciler
+// treats provider throws as "offline", so backoff lives HERE: honor Retry-After
+// up to 3 attempts with a hard cap per wait, then throw — a sustained throttle
+// degrades to offline, never a wedge.
+//
+// Real-tenant corners (#315 hardening, tenant-unproven but written to Graph's
+// documented contract so a tester's failure names its stage):
+// - A 401 mid-session is a token that expired or was revoked (consent changed,
+//   password reset, conditional-access re-evaluation). The client asks the
+//   token source ONCE for a forced refresh and retries; a second 401 throws a
+//   GraphAuthError naming the sign-in stage, which the gate shows instead of
+//   silently reading as "offline" forever.
+// - File content is read through the item's `@microsoft.graph.downloadUrl` —
+//   a short-lived pre-authenticated URL fetched with NO Authorization header.
+//   `/content` answers 302 to that same URL on a different host
+//   (*.sharepoint.com / *.1drv.com); a bearer on the redirected request is
+//   exactly the corner where business SharePoint and consumer OneDrive diverge
+//   (one ignores it, the other can refuse it), and browsers differ on whether
+//   they strip it. Reading the URL and fetching it bare removes the question.
 
 const GRAPH_BASE = "https://graph.microsoft.com/v1.0";
 // The sync layers compare against the Drive folder mime; the Graph client
 // speaks the same token so consumers stay provider-blind.
 const FOLDER_MIME = "application/vnd.google-apps.folder";
 
+/** A Graph reply that means "this browser is no longer signed in usefully" —
+ *  the token source could not produce a token Graph accepts. Surfaced as its
+ *  own class so the gate can say "sign in again" instead of "offline". */
+export class GraphAuthError extends Error {
+  constructor(message, status) { super(message); this.name = "GraphAuthError"; this.stage = "sign-in"; this.status = status; }
+}
+
+/** Retry-After as milliseconds: Graph sends seconds; RFC 7231 also allows an
+ *  HTTP-date. Anything unparseable → the fallback. */
+export function retryAfterMs(value, now = Date.now(), fallbackMs = 1000) {
+  if (value == null || value === "") return fallbackMs;
+  const secs = Number(value);
+  if (Number.isFinite(secs)) return secs >= 0 ? secs * 1000 : fallbackMs;
+  const at = Date.parse(String(value));
+  return Number.isFinite(at) ? Math.max(0, at - now) : fallbackMs;
+}
+
 /**
  * @param {object} opts
- * @param {() => Promise<string>} opts.getToken async access-token source (MSAL later; injected in tests)
+ * @param {(opts?: {forceRefresh?: boolean}) => Promise<string>} opts.getToken async access-token source
+ *   (MSAL in the app; injected in tests). Called with {forceRefresh: true} exactly once after a 401.
  * @param {string} opts.driveId   the document library's Graph drive id
  * @param {typeof fetch} [opts.fetch]    injectable for tests
  * @param {(ms:number)=>Promise<void>} [opts.sleep] injectable for tests
@@ -44,20 +78,32 @@ export function createGraphDrive({ getToken, driveId, fetch = globalThis.fetch, 
   const childPath = (parentId, name, suffix = "") =>
     `${base}/drives/${encodeURIComponent(driveId)}/items/${encodeURIComponent(parentId)}:/${encodeURIComponent(name)}${suffix ? `:${suffix}` : ""}`;
 
-  async function authHeaders(extra) {
-    const t = await getToken();
+  async function authHeaders(extra, tokenOpts) {
+    const t = await getToken(tokenOpts);
     return { Authorization: `Bearer ${t}`, ...extra };
   }
 
-  // fetch with Retry-After honor. Waits are capped (15 s) and bounded (3
-  // tries) so a hard throttle surfaces as a throw — "offline" upstream — not
-  // an unbounded stall under the user's autosave.
+  const THROTTLED = new Set([429, 503, 504]);
+
+  // fetch with Retry-After honor and ONE forced token refresh on 401. Waits
+  // are capped (15 s) and bounded (3 tries) so a hard throttle surfaces as a
+  // throw — "offline" upstream — not an unbounded stall under the user's
+  // autosave. `init.headers` is rebuilt for the retry after a 401 so the
+  // refreshed token is what goes out.
   async function graphFetch(url, init) {
+    let refreshed = false;
     for (let attempt = 0; ; attempt++) {
       const res = await fetch(url, init);
-      if ((res.status !== 429 && res.status !== 503) || attempt >= 2) return res;
-      const ra = Number(res.headers?.get?.("Retry-After"));
-      await sleep(Math.min(Number.isFinite(ra) && ra >= 0 ? ra * 1000 : 1000, 15_000));
+      if (res.status === 401 && !refreshed && init?.headers?.Authorization) {
+        refreshed = true;
+        let fresh;
+        try { fresh = await getToken({ forceRefresh: true }); }
+        catch (e) { throw new GraphAuthError(`Microsoft 365 sign-in expired and could not be refreshed silently — sign in again (${String(e?.message || e)}).`, 401); }
+        init = { ...init, headers: { ...init.headers, Authorization: `Bearer ${fresh}` } };
+        continue;
+      }
+      if (!THROTTLED.has(res.status) || attempt >= 2) return res;
+      await sleep(Math.min(retryAfterMs(res.headers?.get?.("Retry-After")), 15_000));
     }
   }
 
@@ -65,6 +111,8 @@ export function createGraphDrive({ getToken, driveId, fetch = globalThis.fetch, 
     if (res.ok) return res;
     let detail = "";
     try { detail = (await res.text()) || ""; } catch { /* body may be unreadable */ }
+    if (res.status === 401) throw new GraphAuthError(`Microsoft 365 rejected the sign-in token on ${what} (HTTP 401) even after a refresh — sign in again${detail ? `: ${detail}` : "."}`, 401);
+    if (res.status === 403) throw new GraphAuthError(`Microsoft 365 refused ${what} (HTTP 403) — the signed-in account cannot reach this library, or the app was not granted Files.ReadWrite.All (see SELF_HOSTING.md, Microsoft 365 → step 1)${detail ? `: ${detail}` : "."}`, 403);
     throw new Error(`Graph ${what} failed (HTTP ${res.status})${detail ? `: ${detail}` : ""}.`);
   }
 
@@ -99,7 +147,27 @@ export function createGraphDrive({ getToken, driveId, fetch = globalThis.fetch, 
   }
 
   async function getFileBytes(fileId) {
-    // /content answers 302 to a pre-authenticated download URL; fetch follows.
+    // The item's pre-authenticated download URL, fetched BARE (no bearer): the
+    // documented browser path, and the one that does not depend on what a
+    // given tenant's download host does with an Authorization header.
+    const meta = await graphFetch(`${item(fileId)}?$select=id,content.downloadUrl`, { headers: await authHeaders() });
+    await assertOk(meta, "download");
+    const data = await meta.json();
+    const url = data["@microsoft.graph.downloadUrl"];
+    if (typeof url === "string" && url) {
+      const res = await graphFetch(url, { method: "GET" });
+      if (res.ok) return new Uint8Array(await res.arrayBuffer());
+      // the short-lived URL can expire between the two calls — one more
+      // round through the item, then give up readably
+      const again = await graphFetch(`${item(fileId)}?$select=id,content.downloadUrl`, { headers: await authHeaders() });
+      await assertOk(again, "download");
+      const url2 = (await again.json())["@microsoft.graph.downloadUrl"];
+      const res2 = url2 ? await graphFetch(url2, { method: "GET" }) : res;
+      await assertOk(res2, "download (pre-authenticated URL)");
+      return new Uint8Array(await res2.arrayBuffer());
+    }
+    // no downloadUrl on the item (a folder, a zero-byte placeholder, an odd
+    // tenant): the /content stream with the bearer, as before
     const res = await graphFetch(`${item(fileId)}/content`, { headers: await authHeaders() });
     await assertOk(res, "download");
     return new Uint8Array(await res.arrayBuffer());

--- a/web/test/fixtures/mockGraph.ts
+++ b/web/test/fixtures/mockGraph.ts
@@ -5,7 +5,9 @@ export const BASE = "https://graph.test/v1.0";
 export const FOLDER_MIME = "application/vnd.google-apps.folder";
 
 // ── a tiny Graph tenant: driveItems in memory, real URL shapes ─────────────
-export function mockGraph({ pageSize = 200 }: { pageSize?: number } = {}) {
+export const DOWNLOAD_HOST = "https://download.test";
+
+export function mockGraph({ pageSize = 200, downloadUrls = true, expireToken = 0 }: { pageSize?: number; downloadUrls?: boolean; expireToken?: number } = {}) {
   type Item = { id: string; name: string; parentId: string | null; folder: boolean; content: Uint8Array | null };
   const items = new Map<string, Item>();
   items.set("root", { id: "root", name: "root", parentId: null, folder: true, content: null });
@@ -17,6 +19,9 @@ export function mockGraph({ pageSize = 200 }: { pageSize?: number } = {}) {
   const asItem = (i: Item) => ({
     id: i.id, name: i.name, lastModifiedDateTime: "2026-08-24T00:00:00Z", size: i.content?.length ?? 0,
     ...(i.folder ? { folder: { childCount: childrenOf(i.id).length } } : { file: { mimeType: "application/json" } }),
+    // the pre-authenticated download URL a real tenant hands out on a file
+    // item — a different host, short-lived, no auth expected
+    ...(!i.folder && downloadUrls ? { "@microsoft.graph.downloadUrl": `${DOWNLOAD_HOST}/dl/${i.id}?tempauth=t` } : {}),
   });
 
   const resp = (status: number, body: any = null, headers: Record<string, string> = {}) => ({
@@ -29,10 +34,25 @@ export function mockGraph({ pageSize = 200 }: { pageSize?: number } = {}) {
   });
 
   const calls: string[] = [];
+  const tokensSeen: string[] = [];
+  let expireLeft = expireToken;
   async function fetchImpl(url: string, init: any = {}) {
     const method = (init.method || "GET").toUpperCase();
     calls.push(`${method} ${url}`);
+    // the download host: a pre-authenticated URL, and a bearer on it is the
+    // corner tenants disagree on — the mock REFUSES it, so a client that
+    // leaks the token onto the redirect host fails here instead of in the field
+    if (url.startsWith(DOWNLOAD_HOST)) {
+      if (init.headers?.Authorization) return resp(401, { error: "bearer on a pre-authenticated URL" });
+      const it = items.get(url.match(/\/dl\/([^?]+)/)?.[1] || "");
+      if (!it || it.folder) return resp(404, { error: "expired" });
+      return resp(200, it.content ?? new Uint8Array());
+    }
     if (!init.headers?.Authorization?.startsWith("Bearer ")) return resp(401, { error: "no token" });
+    tokensSeen.push(init.headers.Authorization.slice(7));
+    // an expired / revoked token: the first `expireToken` authenticated calls
+    // answer 401 (the tenant re-evaluated the session), then accept
+    if (expireLeft > 0) { expireLeft--; return resp(401, { error: { code: "InvalidAuthenticationToken", message: "Access token has expired" } }); }
     const u = new URL(url);
     const path = decodeURIComponent(u.pathname);
     const m = path.match(/\/drives\/([^/]+)\/items\/(.+)$/);
@@ -114,6 +134,6 @@ export function mockGraph({ pageSize = 200 }: { pageSize?: number } = {}) {
     return resp(400, { error: `unhandled ${method} ${rest}` });
   }
 
-  return { fetchImpl, items, calls };
+  return { fetchImpl, items, calls, tokensSeen };
 }
 

--- a/web/test/graphDrive.test.ts
+++ b/web/test/graphDrive.test.ts
@@ -8,11 +8,11 @@ import "fake-indexeddb/auto";
 import { IDBFactory } from "fake-indexeddb";
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { createGraphDrive } from "../src/lib/msgraph/graphDrive.js";
+import { createGraphDrive, GraphAuthError, retryAfterMs } from "../src/lib/msgraph/graphDrive.js";
 import { createDriveProvider } from "../src/lib/sync/provider.js";
 import { createSyncStore } from "../src/lib/sync/syncStore.js";
 import { createLocalStore } from "../src/lib/store.js";
-import { BASE, FOLDER_MIME, mockGraph } from "./fixtures/mockGraph.ts";
+import { BASE, FOLDER_MIME, DOWNLOAD_HOST, mockGraph } from "./fixtures/mockGraph.ts";
 
 beforeEach(() => {
   (globalThis as any).indexedDB = new IDBFactory();
@@ -155,4 +155,69 @@ test("#315 finish line: two-machine push/pull/conflict round-trip through one Gr
   const finalPull: any = await createDriveProvider("root", clientOver(g), { ensureSidecarId: sidecarResolver(clientOver(g)) }).pull();
   assert.equal(finalPull.rev, 3);
   assert.deepEqual(shapeIds(finalPull.data), ["LA", "LB", "S1"]);
+});
+
+// ── #315 hardening: the real-tenant corners, over the mock tenant ──────────
+
+test("file content is read through the item's pre-authenticated download URL with NO bearer; the /content stream is the fallback only when the item has none", async () => {
+  const g = mockGraph();
+  const c = clientOver(g);
+  const f: any = await c.createFolder("root", ".opentakeoff");
+  const put: any = await c.putJson({ folderId: f.id, name: "annotations.json", data: { rev: 7 } });
+  g.calls.length = 0;
+  assert.deepEqual(await c.getJson(put.id), { rev: 7 });
+  assert.ok(g.calls.some((u) => u.includes(`/items/${put.id}?$select=id,content.downloadUrl`)), "reads the URL off the item");
+  assert.ok(g.calls.some((u) => u.startsWith(`GET ${DOWNLOAD_HOST}/dl/${put.id}`)), "then fetches it on the download host (which refuses a bearer)");
+  assert.ok(!g.calls.some((u) => u.endsWith("/content")), "never the /content redirect");
+
+  const plain = mockGraph({ downloadUrls: false });   // a tenant that hands out no downloadUrl on the item
+  const c2 = clientOver(plain);
+  const f2: any = await c2.createFolder("root", ".opentakeoff");
+  const put2: any = await c2.putJson({ folderId: f2.id, name: "annotations.json", data: { rev: 1 } });
+  assert.deepEqual(await c2.getJson(put2.id), { rev: 1 });
+  assert.ok(plain.calls.some((u) => u === `GET ${BASE}/drives/d1/items/${put2.id}/content`), "the /content stream with the bearer, as before");
+});
+
+test("a 401 mid-session asks the token source for ONE forced refresh and retries with the new token; a second 401 is a readable sign-in error, not 'offline'", async () => {
+  const g = mockGraph({ expireToken: 1 });
+  const asks: any[] = [];
+  let n = 0;
+  const c = createGraphDrive({ getToken: async (opts?: any) => { asks.push(opts); return `tok${++n}`; }, driveId: "d1", fetch: g.fetchImpl as any, base: BASE });
+  const f: any = await c.createFolder("root", ".opentakeoff");
+  assert.equal(f.name, ".opentakeoff", "the call succeeded after the refresh");
+  assert.deepEqual(asks, [undefined, { forceRefresh: true }], "exactly one forced refresh");
+  assert.deepEqual(g.tokensSeen, ["tok1", "tok2"], "the retry carried the NEW token");
+
+  const dead = mockGraph({ expireToken: 99 });
+  const c2 = createGraphDrive({ getToken: async () => "tok", driveId: "d1", fetch: dead.fetchImpl as any, base: BASE });
+  await assert.rejects(c2.findChild("root", "x"), (e: any) => e instanceof GraphAuthError && e.stage === "sign-in" && /sign in again/.test(e.message));
+  assert.equal(dead.tokensSeen.length, 2, "one retry, then stop — never a refresh loop");
+
+  const refuse = mockGraph({ expireToken: 1 });
+  const c3 = createGraphDrive({ getToken: async (opts?: any) => { if (opts?.forceRefresh) throw new Error("interaction_required"); return "tok"; }, driveId: "d1", fetch: refuse.fetchImpl as any, base: BASE });
+  await assert.rejects(c3.findChild("root", "x"), (e: any) => e instanceof GraphAuthError && /could not be refreshed silently/.test(e.message) && /interaction_required/.test(e.message));
+});
+
+test("403 names the permission stage; 504 is throttled like 429; Retry-After as an HTTP-date is honored", async () => {
+  const g = mockGraph();
+  const forbidding = async (url: string, init: any) => (url.includes("/children") ? { ok: false, status: 403, headers: { get: () => null }, json: async () => ({}), text: async () => "Access denied", arrayBuffer: async () => new ArrayBuffer(0) } : g.fetchImpl(url, init));
+  const c = createGraphDrive({ getToken: async () => "tok", driveId: "d1", fetch: forbidding as any, base: BASE });
+  await assert.rejects(c.listChildren("root"), (e: any) => e instanceof GraphAuthError && /Files\.ReadWrite\.All/.test(e.message) && e.status === 403);
+
+  let gateways = 1;
+  const sleeps: number[] = [];
+  const now = Date.now();
+  const flaky = async (url: string, init: any) => {
+    if (gateways > 0) { gateways--; return { ok: false, status: 504, headers: { get: (k: string) => (k === "Retry-After" ? new Date(now + 3000).toUTCString() : null) }, json: async () => ({}), text: async () => "gateway", arrayBuffer: async () => new ArrayBuffer(0) }; }
+    return g.fetchImpl(url, init);
+  };
+  const c2 = createGraphDrive({ getToken: async () => "tok", driveId: "d1", fetch: flaky as any, base: BASE, sleep: async (ms: number) => { sleeps.push(ms); } });
+  const f: any = await c2.createFolder("root", "z");
+  assert.equal(f.name, "z");
+  assert.equal(sleeps.length, 1);
+  assert.ok(sleeps[0] > 1500 && sleeps[0] <= 3000, `HTTP-date Retry-After → ~3 s wait, got ${sleeps[0]}`);
+  assert.equal(retryAfterMs("2"), 2000);
+  assert.equal(retryAfterMs("garbage"), 1000);
+  assert.equal(retryAfterMs(null, 0, 500), 500);
+  assert.equal(retryAfterMs(new Date(10_000).toUTCString(), 4_000), 6000);
 });

--- a/web/test/msalErrors.test.ts
+++ b/web/test/msalErrors.test.ts
@@ -1,0 +1,26 @@
+// #315: every MSAL failure names the STAGE that broke, in words an estimator
+// can act on and a tester can report — never a bare AADSTS code.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { describeMsalError } from "../src/lib/msgraph/errors.js";
+
+test("consent, tenant, registration, popup, network and revoked-token failures each name their stage and carry the original code", () => {
+  const cases: Array<[any, RegExp]> = [
+    [{ errorCode: "consent_required", errorMessage: "AADSTS65001: The user or administrator has not consented" }, /at consent: .*admin must grant Files\.ReadWrite\.All.*\(AADSTS65001\)/],
+    [{ message: "AADSTS90072: User account from identity provider does not exist in tenant" }, /at tenant: .*VITE_MSAL_TENANT/],
+    [{ message: "AADSTS50011: The redirect URI specified in the request does not match" }, /at app registration: .*redirect URI/],
+    [{ message: "AADSTS7000218: The request body must contain the following parameter: 'client_assertion'" }, /at app registration: .*Single-page application/],
+    [{ errorCode: "interaction_required", errorMessage: "AADSTS50076: Due to a configuration change made by your administrator" }, /at sign-in: .*fresh interactive sign-in/],
+    [{ errorCode: "popup_window_error" }, /at popup: .*allow popups/],
+    [{ errorCode: "user_cancelled" }, /at popup: .*closed before it finished/],
+    [new TypeError("Failed to fetch"), /at network/],
+  ];
+  for (const [err, re] of cases) assert.match(describeMsalError(err), re, JSON.stringify(err));
+});
+
+test("the silent-acquire error is consulted when the popup fails generically; an unknown error is passed through verbatim with the report instruction", () => {
+  assert.match(describeMsalError({ errorCode: "popup_window_error" }, { errorCode: "interaction_required", errorMessage: "AADSTS50079: MFA required" }), /at popup/, "the popup failure is what the user saw last");
+  assert.match(describeMsalError({ message: "something new" }, { errorCode: "consent_required" }), /at consent/, "but a generic popup message defers to the silent error's code");
+  assert.equal(describeMsalError({ message: "  odd   thing  " }), "Microsoft 365 sign-in failed: odd thing — report this text verbatim on issue #315.");
+  assert.equal(describeMsalError(undefined), "Microsoft 365 sign-in failed: unknown error — report this text verbatim on issue #315.");
+});


### PR DESCRIPTION
## What & why

Toward #315 — which stays **open**: its finish line is a live two-machine round trip through a real tenant, and nobody on this project has one. What this PR does is harden the corners a tester will hit, each written to Graph's documented contract and exercised against the mock tenant, so a failure in the field names its stage instead of reading as "offline".

- **A token the tenant revokes mid-session** (consent change, password reset, conditional access): Graph answers 401; the client asks MSAL for **one forced refresh** and retries with the new token. A second 401 is a `GraphAuthError` (stage `sign-in`) — *sign in again* — never a silent offline loop. 403 names the permission stage.
- **File content is read through the item's `@microsoft.graph.downloadUrl` with no Authorization header** — the documented browser path. `/content` answers 302 to that URL on a different host, and whether a bearer on the redirected request is ignored or refused is exactly where business SharePoint and consumer OneDrive diverge (and browsers differ on stripping it). Fetching the URL bare removes the question; `/content` stays as the fallback for an item with no download URL.
- **Throttling** covers 504 and honors `Retry-After` as an HTTP-date as well as seconds.
- **Every MSAL failure names its stage** — consent, tenant, app registration, popup, network, sign-in — with the AADSTS code (`web/src/lib/msgraph/errors.js`, pure and unit-tested), in the landing screen and the Manage panel.
- `SELF_HOSTING.md` gains a **no-tenant test path**: a personal Microsoft account's OneDrive against a free Entra registration with `VITE_MSAL_TENANT=consumers`.

Web only; no MCP change, no version bump.

## How it was verified

- [x] Node v24.18.0 `npm run check` in `web/` — green (1733 passing). The mock tenant now hands out download URLs on a host that **refuses a bearer** and can expire tokens; `graphDrive.test.ts` covers the download path (and the `/content` fallback), one forced refresh with the NEW token on the retry, the readable second-401 and refresh-refused states, 403, 504 with an HTTP-date `Retry-After`, and `retryAfterMs`. `msalErrors.test.ts` pins every stage mapping and the precedence rule (the error the user saw last decides).
- [x] The existing #315 finish-line test (two-machine push/pull/conflict through the mock tenant, reconciler unchanged) still passes unchanged.
- [x] Docs link check green.

## Notes for the reviewer

- Not proven against a real tenant — that is the whole point of #315 staying open. The consumer-account path in `SELF_HOSTING.md` is the cheapest live proof; the two-machine round trip and the error texts are what to report there.
- Stacked on #394 (scope collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HH2tCj4T3FLpsbEUMgroS
